### PR TITLE
Add AI bot samples with Azure Foundry LLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,104 @@ cd node && npx tsx samples/teams-sample/index.ts
 cd python/samples/teams-sample && python main.py
 ```
 
+---
+
+## AI bot — LLM integration with Azure Foundry
+
+Each language has an AI bot sample that forwards messages to an LLM via Azure AI Foundry and maintains multi-turn conversation history.
+
+### Environment variables (in addition to bot credentials)
+
+| Variable | Description |
+|---|---|
+| `AZURE_OPENAI_ENDPOINT` | Azure Foundry resource endpoint (e.g. `https://<resource>.openai.azure.com`) |
+| `AZURE_OPENAI_API_KEY` | API key for the deployed model |
+| `AZURE_OPENAI_DEPLOYMENT` | Deployment/model name (default: `gpt-4o`) |
+
+### .NET (Azure.AI.OpenAI + Microsoft.Extensions.AI)
+
+```csharp
+using System.Collections.Concurrent;
+using Azure.AI.OpenAI;
+using Botas;
+using Microsoft.Extensions.AI;
+
+IChatClient chatClient = new AzureOpenAIClient(
+    new Uri(endpoint), new System.ClientModel.ApiKeyCredential(apiKey))
+    .GetChatClient(deployment)
+    .AsIChatClient();
+
+var history = new ConcurrentDictionary<string, List<ChatMessage>>();
+var app = BotApp.Create(args);
+
+app.On("message", async (ctx, ct) =>
+{
+    var msgs = history.GetOrAdd(ctx.Activity.Conversation!.Id!, _ => []);
+    msgs.Add(new ChatMessage(ChatRole.User, ctx.Activity.Text ?? ""));
+    var response = await chatClient.GetResponseAsync(msgs, cancellationToken: ct);
+    msgs.Add(new ChatMessage(ChatRole.Assistant, response.Text ?? ""));
+    await ctx.SendAsync(response.Text ?? "", ct);
+});
+
+app.Run();
+```
+
+```bash
+cd dotnet && dotnet run --project samples/AiBot
+```
+
+### Node.js (Vercel AI SDK)
+
+```typescript
+import { BotApp } from 'botas-express'
+import { azure } from '@ai-sdk/azure'
+import { generateText, type CoreMessage } from 'ai'
+
+const history = new Map<string, CoreMessage[]>()
+const app = new BotApp()
+
+app.on('message', async (ctx) => {
+  const msgs = history.get(ctx.activity.conversation.id) ?? []
+  msgs.push({ role: 'user', content: ctx.activity.text ?? '' })
+  const { text } = await generateText({ model: azure('gpt-4o'), messages: msgs })
+  msgs.push({ role: 'assistant', content: text })
+  history.set(ctx.activity.conversation.id, msgs)
+  await ctx.send(text)
+})
+
+app.start()
+```
+
+```bash
+cd node && npx tsx samples/ai-bot/index.ts
+```
+
+### Python (LangChain)
+
+```python
+from botas_fastapi import BotApp
+from langchain_azure_ai.chat_models import AzureAIChatCompletionsModel
+from langchain_core.messages import AIMessage, HumanMessage
+
+model = AzureAIChatCompletionsModel(endpoint=endpoint, credential=api_key, model=deployment)
+history: dict[str, list] = {}
+app = BotApp()
+
+@app.on("message")
+async def on_message(ctx):
+    msgs = history.setdefault(ctx.activity.conversation.id, [])
+    msgs.append(HumanMessage(content=ctx.activity.text or ""))
+    response = await model.ainvoke(msgs)
+    msgs.append(AIMessage(content=response.content))
+    await ctx.send(response.content)
+
+app.start()
+```
+
+```bash
+cd python/samples/ai-bot && pip install -e . && python main.py
+```
+
 ## Documentation
 
 | Document | Description |

--- a/dotnet/Botas.slnx
+++ b/dotnet/Botas.slnx
@@ -5,6 +5,7 @@
   </Folder>
   <Project Path="samples/AspNetHosting/AspNetHosting.csproj" />
   <Project Path="samples/EchoBot/EchoBot.csproj" />
