### PR TITLE
fix(.NET): Medium/low audit findings (#75)

### DIFF
--- a/dotnet/src/Botas/BotApp.cs
+++ b/dotnet/src/Botas/BotApp.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,12 @@ public class BotApp
     {
         _builder = WebApplication.CreateSlimBuilder(args ?? []);
         _routePath = routePath;
+
+        // #75: Limit request body to 1 MB to prevent unbounded payload abuse
+        _builder.WebHost.ConfigureKestrel(options =>
+        {
+            options.Limits.MaxRequestBodySize = 1_048_576; // 1 MB
+        });
 
         string? clientId = _builder.Configuration["AzureAd:ClientId"];
         if (!string.IsNullOrEmpty(clientId))

--- a/dotnet/src/Botas/BotApplication.cs
+++ b/dotnet/src/Botas/BotApplication.cs
@@ -66,9 +66,24 @@ public class BotApplication
 
         CoreActivity activity = await CoreActivity.FromJsonStreamAsync(httpContext.Request.Body, cancellationToken) ?? throw new InvalidOperationException("Invalid Activity");
 
+        // #75: Validate required activity fields before processing
+        if (string.IsNullOrEmpty(activity.Type))
+        {
+            throw new InvalidOperationException("Activity.Type is required.");
+        }
+        if (activity.Conversation is null || string.IsNullOrEmpty(activity.Conversation.Id))
+        {
+            throw new InvalidOperationException("Activity.Conversation.Id is required.");
+        }
+        if (string.IsNullOrEmpty(activity.ServiceUrl))
+        {
+            throw new InvalidOperationException("Activity.ServiceUrl is required.");
+        }
+
+        // #75: Log only non-PII fields at Trace level
         if (_logger.IsEnabled(LogLevel.Trace))
         {
-            _logger.LogTrace("Received activity: {Activity}", activity.ToJson());
+            _logger.LogTrace("Received activity Type={Type} ConversationId={ConversationId}", activity.Type, activity.Conversation.Id);
         }
 
         using (_logger.BeginScope("Processing activity {Type}", activity.Type))
@@ -78,6 +93,10 @@ public class BotApplication
             {
                 var callback = OnActivity ?? DispatchToHandler;
                 await _turnMiddleware.RunPipeline(context, callback, 0, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw; // #75: Don't wrap cancellation — let it propagate
             }
             catch (Exception ex)
             {
@@ -92,6 +111,11 @@ public class BotApplication
         }
     }
 
+    /// <summary>
+    /// Register middleware to run before handlers on every turn.
+    /// Middleware executes in registration order.
+    /// <para>Call this method during startup only; adding middleware after request processing begins is not supported.</para>
+    /// </summary>
     public ITurnMiddleWare Use(ITurnMiddleWare middleware)
     {
         _turnMiddleware.Use(middleware);

--- a/dotnet/src/Botas/JwtExtensions.cs
+++ b/dotnet/src/Botas/JwtExtensions.cs
@@ -103,23 +103,21 @@ public static class JwtExtensions
              jwtOptions.MapInboundClaims = true;
              jwtOptions.Events = new JwtBearerEvents
              {
-                 OnMessageReceived = async context =>
+                 OnMessageReceived = context =>
                  {
                      string authorizationHeader = context.Request.Headers.Authorization.ToString();
 
                      if (string.IsNullOrEmpty(authorizationHeader))
                      {
                          context.Options.TokenValidationParameters.ConfigurationManager ??= jwtOptions.ConfigurationManager as BaseConfigurationManager;
-                         await Task.CompletedTask.ConfigureAwait(false);
-                         return;
+                         return Task.CompletedTask;
                      }
 
                      string[] parts = authorizationHeader?.Split(' ')!;
                      if (parts.Length != 2 || parts[0] != "Bearer")
                      {
                          context.Options.TokenValidationParameters.ConfigurationManager ??= jwtOptions.ConfigurationManager as BaseConfigurationManager;
-                         await Task.CompletedTask.ConfigureAwait(false);
-                         return;
+                         return Task.CompletedTask;
                      }
 
                      JwtSecurityToken token = new(parts[1]);
@@ -130,7 +128,7 @@ public static class JwtExtensions
                      if (!IsKnownIssuer(issuer, validIssuers))
                      {
                          context.Fail("Token issuer is not in the allowed issuers list.");
-                         return;
+                         return Task.CompletedTask;
                      }
 
                      string oidcAuthority;
@@ -145,7 +143,7 @@ public static class JwtExtensions
                      else
                      {
                          context.Fail("Token tenant ID does not match the configured tenant.");
-                         return;
+                         return Task.CompletedTask;
                      }
 
                      // #104: Reuse cached ConfigurationManager per OIDC authority
@@ -158,7 +156,7 @@ public static class JwtExtensions
                                  RequireHttps = jwtOptions.RequireHttpsMetadata
                              }));
 
-                     await Task.CompletedTask.ConfigureAwait(false);
+                     return Task.CompletedTask;
                  },
                  OnTokenValidated = context =>
                  {

--- a/dotnet/tests/Botas.Tests/AuditFixTests.cs
+++ b/dotnet/tests/Botas.Tests/AuditFixTests.cs
@@ -1,0 +1,130 @@
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Botas.Tests;
+
+/// <summary>
+/// Tests for medium/low audit fixes (#75).
+/// </summary>
+public class ActivityValidationTests
+{
+    private static (BotApplication bot, HttpContext httpCtx) CreateTestBot(string activityJson)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new[] { new KeyValuePair<string, string?>("AzureAd:ClientId", "test-id") })
+            .Build();
+        var bot = new BotApplication(config, NullLogger<BotApplication>.Instance);
+        bot.On("message", (ctx, ct) => Task.CompletedTask);
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ConversationClient>("AzureAd",
+            new ConversationClient(new HttpClient(), NullLogger<ConversationClient>.Instance));
+        var sp = services.BuildServiceProvider();
+
+        var httpCtx = new DefaultHttpContext { RequestServices = sp };
+        httpCtx.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(activityJson));
+        httpCtx.Request.ContentType = "application/json";
+
+        return (bot, httpCtx);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RejectsActivity_WithMissingType()
+    {
+        var json = """{"type":"","serviceUrl":"https://example.com","conversation":{"id":"c1"}}""";
+        var (bot, ctx) = CreateTestBot(json);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bot.ProcessAsync(ctx));
+        Assert.Contains("Type", ex.Message);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RejectsActivity_WithNullConversation()
+    {
+        var json = """{"type":"message","serviceUrl":"https://example.com"}""";
+        var (bot, ctx) = CreateTestBot(json);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bot.ProcessAsync(ctx));
+        Assert.Contains("Conversation.Id", ex.Message);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RejectsActivity_WithEmptyConversationId()
+    {
+        var json = """{"type":"message","serviceUrl":"https://example.com","conversation":{"id":""}}""";
+        var (bot, ctx) = CreateTestBot(json);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bot.ProcessAsync(ctx));
+        Assert.Contains("Conversation.Id", ex.Message);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RejectsActivity_WithMissingServiceUrl()
+    {
+        var json = """{"type":"message","conversation":{"id":"c1"}}""";
+        var (bot, ctx) = CreateTestBot(json);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bot.ProcessAsync(ctx));
+        Assert.Contains("ServiceUrl", ex.Message);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_AcceptsValidActivity()
+    {
+        var json = """{"type":"message","serviceUrl":"https://example.com","conversation":{"id":"c1"},"text":"hello"}""";
+        var (bot, ctx) = CreateTestBot(json);
+
+        var result = await bot.ProcessAsync(ctx);
+        Assert.Equal("message", result.Type);
+    }
+}
+
+public class CancellationPropagationTests
+{
+    [Fact]
+    public async Task ProcessAsync_PropagatesOperationCanceledException()
+    {
+        var json = """{"type":"message","serviceUrl":"https://example.com","conversation":{"id":"c1"}}""";
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new[] { new KeyValuePair<string, string?>("AzureAd:ClientId", "test-id") })
+            .Build();
+        var bot = new BotApplication(config, NullLogger<BotApplication>.Instance);
+        bot.On("message", (ctx, ct) => throw new OperationCanceledException());
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ConversationClient>("AzureAd",
+            new ConversationClient(new HttpClient(), NullLogger<ConversationClient>.Instance));
+        var sp = services.BuildServiceProvider();
+
+        var httpCtx = new DefaultHttpContext { RequestServices = sp };
+        httpCtx.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => bot.ProcessAsync(httpCtx));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WrapsNonCancellationExceptions()
+    {
+        var json = """{"type":"message","serviceUrl":"https://example.com","conversation":{"id":"c1"}}""";
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new[] { new KeyValuePair<string, string?>("AzureAd:ClientId", "test-id") })
+            .Build();
+        var bot = new BotApplication(config, NullLogger<BotApplication>.Instance);
+        bot.On("message", (ctx, ct) => throw new InvalidOperationException("handler bug"));
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ConversationClient>("AzureAd",
+            new ConversationClient(new HttpClient(), NullLogger<ConversationClient>.Instance));
+        var sp = services.BuildServiceProvider();
+
+        var httpCtx = new DefaultHttpContext { RequestServices = sp };
+        httpCtx.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        var ex = await Assert.ThrowsAsync<BotHandlerException>(() => bot.ProcessAsync(httpCtx));
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+}

