### PR TITLE
fix: include dist/ in npm pack and add dotnet tool manifest

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nbgv": {
+      "version": "3.9.50",
+      "commands": [
+        "nbgv"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -5558,7 +5558,7 @@
     },
     "packages/botas": {
       "name": "botas-core",
-      "version": "0.1.0",
+      "version": "0.1.36",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.1.2",

--- a/node/packages/botas/package.json
+++ b/node/packages/botas/package.json
@@ -30,8 +30,13 @@
   "scripts": {
     "clean": "npx rimraf ./dist",
     "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build",
     "test": "node --import tsx --test src/core-activity.spec.ts src/bot-application.spec.ts src/remove-mention-middleware.spec.ts src/teams-activity.spec.ts"
   },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
   "dependencies": {
     "@azure/msal-node": "^5.1.2",
     "axios": "^1.15.0",


### PR DESCRIPTION
## Problem

`npm pack` for `botas-core` produced a tarball without the compiled `dist/` directory because `.gitignore` excludes it, and npm respects `.gitignore` when no `files` field is present in `package.json`. This meant the published package was broken — `main` pointed to `dist/index.js` which didn't exist in the tarball.

Additionally, the Python wheel build (`python -m build`) requires `dotnet tool run nbgv` which needs a local tool manifest.

## Changes

- **`node/packages/botas/package.json`**: Added `prepack` script (calls `npm run build`) and `files` field (`dist/`, `README.md`) so the tarball always includes compiled output
- **`.config/dotnet-tools.json`**: Added dotnet tool manifest with `nbgv` for Python's `nbgv-python` build dependency

## Validation

Created standalone validation projects in `/tmp/botas-validate/` that install from the built packages (`.nupkg`, `.tgz`, `.whl`) and verify:
- Middleware pipeline execution
- Message handler dispatch
- Unknown activity types silently ignored
- All three languages pass ✅