+  <Project Path="samples/AiBot/AiBot.csproj" />
   <Project Path="samples/MentionBot/MentionBot.csproj" />
   <Project Path="src/Botas/Botas.csproj" />
   <Project Path="tests/Botas.Tests/Botas.Tests.csproj" />

--- a/dotnet/samples/AiBot/AiBot.csproj
+++ b/dotnet/samples/AiBot/AiBot.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Botas\Botas.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.*-*" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/samples/AiBot/Program.cs
+++ b/dotnet/samples/AiBot/Program.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+using Azure.AI.OpenAI;
+using Botas;
+using Microsoft.Extensions.AI;
+using OpenAI;
+
+var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? "";
+var apiKey = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? "";
+var deployment = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT") ?? "gpt-4o";
+
+IChatClient chatClient = new AzureOpenAIClient(
+    new Uri(endpoint), new System.ClientModel.ApiKeyCredential(apiKey))
+    .GetChatClient(deployment)
+    .AsIChatClient();
+
+var conversationHistories = new ConcurrentDictionary<string, List<ChatMessage>>();
+
+var app = BotApp.Create(args);
+
+app.On("message", async (context, ct) =>
+{
+    var conversationId = context.Activity.Conversation!.Id!;
+    var history = conversationHistories.GetOrAdd(conversationId, _ => []);
+
+    history.Add(new ChatMessage(ChatRole.User, context.Activity.Text ?? ""));
+
+    var response = await chatClient.GetResponseAsync(history, cancellationToken: ct);
+
+    var assistantMessage = response.Text ?? "";
+    history.Add(new ChatMessage(ChatRole.Assistant, assistantMessage));
+
+    await context.SendAsync(assistantMessage, ct);
+});
+
+app.Run();

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -36,6 +36,109 @@
         "node": ">=20"
       }
     },
