### PR TITLE
docs: add Python ruff linting instructions to agent docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,15 @@ pip install -e ".[dev]"
 python -m pytest tests/ -v
 ```
 
+### Python linting (required before committing)
+Python code uses **ruff** (config in `python/packages/botas/pyproject.toml`). Always lint and auto-fix before committing Python changes:
+```bash
+cd python/packages/botas
+python -m ruff check --fix src/ tests/
+python -m ruff format src/ tests/
+```
+Rules enforced: `E` (pycodestyle errors), `F` (pyflakes), `W` (pycodestyle warnings), `I` (isort). Line length limit is **120**.
+
 ## Key conventions
 - Maintain behavior parity across all ports.
 - Preserve unknown JSON properties on activity serialization/deserialization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,18 @@ pip install -e ".[dev]"
 python -m pytest tests/ -v
 ```
 
+### Python Linting (required before committing)
+
+Python uses **ruff** for linting and formatting. Always run before committing Python changes:
+
+```bash
+cd python/packages/botas
+python -m ruff check --fix src/ tests/
+python -m ruff format src/ tests/
+```
+
+Rules: `E`, `F`, `W`, `I` — line length **120** (see `python/packages/botas/pyproject.toml`).
+
 ### All languages
 
 ```bash


### PR DESCRIPTION
Adds `ruff check --fix` and `ruff format` instructions to both `.github/copilot-instructions.md` and `AGENTS.md` so agents always lint Python code before committing.

**Rules enforced:** `E`, `F`, `W`, `I` — line length 120 (from `pyproject.toml`).