--- a/dotnet/tests/Botas.Tests/Botas.Tests.csproj
+++ b/dotnet/tests/Botas.Tests/Botas.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Moq" Version="4.20.70" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/node/packages/botas/package.json
+++ b/node/packages/botas/package.json
@@ -31,7 +31,7 @@
     "clean": "npx rimraf ./dist",
     "build": "tsc -p tsconfig.json",
     "prepack": "npm run build",
-    "test": "node --import tsx --test src/core-activity.spec.ts src/bot-application.spec.ts src/remove-mention-middleware.spec.ts src/teams-activity.spec.ts src/bot-auth-middleware.spec.ts src/typing-activity.spec.ts src/security-fixes.spec.ts src/p2-fixes.spec.ts"
+    "test": "node --import tsx --test src/core-activity.spec.ts src/bot-application.spec.ts src/remove-mention-middleware.spec.ts src/teams-activity.spec.ts src/bot-auth-middleware.spec.ts src/typing-activity.spec.ts src/security-fixes.spec.ts src/p2-fixes.spec.ts src/audit-medlow.spec.ts"
   },
   "files": [
     "dist/",

--- a/node/packages/botas/src/audit-medlow.spec.ts
+++ b/node/packages/botas/src/audit-medlow.spec.ts
@@ -1,0 +1,176 @@
+// Tests for medium/low audit fixes (#76)
+
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { BotApplication, type CoreActivity, removeMentionMiddleware, TokenManager, configure, resetLogger, noopLogger } from './index.js'
+import { Readable } from 'node:stream'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+function makeActivity (overrides: Partial<CoreActivity> = {}): CoreActivity {
+  return {
+    type: 'message',
+    serviceUrl: 'http://localhost:3978/',
+    conversation: { id: 'conv1' },
+    recipient: { id: 'bot1' },
+    channelId: 'test',
+    ...overrides,
+  } as CoreActivity
+}
+
+function makeReq (body: string): IncomingMessage {
+  const stream = Readable.from([Buffer.from(body)])
+  return Object.assign(stream, {
+    headers: {},
+    method: 'POST',
+    url: '/api/messages',
+  }) as unknown as IncomingMessage
+}
+
+function makeRes (): ServerResponse & { statusCode: number; body: string; headersSent: boolean } {
+  const res = {
+    statusCode: 0,
+    body: '',
+    headersSent: false,
+    writeHead (code: number) { res.statusCode = code; res.headersSent = true },
+    end (b?: string) { res.body = b ?? '' },
+    destroy: mock.fn(),
+  }
+  return res as unknown as ServerResponse & { statusCode: number; body: string; headersSent: boolean }
+}
+
+describe('#2 — Request body size limit', () => {
+  it('rejects bodies exceeding 10MB', async () => {
+    const bot = new BotApplication()
+    const hugeBody = 'x'.repeat(11 * 1024 * 1024)
+    const req = makeReq(hugeBody)
+    const res = makeRes()
+    await bot.processAsync(req, res)
+    assert.equal(res.statusCode, 500)
+  })
+
+  it('accepts bodies under 10MB', async () => {
+    const bot = new BotApplication()
+    bot.on('message', async () => {})
+    const activity = makeActivity({ text: 'hello' })
+    const req = makeReq(JSON.stringify(activity))
+    const res = makeRes()
+    await bot.processAsync(req, res)
+    assert.equal(res.statusCode, 200)
+  })
+})
+
+describe('#4 — ReDoS protection in RemoveMentionMiddleware', () => {
+  it('skips entity.text longer than 200 chars', async () => {
+    const bot = new BotApplication({ clientId: 'bot1' })
+    bot.use(removeMentionMiddleware())
+    let receivedText = ''
+    bot.on('message', async (ctx) => { receivedText = ctx.activity.text ?? '' })
+
+    const longMention = '<at>' + 'A'.repeat(250) + '</at>'
+    const activity = makeActivity({
+      text: longMention + ' hello',
+      entities: [{
+        type: 'mention',
+        mentioned: { id: 'bot1', name: 'Bot' },
+        text: longMention,
+      }] as CoreActivity['entities'],
+    })
+
+    await bot.processBody(JSON.stringify(activity))
+    // Text should NOT be stripped because entity.text > 200 chars
+    assert.ok(receivedText.includes(longMention))
+  })
+
+  it('strips entity.text within 200 chars', async () => {
+    const bot = new BotApplication({ clientId: 'bot1' })
+    bot.use(removeMentionMiddleware())
+    let receivedText = ''
+    bot.on('message', async (ctx) => { receivedText = ctx.activity.text ?? '' })
+
+    const mention = '<at>Bot</at>'
+    const activity = makeActivity({
+      text: mention + ' hello',
+      entities: [{
+        type: 'mention',
+        mentioned: { id: 'bot1', name: 'Bot' },
+        text: mention,
+      }] as CoreActivity['entities'],
+    })
+
+    await bot.processBody(JSON.stringify(activity))
+    assert.equal(receivedText, 'hello')
+  })
+})
+
+describe('#6 — Logger reset for tests', () => {
+  it('resetLogger restores default logger', () => {
+    configure(noopLogger)
+    resetLogger()
+    assert.ok(true)
+  })
+})
+
+describe('#8 — Token acquisition deduplication', () => {
+  it('concurrent getBotToken calls share one promise', async () => {
+    let callCount = 0
+    const tm = new TokenManager({
+      clientId: 'test-id',
+      token: async () => {
+        callCount++
+        await new Promise(r => setTimeout(r, 50))
+        return 'token-value'
+      },
+    })
+    const [t1, t2, t3] = await Promise.all([
+      tm.getBotToken(),
+      tm.getBotToken(),
+      tm.getBotToken(),
+    ])
+    assert.equal(t1, 'token-value')
+    assert.equal(t2, 'token-value')
+    assert.equal(t3, 'token-value')
+    assert.equal(callCount, 1, 'token factory should only be called once for concurrent requests')
+  })
+})
+
+describe('#11 — Input validation on activity fields', () => {
+  it('rejects text exceeding 50,000 chars', async () => {
+    const bot = new BotApplication()
+    const activity = makeActivity({ text: 'x'.repeat(50_001) })
+    await assert.rejects(
+      () => bot.processBody(JSON.stringify(activity)),
+      /text exceeds maximum length/
+    )
+  })
+
+  it('rejects entities exceeding 250', async () => {
+    const bot = new BotApplication()
+    const entities = Array.from({ length: 251 }, () => ({ type: 'mention' }))
+    const activity = makeActivity({ entities } as unknown as Partial<CoreActivity>)
+    await assert.rejects(
+      () => bot.processBody(JSON.stringify(activity)),
+      /entities exceeds maximum count/
+    )
+  })
+
+  it('rejects attachments exceeding 50', async () => {
+    const bot = new BotApplication()
+    const attachments = Array.from({ length: 51 }, () => ({ contentType: 'text/plain' }))
+    const activity = { ...makeActivity(), attachments }
+    await assert.rejects(
+      () => bot.processBody(JSON.stringify(activity)),
+      /attachments exceeds maximum count/
+    )
+  })
+})
+
+describe('#15 — processAsync cleanup', () => {
+  it('checks headersSent before writing error response', async () => {
+    const bot = new BotApplication()
+    const req = makeReq('not json')
+    const res = makeRes()
+    await bot.processAsync(req, res)
+    assert.equal(res.statusCode, 500)
+    assert.equal(res.body, 'Internal server error')
+  })
+})

--- a/node/packages/botas/src/bot-application.ts
+++ b/node/packages/botas/src/bot-application.ts
@@ -111,11 +111,17 @@ export class BotApplication {
     try {
       const body = await readBody(req)
       await this.processBody(body)
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end('{}')
-    } catch {
-      res.writeHead(500)
-      res.end('Internal server error')
+      if (!res.headersSent) {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end('{}')
+      }
+    } catch (err) {
+      getLogger().error('processAsync failed: %s', err instanceof Error ? err.message : String(err))
+      if (!res.headersSent) {
+        res.writeHead(500)
+        res.end('Internal server error')
+      }
+      req.destroy()
     }
   }
 
@@ -176,7 +182,8 @@ export class BotApplication {
     let index = 0
     const next = async (): Promise<void> => {
       if (index < this.middlewares.length) {
-        await this.middlewares[index++](context, next)
+        const mw = this.middlewares[index++]!
+        await mw(context, next)
       } else {
         await this.handleCoreActivityAsync(context)
       }
@@ -226,12 +233,41 @@ function assertCoreActivity (value: unknown): asserts value is CoreActivity {
   ) {
     throw new Error('CoreActivity missing required field: conversation.id')
   }
+  // Input size validation (#11)
+  if (typeof a['text'] === 'string' && (a['text'] as string).length > MAX_TEXT_LENGTH) {
+    throw new Error(`CoreActivity text exceeds maximum length of ${MAX_TEXT_LENGTH}`)
+  }
+  if (Array.isArray(a['entities']) && (a['entities'] as unknown[]).length > MAX_ENTITIES) {
+    throw new Error(`CoreActivity entities exceeds maximum count of ${MAX_ENTITIES}`)
+  }
+  if (Array.isArray(a['attachments']) && (a['attachments'] as unknown[]).length > MAX_ATTACHMENTS) {
+    throw new Error(`CoreActivity attachments exceeds maximum count of ${MAX_ATTACHMENTS}`)
+  }
 }
+
+/** Maximum request body size (10 MB). */
+const MAX_BODY_BYTES = 10 * 1024 * 1024
+
+/** Maximum allowed length for activity.text. */
+const MAX_TEXT_LENGTH = 50_000
+/** Maximum number of entities per activity. */
+const MAX_ENTITIES = 250
+/** Maximum number of attachments per activity. */
+const MAX_ATTACHMENTS = 50
 
 function readBody (req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    let totalBytes = 0
+    req.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.length
+      if (totalBytes > MAX_BODY_BYTES) {
+        req.destroy()
+        reject(new Error(`Request body exceeds ${MAX_BODY_BYTES} bytes`))
+        return
+      }
+      chunks.push(chunk)
+    })
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
     req.on('error', reject)
   })

