### PR TITLE
Add README, Architecture, and Setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,174 @@
-# BotAS (Bot ApplicationS)
+# BotAS — Bot ApplicationS
 
-A Library to implement bot applications
+A lightweight, multi-language library for building [Microsoft Bot Framework](https://learn.microsoft.com/azure/bot-service/) bots. Implementations exist for **.NET (C#)**, **TypeScript/Node.js**, and **Python**, with behavioral parity across all three.
 
+## What it does
+
+BotAS handles the plumbing so you can focus on bot logic:
+
+- Validates inbound JWT tokens from the Bot Framework Service
+- Deserializes activities and dispatches them to registered handlers
+- Runs a configurable middleware pipeline before each handler
+- Authenticates outbound HTTP calls using OAuth2 client credentials
+- Preserves unknown JSON properties so custom channel data round-trips safely
+
+## Getting started
+
+### Prerequisites
+
+- Azure AD app registration (bot credentials) — see [Infrastructure Setup](docs/Setup.md)
+- A tunneling tool for local dev (Microsoft devtunnels or ngrok)
+- Runtime for your chosen language:
+  - .NET 10.0 SDK
+  - Node.js 20+
+  - Python 3.11+
+
+### Environment variables
+
+All three implementations read the same variables:
+
+| Variable | Description |
+|---|---|
+| `CLIENT_ID` | Azure AD application (bot) ID |
+| `CLIENT_SECRET` | Azure AD client secret |
+| `TENANT_ID` | Azure AD tenant ID (or `common`) |
+| `PORT` | HTTP listen port (default: `3978`) |
+
+Copy `.env` from the repo root and fill in the values from your bot registration.
+
+---
+
+## Echo bot — quick start
+
+### .NET (ASP.NET Core)
+
+```csharp
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.AddBotApplication<BotApplication>();
+var webApp = builder.Build();
+var botApp = webApp.UseBotApplication<BotApplication>();
+
+botApp.OnActivity = async (activity, ct) => {
+    if (activity.Type == "message")
+        await botApp.SendActivityAsync(activity.CreateReply($"You said: {activity.Text}"), ct);
+};
+
+webApp.Run();
+```
+
+Run:
+```bash
+cd dotnet
+dotnet run --project samples/EchoBot
+```
+
+### Node.js (Express)
+
+```typescript
+import express from 'express'
+import { BotApplication, botAuthExpress, createReplyActivity } from '@botas/botas'
+
+const bot = new BotApplication()
+
+bot.on('message', async (activity) => {
+  await bot.sendActivityAsync(
+    activity.serviceUrl,
+    activity.conversation.id,
+    createReplyActivity(activity, `You said: ${activity.text}`)
+  )
+})
+
+const server = express()
+server.use(express.json())
+server.post('/api/messages', botAuthExpress(), (req, res) => bot.processAsync(req, res))
+server.listen(process.env.PORT ?? 3978)
+```
+
+Run:
+```bash
+cd node
+npm install && npm run build
+npx tsx samples/express/index.ts
+```
+
+### Python (FastAPI)
+
+```python
+from fastapi import FastAPI, Depends, Request
+from botas import BotApplication, create_reply_activity, bot_auth_dependency
+
+bot = BotApplication()
+
+@bot.on("message")
+async def on_message(activity):
+    await bot.send_activity_async(
+        activity.service_url,
+        activity.conversation.id,
+        create_reply_activity(activity, f"You said: {activity.text}")
+    )
+
+app = FastAPI()
+
+@app.post("/api/messages", dependencies=[Depends(bot_auth_dependency())])
+async def messages(request: Request):
+    await bot.process_body((await request.body()).decode())
+    return {}
+```
+
+Run:
+```bash
+cd python/packages/botas
+pip install -e ".[dev]"
+uvicorn samples.fastapi.main:app --port 3978
+```
+
+---
+
+## Repository layout
+
+```
+botas/
+├── dotnet/           .NET library + ASP.NET Core integration + EchoBot sample
+├── node/             TypeScript library + Express and Hono samples
+├── python/           Python library + FastAPI and aiohttp samples
+├── bot-spec.md       Canonical feature specification
+├── AGENTS.md         Guide for porting to new languages
+└── docs/
+    ├── Architecture.md   Turn pipeline, auth model, component overview
+    └── Setup.md          Bot infrastructure setup (Teams CLI)
+```
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| [Architecture](docs/Architecture.md) | Turn pipeline, two-auth model, middleware, schema |
+| [Infrastructure Setup](docs/Setup.md) | Register a bot and get credentials using the Teams CLI |
+| [bot-spec.md](bot-spec.md) | Full feature specification and API surface per language |
+| [AGENTS.md](AGENTS.md) | Porting guide for new language implementations |
+
+## Suggested additional docs
+
+The following areas are good candidates for future documentation:
+
+- **`docs/ActivityPayloads.md`** — Annotated JSON examples for each activity type (`message`, `conversationUpdate`, `messageReaction`, `invoke`, `installationUpdate`) and Teams-specific `channelData` shapes
+- **`docs/Configuration.md`** — Per-language configuration reference: env vars, DI wiring (.NET), options objects (Node), constructor args (Python), managed identity setup
+- **`docs/Middleware.md`** — How to write and register middleware, execution order, short-circuiting, and example patterns (logging, error handling, feature flags)
+- **`docs/ProactiveMessaging.md`** — How to send messages outside of a turn using `ConversationClient` and `UserTokenClient`
+- **`docs/Samples.md`** — Walkthrough of each sample (EchoBot, aiohttp, Hono) with annotated code and expected behavior
+- **`docs/Contributing.md`** — Behavioral invariants, CI setup, how to add a new language port
+
+## Building and testing
+
+```bash
+# .NET
+cd dotnet && dotnet build src/Botas && dotnet test
+
+# Node
+cd node && npm install && npm run build && npm test
+
+# Python
+cd python/packages/botas && pip install -e ".[dev]" && pytest
+```
+
+CI runs all three on every push and pull request (see `.github/workflows/CI.yml`).

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,221 @@
+# Architecture
+
+BotAS is a thin adapter between an HTTP framework and the [Microsoft Bot Framework REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference). The same design is implemented in .NET, Node.js, and Python.
+
+---
+
+## Turn pipeline
+
+Every incoming bot activity travels through this pipeline:
+
+```
+HTTP POST /api/messages
+  │
+  ├─ Auth middleware          validate JWT bearer token (inbound auth)
+  │
+  └─ BotApplication
+       ├─ middleware[0].onTurnAsync(app, activity, next)
+       ├─ middleware[1].onTurnAsync(app, activity, next)
+       ├─ ...
+       └─ handler dispatch    call handler registered for activity.type
+                              (silently ignore if no handler registered)
+```
+
+Middleware executes in registration order. Each middleware calls `next()` to continue; omitting the call short-circuits the pipeline.
+
+---
+
+## Two-auth model
+
+### Inbound — JWT validation
+
+Every POST to `/api/messages` must carry a signed JWT in the `Authorization: Bearer <token>` header. The library:
+
+1. Fetches the signing keys from `https://login.botframework.com/v1/.well-known/openid-configuration`
+2. Validates the token signature, issuer (`api.botframework.com` or `sts.windows.net/{tenantId}`), and audience (your `CLIENT_ID`)
+3. Returns `401` if validation fails — the activity never reaches middleware or handlers
+
+### Outbound — client credentials
+
+When the bot sends an activity back to the channel, it calls the Bot Framework REST API. Before each outbound call the library:
+
+1. Acquires an OAuth2 token using client credentials (`CLIENT_ID`, `CLIENT_SECRET`, `TENANT_ID`)
+2. Scope: `https://api.botframework.com/.default`
+3. Attaches the token as `Authorization: Bearer <token>` on the outbound request
+
+Token acquisition is handled by a `TokenManager` component; tokens are cached and refreshed automatically.
+
+---
+
+## Components
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Web Framework                      │
+│          (ASP.NET Core / Express / FastAPI)          │
+└──────────────────────┬──────────────────────────────┘
+                       │ HTTP POST /api/messages
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│              Auth Middleware                         │
+│  BotAuthenticationHandler  /  botAuthExpress()       │
+│  /  bot_auth_dependency()                            │
+│                                                     │
+│  ● Fetches JWKS from botframework.com               │
+│  ● Validates JWT signature, issuer, audience        │
+│  ● Returns 401 on failure                           │
+└──────────────────────┬──────────────────────────────┘
+                       │ validated Activity JSON
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│                 BotApplication                       │
+│                                                     │
+│  use(middleware)   register middleware               │
+│  on(type, fn)      register handler (Node/Python)   │
+│  OnActivity        single callback (.NET)            │
+│                                                     │
+│  processAsync / ProcessAsync / process_body          │
+│    → run middleware chain                           │
+│    → dispatch to handler by activity.type           │
+│    → wrap handler exceptions in BotHandlerException │
+└──────┬──────────────────────────────────────────────┘
+       │ bot wants to reply
+       ▼
+┌─────────────────────────────────────────────────────┐
+│             ConversationClient                       │
+│                                                     │
+│  sendActivityAsync(serviceUrl, conversationId, act) │
+│    → TokenManager acquires/caches outbound token    │
+│    → POST {serviceUrl}v3/conversations/{id}/        │
+│           activities                                │
+└─────────────────────────────────────────────────────┘
+```
+
+### Supporting components
+
+| Component | Purpose |
+|---|---|
+| `TokenManager` | OAuth2 client-credentials token acquisition and caching |
+| `UserTokenClient` | OAuth user token operations (getToken, signOut, exchange) |
+| `createReplyActivity` | Helper — copies routing fields, swaps from/recipient, sets replyToId |
+
+---
+
+## Activity schema
+
+The core `Activity` type carries all information about a single turn:
+
+```json
+{
+  "type": "message",
+  "id": "activity-id",
+  "serviceUrl": "https://smba.trafficmanager.net/amer/",
+  "channelId": "msteams",
+  "text": "Hello!",
+  "replyToId": "previous-activity-id",
+  "from": {
+    "id": "user-aad-object-id",
+    "name": "Alice",
+    "aadObjectId": "user-aad-object-id",
+    "role": "user"
+  },
+  "recipient": {
+    "id": "bot-app-id",
+    "name": "My Bot",
+    "role": "bot"
+  },
+  "conversation": {
+    "id": "conversation-id",
+    "name": null,
+    "isGroup": false
+  },
+  "channelData": { },
+  "entities": []
+}
+```
+
+**Key rules:**
+
+- Unknown properties are preserved in an extension dictionary so custom channel data round-trips safely
+- `null` values are omitted on serialization
+- All property names use camelCase in JSON
+
+### Activity types
+
+| `type` value | When it fires |
+|---|---|
+| `message` | User or bot sends a text message |
+| `conversationUpdate` | Members added or removed from the conversation |
+| `messageReaction` | Emoji reaction added or removed from a message |
+| `installationUpdate` | Bot installed or uninstalled (Teams-specific) |
+| `invoke` | Synchronous request requiring an immediate response body |
+
+### Teams `channelData`
+
+When `channelId` is `msteams`, the `channelData` field carries Teams-specific metadata:
+
+```json
+{
+  "channelData": {
+    "tenant": { "id": "tenant-id" },
+    "team": { "id": "team-id", "name": "Team Name" },
+    "channel": { "id": "channel-id", "name": "Channel Name" },
+    "settings": { "selectedChannel": { "id": "channel-id" } }
+  }
+}
+```
+
+---
+
+## Handler dispatch
+
+### Node.js / Python — per-type map
+
+```
+activity arrives with type = "message"
+  → look up handler registered with on("message", fn)
+  → call fn(activity)
+  → unregistered types are silently ignored
+```
+
+### .NET — single callback
+
+```
+activity arrives
+  → OnActivity(activity, cancellationToken) is called
+  → dispatch logic lives in application code (switch on activity.Type)
+```
+
+---
+
+## Error handling
+
+Any exception thrown inside a handler is caught and re-thrown wrapped as `BotHandlerException` (or `BotHanlderException` in .NET — the typo is preserved for backward compatibility). The wrapper carries:
+
+- `cause` — the original exception
+- `activity` — the activity that triggered the handler
+
+---
+
+## Cross-language behavioral invariants
+
+These hold in every language implementation:
+
+1. JWT validation happens before activity processing — unauthenticated requests never reach middleware or handlers
+2. `createReplyActivity` copies `serviceUrl`, `channelId`, and `conversation`; swaps `from`/`recipient`; sets `replyToId`
+3. Unregistered activity types are silently ignored (no error thrown)
+4. Handler exceptions are wrapped in `BotHandlerException`
+5. Outbound activities are authenticated with a client-credentials bearer token
+6. Middleware executes in registration order
+
+---
+
+## Language-specific notes
+
+| Area | .NET | Node.js | Python |
+|---|---|---|---|
+| Handler registration | Single `OnActivity` callback | `on(type, fn)` per-type map | `@bot.on("type")` decorator or `bot.on("type", fn)` |
+| Framework integration | ASP.NET Core middleware (`UseBotApplication`) | Framework-agnostic (`botAuthExpress`, `botAuthHono`) | FastAPI `Depends` or aiohttp middleware |
+| DI support | Full DI via `AddBotApplication<T>` | Not applicable | Not applicable |
+| Async model | `async/await` + `CancellationToken` | `async/await` (Promise) | `async/await` (asyncio) |
+| JSON serialization | `System.Text.Json` (camelCase policy) | `JSON.parse` / `JSON.stringify` | Pydantic v2 (camelCase alias) |

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,0 +1,159 @@
+# Infrastructure Setup
+
+This guide walks through registering a Teams bot and obtaining credentials using the Teams CLI. After completing it you will have `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` values ready to use with any BotAS sample.
+
+> **Scope**: This guide covers bot *infrastructure* only (Azure AD app registration, Teams app manifest). It does not cover hosting or deploying your bot code.
+
+---
+
+## Prerequisites
+
+### 1. Install the Teams CLI
+
+```bash
+npm install -g https://github.com/heyitsaamir/teamscli/releases/latest/download/teamscli.tgz
+```
+
+Verify:
+
+```bash
+teams --version
+```
+
+### 2. Authenticate
+
+```bash
+teams login
+```
+
+Confirm you are authenticated:
+
+```bash
+teams status
+```
+
+### 3. Expose your bot endpoint
+
+Your bot must be reachable from the internet before you register it. For local development, use a tunneling tool:
+
+**Microsoft devtunnels (recommended):**
+See [Get started with devtunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started?tabs=windows)
+
+**ngrok (alternative):**
+See [ngrok quickstart](https://ngrok.com/docs/getting-started/)
+
+BotAS samples listen on port `3978` by default, so your endpoint will look like:
+
+```
+https://<your-tunnel>/api/messages
+```
+
+---
+
+## Create the bot
+
+Run the creation command with your bot name and endpoint:
+
+```bash
+teams app create --name "MyBot" --endpoint "https://<your-tunnel>/api/messages" --json
+```
+
+The command returns JSON similar to:
+
+```json
+{
+  "appName": "MyBot",
+  "teamsAppId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "botId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "endpoint": "https://<your-tunnel>/api/messages",
+  "installLink": "https://teams.microsoft.com/l/app/...",
+  "credentials": {
+    "CLIENT_ID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "CLIENT_SECRET": "your-secret-value",
+    "TENANT_ID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+}
+```
+
+---
+
+## Configure your environment
+
+Copy the credentials into your `.env` file at the repo root:
+
+```
+CLIENT_ID=<value from JSON>
+CLIENT_SECRET=<value from JSON>
+TENANT_ID=<value from JSON>
+PORT=3978
+```
+
+> **Security**: Never commit `.env` to source control. The repo's `.gitignore` already excludes it.
+
+---
+
+## Install the bot in Teams
+
+Open the `installLink` from the JSON output in your browser. You can install the bot for:
+
+- **Personal use** — chat 1-on-1 with the bot
+- **A team** — add the bot to a team channel
+- **A group chat** — add the bot to an existing chat
+
+---
+
+## Verify the registration
+
+Confirm the app was created correctly using the `teamsAppId` from the JSON output:
+
+```bash
+teams app view <teamsAppId> --json
+```
+
+The response should show your bot name, endpoint, and matching IDs.
+
+---
+
+## Update the endpoint
+
+Each time your tunnel URL changes (new ngrok or devtunnels session), update the registered endpoint:
+
+```bash
+teams app edit <teamsAppId> --endpoint "https://<new-tunnel>/api/messages"
+```
+
+---
+
+## Common errors
+
+### `AUTH_REQUIRED` or `Not logged in`
+
+Run `teams login` and retry.
+
+### `AUTH_TOKEN_FAILED`
+
+Token expired. Run `teams login` again to refresh, then retry.
+
+### Install link shows "Permission denied" or "Custom apps are blocked"
+
+Sideloading is disabled in your tenant. Ask your Teams admin to enable **"Allow interaction with custom apps"** in the Teams Admin Center:
+[Enable custom Teams apps](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-configure-custom-app-upload-settings)
+
+---
+
+## Next steps
+
+With credentials in `.env`, start any sample:
+
+```bash
+# .NET
+cd dotnet && dotnet run --project samples/EchoBot
+
+# Node (Express)
+cd node && npx tsx samples/express/index.ts
+
+# Python (FastAPI)
+cd python/packages/botas && uvicorn samples.fastapi.main:app --port 3978
+```
+
+Then send a message to your bot in Teams.


### PR DESCRIPTION
## Summary

- Replaces the stub `README.md` with a full project overview: what BotAS does, echo bot quickstarts in all three languages (C#, TypeScript, Python), repo layout, links to docs, and a suggested docs roadmap
- Adds `docs/Architecture.md` covering the turn pipeline, two-auth model, component diagram, activity schema with JSON examples, Teams `channelData` shape, handler dispatch per language, and cross-language behavioral invariants
- Adds `docs/Setup.md` with step-by-step bot infrastructure setup using the Teams CLI: install, authenticate, expose endpoint, create bot, configure `.env`, install in Teams, update endpoint, and error recovery

## Test plan

- [ ] Review README renders correctly on GitHub
- [ ] Review Architecture.md diagrams and tables render correctly
- [ ] Follow Setup.md end-to-end with a real tunnel to verify accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)