### PR TITLE
Add unit tests for node implementation

### DIFF
--- a/node/packages/botas/package.json
+++ b/node/packages/botas/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "clean": "npx rimraf ./dist",
     "build": "tsc -p tsconfig.json",
-    "test": "node --import tsx --test src/**/*.spec.ts"
+    "test": "node --import tsx --test src/schema/activity.spec.ts src/app/bot-application.spec.ts"
   },
   "dependencies": {
     "@azure/msal-node": "^2.16.2",

--- a/node/packages/botas/src/app/bot-application.spec.ts
+++ b/node/packages/botas/src/app/bot-application.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { BotApplication, BotHandlerException } from './bot-application.js'
+import type { Activity } from '../schema/activity.js'
+
+const baseActivity: Activity = {
+  type: 'message',
+  id: 'act1',
+  channelId: 'msteams',
+  serviceUrl: 'http://service.url',
+  from: { id: 'user1' },
+  recipient: { id: 'bot1' },
+  conversation: { id: 'conv1' },
+  text: 'hello',
+}
+
+function makeBody (overrides: Partial<Activity> = {}): string {
+  return JSON.stringify({ ...baseActivity, ...overrides })
+}
+
+describe('BotApplication', () => {
+  describe('processBody', () => {
+    it('dispatches to registered handler by type', async () => {
+      const bot = new BotApplication()
+      let received: Activity | undefined
+      bot.on('message', async (activity) => { received = activity })
+      await bot.processBody(makeBody({ type: 'message' }))
+      assert.ok(received)
+      assert.equal(received.type, 'message')
+      assert.equal(received.text, 'hello')
+    })
+
+    it('silently ignores unregistered activity types', async () => {
+      const bot = new BotApplication()
+      let called = false
+      bot.on('message', async () => { called = true })
+      await bot.processBody(makeBody({ type: 'conversationUpdate' }))
+      assert.equal(called, false)
+    })
+
+    it('dispatches conversationUpdate to its handler', async () => {
+      const bot = new BotApplication()
+      let received: Activity | undefined
+      bot.on('conversationUpdate', async (activity) => { received = activity })
+      await bot.processBody(makeBody({ type: 'conversationUpdate' }))
+      assert.ok(received)
+      assert.equal(received.type, 'conversationUpdate')
+    })
+
+    it('replaces handler when same type registered twice', async () => {
+      const bot = new BotApplication()
+      const calls: string[] = []
+      bot.on('message', async () => { calls.push('first') })
+      bot.on('message', async () => { calls.push('second') })
+      await bot.processBody(makeBody())
+      assert.deepEqual(calls, ['second'])
+    })
+
+    it('throws on missing type field', async () => {
+      const bot = new BotApplication()
+      const body = JSON.stringify({ serviceUrl: 'http://s', conversation: { id: 'c' } })
+      await assert.rejects(() => bot.processBody(body), /type/)
+    })
+
+    it('throws on missing serviceUrl field', async () => {
+      const bot = new BotApplication()
+      const body = JSON.stringify({ type: 'message', conversation: { id: 'c' } })
+      await assert.rejects(() => bot.processBody(body), /serviceUrl/)
+    })
+
+    it('throws on missing conversation.id', async () => {
+      const bot = new BotApplication()
+      const body = JSON.stringify({ type: 'message', serviceUrl: 'http://s', conversation: {} })
+      await assert.rejects(() => bot.processBody(body), /conversation/)
+    })
+  })
+
+  describe('BotHandlerException', () => {
+    it('wraps handler errors with activity reference', async () => {
+      const bot = new BotApplication()
+      const cause = new Error('handler blew up')
+      bot.on('message', async () => { throw cause })
+      const err = await bot.processBody(makeBody()).catch((e: unknown) => e)
+      assert.ok(err instanceof BotHandlerException)
+      assert.equal(err.cause, cause)
+      assert.equal(err.activity.type, 'message')
+      assert.equal(err.name, 'BotHandlerException')
+    })
+
+    it('message includes activity type', async () => {
+      const bot = new BotApplication()
+      bot.on('message', async () => { throw new Error('oops') })
+      const err = await bot.processBody(makeBody()).catch((e: unknown) => e)
+      assert.ok(err instanceof BotHandlerException)
+      assert.ok(err.message.includes('message'))
+    })
+  })
+
+  describe('middleware', () => {
+    it('runs middleware before handler', async () => {
+      const bot = new BotApplication()
+      const order: string[] = []
+      bot.use({
+        async onTurnAsync (_app, _activity, next) {
+          order.push('middleware')
+          await next()
+        },
+      })
+      bot.on('message', async () => { order.push('handler') })
+      await bot.processBody(makeBody())
+      assert.deepEqual(order, ['middleware', 'handler'])
+    })
+
+    it('runs multiple middleware in registration order', async () => {
+      const bot = new BotApplication()
+      const order: string[] = []
+      bot.use({ async onTurnAsync (_a, _b, next) { order.push('mw1'); await next() } })
+      bot.use({ async onTurnAsync (_a, _b, next) { order.push('mw2'); await next() } })
+      bot.on('message', async () => { order.push('handler') })
+      await bot.processBody(makeBody())
+      assert.deepEqual(order, ['mw1', 'mw2', 'handler'])
+    })
+
+    it('middleware can short-circuit by not calling next', async () => {
+      const bot = new BotApplication()
+      let handlerCalled = false
+      bot.use({ async onTurnAsync () { /* no next() */ } })
+      bot.on('message', async () => { handlerCalled = true })
+      await bot.processBody(makeBody())
+      assert.equal(handlerCalled, false)
+    })
+  })
+})

--- a/node/packages/botas/src/schema/activity.spec.ts
+++ b/node/packages/botas/src/schema/activity.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createReplyActivity } from './activity.js'
+import type { Activity } from './activity.js'
+
+describe('activity schema', () => {
+  describe('JSON deserialization', () => {
+    it('parses known fields', () => {
+      const json = JSON.stringify({
+        type: 'message',
+        text: 'hello',
+        channelId: 'msteams',
+        serviceUrl: 'http://service.url',
+        from: { id: 'user1', name: 'User One' },
+        recipient: { id: 'bot1', name: 'Bot One' },
+        conversation: { id: 'conv1' },
+      })
+      const act = JSON.parse(json) as Activity
+      assert.equal(act.type, 'message')
+      assert.equal(act.text, 'hello')
+      assert.equal(act.channelId, 'msteams')
+      assert.equal(act.from.id, 'user1')
+      assert.equal(act.from.name, 'User One')
+    })
+
+    it('handles null text field', () => {
+      const act = JSON.parse('{"type":"message","text":null}') as Activity
+      assert.equal(act.type, 'message')
+      assert.equal(act.text, null)
+    })
+
+    it('handles missing optional fields', () => {
+      const act = JSON.parse('{"type":"message","serviceUrl":"http://s","channelId":"c","from":{"id":"u"},"recipient":{"id":"b"},"conversation":{"id":"c"}}') as Activity
+      assert.equal(act.type, 'message')
+      assert.equal(act.text, undefined)
+    })
+
+    it('deserializes aadObjectId as typed property on ChannelAccount', () => {
+      const json = JSON.stringify({
+        type: 'message',
+        text: 'hello',
+        from: { id: '1', name: 'tester', aadObjectId: '123' },
+      })
+      const act = JSON.parse(json) as Activity
+      assert.equal(act.from.id, '1')
+      assert.equal(act.from.name, 'tester')
+      assert.equal(act.from.aadObjectId, '123')
+    })
+
+    it('deserializes role as typed property on ChannelAccount', () => {
+      const json = JSON.stringify({
+        type: 'message',
+        from: { id: '1', role: 'user' },
+      })
+      const act = JSON.parse(json) as Activity
+      assert.equal(act.from.role, 'user')
+    })
+  })
+
+  describe('createReplyActivity', () => {
+    const incoming: Activity = {
+      type: 'message',
+      id: 'activity1',
+      channelId: 'channel1',
+      serviceUrl: 'http://service.url',
+      from: { id: 'user1', name: 'User One' },
+      recipient: { id: 'bot1', name: 'Bot One' },
+      conversation: { id: 'conversation1' },
+      text: 'hello',
+    }
+
+    it('sets type to message', () => {
+      const reply = createReplyActivity(incoming, 'reply')
+      assert.equal(reply.type, 'message')
+    })
+
+    it('copies channelId, serviceUrl, conversation', () => {
+      const reply = createReplyActivity(incoming, 'reply')
+      assert.equal(reply.channelId, 'channel1')
+      assert.equal(reply.serviceUrl, 'http://service.url')
+      assert.equal(reply.conversation?.id, 'conversation1')
+    })
+
+    it('swaps from and recipient', () => {
+      const reply = createReplyActivity(incoming, 'reply')
+      assert.equal(reply.from?.id, 'bot1')
+      assert.equal(reply.from?.name, 'Bot One')
+      assert.equal(reply.recipient?.id, 'user1')
+      assert.equal(reply.recipient?.name, 'User One')
+    })
+
+    it('sets replyToId to original activity id', () => {
+      const reply = createReplyActivity(incoming, 'reply')
+      assert.equal(reply.replyToId, 'activity1')
+    })
+
+    it('sets text', () => {
+      const reply = createReplyActivity(incoming, 'you said: hello')
+      assert.equal(reply.text, 'you said: hello')
+    })
+
+    it('defaults text to empty string', () => {
+      const reply = createReplyActivity(incoming)
+      assert.equal(reply.text, '')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `activity.spec.ts`: 11 tests covering JSON deserialization (known fields, nulls, `aadObjectId`/`role` as typed properties) and `createReplyActivity` (copies, swaps from/recipient, replyToId, text default)
- Add `bot-application.spec.ts`: 12 tests covering handler dispatch by type, unknown type ignored, handler replacement, validation errors, `BotHandlerException` wrapping, and middleware order/short-circuit
- Update test script in `package.json` to list spec files explicitly (Windows glob fix)

## Test plan

- [x] All 23 tests pass locally (`npm test -w packages/botas`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)