--- a/node/packages/botas/src/bot-http-client.ts
+++ b/node/packages/botas/src/bot-http-client.ts
@@ -29,6 +29,7 @@ export class BotHttpClient {
   constructor (getToken?: TokenProvider) {
     this.http = axios.create({
       headers: { 'Content-Type': 'application/json' },
+      timeout: 30_000,
     })
 
     if (getToken) {

--- a/node/packages/botas/src/conversation-client.ts
+++ b/node/packages/botas/src/conversation-client.ts
@@ -234,7 +234,7 @@ export class ConversationClient {
 }
 
 function encodeConversationId (conversationId: string): string {
-  const truncated = conversationId.split(';')[0]
+  const truncated = conversationId.split(';')[0] ?? conversationId
   if (truncated !== conversationId) {
     getLogger().info("Truncating conversation ID for 'agents' channel")
   }

--- a/node/packages/botas/src/logger.ts
+++ b/node/packages/botas/src/logger.ts
@@ -81,3 +81,12 @@ export function configure (logger: Logger): void {
 export function getLogger (): Logger {
   return _logger
 }
+
+/**
+ * Reset the logger to the default (debugLogger).
+ * Intended for test teardown to avoid cross-test contamination.
+ * @internal
+ */
+export function resetLogger (): void {
+  _logger = debugLogger
+}

--- a/node/packages/botas/src/remove-mention-middleware.ts
+++ b/node/packages/botas/src/remove-mention-middleware.ts
@@ -50,6 +50,7 @@ export function removeMentionMiddleware (): TurnMiddleware {
       if (botId) {
         for (const entity of activity.entities) {
           if (isMentionEntity(entity) && entity.mentioned.id.toLowerCase() === botId.toLowerCase()) {
+            if (entity.text.length > 200) continue // ReDoS guard
             const pattern = new RegExp(escapeRegExp(entity.text), 'gi')
             activity.text = activity.text.replace(pattern, '').trim()
           }

--- a/node/packages/botas/src/token-manager.ts
+++ b/node/packages/botas/src/token-manager.ts
@@ -50,11 +50,15 @@ type ResolvedOptions = Required<Omit<TokenManagerOptions, 'token'>> & {
 // #94: Negative cache for failed token acquisitions
 const NEGATIVE_CACHE_TTL_MS = 30_000
 
+/** Maximum number of MSAL confidential clients to cache. */
+const MAX_CONFIDENTIAL_CLIENTS = 10
+
 export class TokenManager {
   private readonly opts: ResolvedOptions
   private confidentialClients: Record<string, ConfidentialClientApplication> = {}
   private managedIdentityClient: ManagedIdentityApplication | null = null
   private negativeCache: { failedAt: number; error: string } | null = null
+  private pendingToken: Promise<string | null> | null = null
 
   constructor (options: TokenManagerOptions = {}) {
     this.opts = {
@@ -66,10 +70,14 @@ export class TokenManager {
     }
   }
 
-  /** Acquire a Bot Framework access token. */
+  /** Acquire a Bot Framework access token. Concurrent calls are deduplicated. */
   async getBotToken (): Promise<string | null> {
+    if (this.pendingToken) return this.pendingToken
     const tenantId = this.opts.tenantId || BOT_TOKEN_TENANT
-    return this.getToken(BOT_TOKEN_SCOPE, tenantId)
+    this.pendingToken = this.getToken(BOT_TOKEN_SCOPE, tenantId).finally(() => {
+      this.pendingToken = null
+    })
+    return this.pendingToken
   }
 
   private async getToken (scope: string, tenantId: string): Promise<string | null> {
@@ -183,6 +191,11 @@ export class TokenManager {
   ): ConfidentialClientApplication {
     const key = `${clientId}:${tenantId}`
     if (!this.confidentialClients[key]) {
+      // Evict oldest entry when at capacity
+      const keys = Object.keys(this.confidentialClients)
+      if (keys.length >= MAX_CONFIDENTIAL_CLIENTS) {
+        delete this.confidentialClients[keys[0]!]
+      }
       this.confidentialClients[key] = new ConfidentialClientApplication({
         auth: {
           clientId,
@@ -192,7 +205,7 @@ export class TokenManager {
         system: { loggerOptions: this.msalLoggerOptions() },
       })
     }
-    return this.confidentialClients[key]
+    return this.confidentialClients[key]!
   }
 
   private getOrCreateManagedIdentityClient (

--- a/node/packages/botas/tsconfig.json
+++ b/node/packages/botas/tsconfig.json
@@ -15,6 +15,7 @@
     "resolveJsonModule": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "rootDir": "src",
     "types": ["node"]

--- a/node/samples/express/index.ts
+++ b/node/samples/express/index.ts
@@ -31,8 +31,8 @@ server.use((req, _res, next) => {
   next()
 })
 
-server.post('/api/messages', botAuthExpress(), (req, res) => {
-  bot.processAsync(req, res)
+server.post('/api/messages', botAuthExpress(), async (req, res) => {
+  await bot.processAsync(req, res)
 })
 
 server.get('/', (_req, res) => res.send(`Bot ${bot.options.clientId} is running. Send messages to /api/messages`))


### PR DESCRIPTION
## Summary

Fixes remaining medium/low audit items from #75.

### Changes

**MEDIUM fixes:**
1. **Input validation** - Validate required activity fields (Type, Conversation.Id, ServiceUrl) before processing
2. **HttpClient lifecycle** - Already fixed by P1 PR #120 (uses IHttpClientFactory)
3. **Async event handlers** - Removed misleading async/await from JwtExtensions OnMessageReceived
4. **Catch-all too broad** - Re-throw OperationCanceledException before wrapping in BotHandlerException

**LOW fixes:**
5. **Request body size limit** - Added Kestrel MaxRequestBodySize (1 MB) in BotApp
6. **Trace logging PII** - Replaced full activity JSON logging with non-PII fields only
7. **Middleware pipeline docs** - Added XML doc comment on BotApplication.Use()
8. **ValueTask** - Informational only, no action needed

### Tests
- 7 new tests for input validation and cancellation propagation
- All 75 tests pass

Fixes #75