+    "node_modules/@ai-sdk/azure": {
+      "version": "1.3.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-1.3.25.tgz",
+      "integrity": "sha512-cTME89A9UYrza0t5pbY9b80yYY02Q5ALQdB2WP3R7/Yl1PLwbFChx994Q3Un0G2XV5h3arlm4fZTViY10isjhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/openai": "1.3.24",
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "1.3.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
+      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
     "node_modules/@azure/msal-common": {
       "version": "16.4.1",
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.1.tgz",
@@ -755,6 +858,15 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
@@ -802,6 +914,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -952,6 +1070,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -1194,6 +1313,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1210,6 +1330,36 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ai-bot": {
+      "resolved": "samples/ai-bot",
+      "link": true
     },
     "node_modules/ajv": {
       "version": "6.14.0",
@@ -1794,6 +1944,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2104,6 +2269,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2904,6 +3070,7 @@
       "version": "4.12.12",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3466,6 +3633,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3479,6 +3652,35 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -3745,6 +3947,24 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4392,6 +4612,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4581,6 +4811,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -4969,6 +5205,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
@@ -4986,6 +5235,18 @@
     "node_modules/teams-sample": {
       "resolved": "samples/teams-sample",
       "link": true
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -5203,6 +5464,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5290,6 +5552,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/uuid": {
@@ -5442,6 +5713,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "packages/botas": {
       "version": "0.1.0",
       "license": "MIT",
@@ -5468,6 +5758,14 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "samples/ai-bot": {
+      "version": "0.1.0",
+      "dependencies": {
+        "@ai-sdk/azure": "^1.0.0",
+        "ai": "^4.0.0",
+        "botas-express": "*"
       }
     },
     "samples/echo-bot": {

--- a/node/samples/ai-bot/index.ts
+++ b/node/samples/ai-bot/index.ts
@@ -1,0 +1,32 @@
+// AI Bot — BotApp + Vercel AI SDK with Azure Foundry
+// Run: npx tsx index.ts
+// Env: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT
+
+import { BotApp } from 'botas-express'
+import { azure } from '@ai-sdk/azure'
+import { generateText, type CoreMessage } from 'ai'
+
+const deployment = process.env.AZURE_OPENAI_DEPLOYMENT ?? 'gpt-4o'
+
+const conversationHistories = new Map<string, CoreMessage[]>()
+
+const app = new BotApp()
+
+app.on('message', async (ctx) => {
+  const conversationId = ctx.activity.conversation.id
+  const history = conversationHistories.get(conversationId) ?? []
+
+  history.push({ role: 'user', content: ctx.activity.text ?? '' })
+
+  const { text } = await generateText({
+    model: azure(deployment),
+    messages: history
+  })
+
+  history.push({ role: 'assistant', content: text })
+  conversationHistories.set(conversationId, history)
+
+  await ctx.send(text)
+})
+
+app.start()

--- a/node/samples/ai-bot/package.json
+++ b/node/samples/ai-bot/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ai-bot",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node --import tsx index.ts",
+    "dev": "node --import tsx --watch index.ts"
+  },
+  "dependencies": {
+    "botas-express": "*",
+    "ai": "^4.0.0",
+    "@ai-sdk/azure": "^1.0.0"
+  }
+}

--- a/node/samples/ai-bot/package.json
+++ b/node/samples/ai-bot/package.json
@@ -7,8 +7,8 @@
     "dev": "node --import tsx --watch index.ts"
   },
   "dependencies": {
-    "botas-express": "*",
-    "ai": "^4.0.0",
-    "@ai-sdk/azure": "^1.0.0"
+    "@ai-sdk/azure": "^1.0.0",
+    "ai": "^6.0.158",
+    "botas-express": "*"
   }
 }

--- a/python/samples/ai-bot/main.py
+++ b/python/samples/ai-bot/main.py
@@ -1,0 +1,41 @@
+# AI Bot — BotApp + LangChain with Azure Foundry
+# Run: python main.py
+# Env: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT
+
+import os
+
+from botas_fastapi import BotApp
+from langchain_azure_ai.chat_models import AzureAIChatCompletionsModel
+from langchain_core.messages import AIMessage, HumanMessage
+
+endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "")
+api_key = os.environ.get("AZURE_OPENAI_API_KEY", "")
+deployment = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
+
+model = AzureAIChatCompletionsModel(
+    endpoint=endpoint,
+    credential=api_key,
+    model=deployment,
+)
+
+conversation_histories: dict[str, list] = {}
+
+app = BotApp()
+
+
+@app.on("message")
+async def on_message(ctx):
+    conversation_id = ctx.activity.conversation.id
+    history = conversation_histories.get(conversation_id, [])
+
+    history.append(HumanMessage(content=ctx.activity.text or ""))
+
+    response = await model.ainvoke(history)
+
+    history.append(AIMessage(content=response.content))
+    conversation_histories[conversation_id] = history
+
+    await ctx.send(response.content)
+
+
+app.start()

--- a/python/samples/ai-bot/pyproject.toml
+++ b/python/samples/ai-bot/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "botas-sample-ai-bot"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "botas-fastapi",
+    "langchain-azure-ai>=0.1.0",
+    "langchain-core>=0.3.0",
+]


### PR DESCRIPTION
## Summary

Adds **ai-bot** samples for all three languages showing how to integrate bots with LLMs via Azure AI Foundry, with multi-turn conversation history.

## Library choices

| Language | Framework | Key Packages |
|----------|-----------|-------------|
| **.NET** | Microsoft.Extensions.AI | `Azure.AI.OpenAI` + `Microsoft.Extensions.AI.OpenAI` |
| **Node.js** | Vercel AI SDK | `ai` + `@ai-sdk/azure` |
| **Python** | LangChain | `langchain-azure-ai` + `langchain-core` |

## What each sample does

1. Creates a `BotApp` using existing botas conventions
2. On `message` handler, forwards `ctx.activity.text` to the LLM with conversation history
3. Stores conversation history in-memory keyed by `conversation.id`
4. Sends the LLM response back via `ctx.send()`

## Environment variables

All samples require these additional env vars (on top of standard bot credentials):

- `AZURE_OPENAI_ENDPOINT` — Azure Foundry resource endpoint
- `AZURE_OPENAI_API_KEY` — API key for the deployed model
- `AZURE_OPENAI_DEPLOYMENT` — deployment/model name (default: `gpt-4o`)

## Files changed

- `dotnet/samples/AiBot/` — .NET sample + added to solution
- `node/samples/ai-bot/` — Node.js sample
- `python/samples/ai-bot/` — Python sample
- `README.md` — Added AI bot documentation section