### PR TITLE
fix(python): Complete P2 audit fixes #113 #114 #115

### DIFF
--- a/python/packages/botas/src/botas/bot_auth.py
+++ b/python/packages/botas/src/botas/bot_auth.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 from typing import Any
 
 import httpx
 import jwt
 from jwt.algorithms import RSAAlgorithm  # type: ignore[attr-defined]
+
+_logger = logging.getLogger(__name__)
 
 _OPENID_METADATA_URL = "https://login.botframework.com/v1/.well-known/openid-configuration"
 _VALID_ISSUERS = {"https://api.botframework.com"}
@@ -16,6 +19,7 @@ _VALID_ISSUER_PREFIX = "https://sts.windows.net/"
 _jwks_uri: str | None = None
 _jwks_keys: list[dict[str, Any]] = []
 _jwks_lock = asyncio.Lock()
+_jwks_refresh_task: asyncio.Task[list[dict[str, Any]]] | None = None
 
 
 class BotAuthError(Exception):
@@ -37,13 +41,39 @@ async def _fetch_jwks(jwks_uri: str) -> list[dict[str, Any]]:
 
 
 async def _get_jwks(force_refresh: bool = False) -> list[dict[str, Any]]:
-    global _jwks_uri, _jwks_keys
+    """Get JWKS keys with single-flight refresh pattern.
+
+    When multiple concurrent callers request a refresh, only one fetch occurs
+    and all waiters share the result. This prevents DoS amplification from
+    redundant JWKS fetches during cache misses.
+    """
+    global _jwks_uri, _jwks_keys, _jwks_refresh_task
+
     async with _jwks_lock:
-        if not _jwks_keys or force_refresh:
-            if _jwks_uri is None:
-                _jwks_uri = await _fetch_jwks_uri()
-            _jwks_keys = await _fetch_jwks(_jwks_uri)
-    return _jwks_keys
+        # If a refresh is already in progress, wait for it
+        if _jwks_refresh_task is not None:
+            _logger.debug("JWKS refresh already in progress, waiting...")
+            return await _jwks_refresh_task
+
+        # Return cached keys if available and not forcing refresh
+        if _jwks_keys and not force_refresh:
+            return _jwks_keys
+
+        # Start a new refresh task
+        async def _refresh() -> list[dict[str, Any]]:
+            global _jwks_uri, _jwks_keys
+            try:
+                if _jwks_uri is None:
+                    _jwks_uri = await _fetch_jwks_uri()
+                _jwks_keys = await _fetch_jwks(_jwks_uri)
+                _logger.debug("JWKS refreshed successfully, %d keys", len(_jwks_keys))
+                return _jwks_keys
+            finally:
+                global _jwks_refresh_task
+                _jwks_refresh_task = None
+
+        _jwks_refresh_task = asyncio.create_task(_refresh())
+        return await _jwks_refresh_task
 
 
 async def validate_bot_token(auth_header: str | None, app_id: str | None = None) -> None:
@@ -96,4 +126,5 @@ async def validate_bot_token(auth_header: str | None, app_id: str | None = None)
 
     issuer: str = claims.get("iss", "")
     if issuer not in _VALID_ISSUERS and not issuer.startswith(_VALID_ISSUER_PREFIX):
-        raise BotAuthError(f"Untrusted issuer: {issuer!r}")
+        _logger.warning("Token rejected: untrusted issuer %r", issuer)
+        raise BotAuthError("Invalid issuer")

--- a/python/packages/botas/src/botas/conversation_client.py
+++ b/python/packages/botas/src/botas/conversation_client.py
@@ -22,6 +22,11 @@ def _encode_conversation_id(conversation_id: str) -> str:
     return quote(truncated, safe="")
 
 
+def _encode_id(id_value: str) -> str:
+    """URL-encode an ID for use in path parameters."""
+    return quote(id_value, safe="")
+
+
 def _serialize(obj: Any) -> Any:
     """Convert Pydantic model or plain dict to a JSON-serializable dict."""
     if hasattr(obj, "model_dump"):
@@ -55,7 +60,7 @@ class ConversationClient:
         activity_id: str,
         activity: CoreActivity | dict[str, Any],
     ) -> ResourceResponse | None:
-        endpoint = f"/v3/conversations/{_encode_conversation_id(conversation_id)}/activities/{activity_id}"
+        endpoint = f"/v3/conversations/{_encode_conversation_id(conversation_id)}/activities/{_encode_id(activity_id)}"
         data = await self._http.put(
             service_url,
             endpoint,
@@ -65,7 +70,7 @@ class ConversationClient:
         return ResourceResponse.model_validate(data) if data else None
 
     async def delete_activity_async(self, service_url: str, conversation_id: str, activity_id: str) -> None:
-        endpoint = f"/v3/conversations/{_encode_conversation_id(conversation_id)}/activities/{activity_id}"
+        endpoint = f"/v3/conversations/{_encode_conversation_id(conversation_id)}/activities/{_encode_id(activity_id)}"
         await self._http.delete(
             service_url,
             endpoint,
@@ -84,7 +89,7 @@ class ConversationClient:
     async def get_conversation_member_async(
         self, service_url: str, conversation_id: str, member_id: str
     ) -> ChannelAccount | None:
-        endpoint = f"/v3/conversations/{_encode_conversation_id(conversation_id)}/members/{member_id}"
+        endpoint = f"/v3/conversations/{_encode_conversation_id(conversation_id)}/members/{_encode_id(member_id)}"
         data = await self._http.get(
             service_url,
             endpoint,
@@ -113,7 +118,7 @@ class ConversationClient:
         return PagedMembersResult.model_validate(data) if data else PagedMembersResult()
 
     async def delete_conversation_member_async(self, service_url: str, conversation_id: str, member_id: str) -> None:
-        endpoint = f"/v3/conversations/{_encode_conversation_id(conversation_id)}/members/{member_id}"
+        endpoint = f"/v3/conversations/{_encode_conversation_id(conversation_id)}/members/{_encode_id(member_id)}"
         await self._http.delete(
             service_url,
             endpoint,

--- a/python/packages/botas/tests/test_bot_auth.py
+++ b/python/packages/botas/tests/test_bot_auth.py
@@ -1,0 +1,100 @@
+"""Tests for bot_auth P2 security fixes."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from botas.bot_auth import BotAuthError, validate_bot_token
+
+
+class TestIssuerSanitization:
+    """Issue #113: Issuer value should not be leaked in error messages."""
+
+    @pytest.mark.asyncio
+    async def test_untrusted_issuer_does_not_leak_value_in_exception(self):
+        """Error message should not include the issuer value."""
+        mock_token = "mock.jwt.token"
+        auth_header = f"Bearer {mock_token}"
+
+        mock_jwk = {"kid": "test-kid", "kty": "RSA", "n": "test-modulus", "e": "AQAB"}
+
+        with (
+            patch("botas.bot_auth.jwt.get_unverified_header") as mock_header,
+            patch("botas.bot_auth.jwt.decode") as mock_decode,
+            patch("botas.bot_auth._get_jwks") as mock_jwks,
+            patch("botas.bot_auth.RSAAlgorithm.from_jwk") as mock_rsa,
+            patch.dict("os.environ", {"CLIENT_ID": "test-app-id"}),
+        ):
+            mock_header.return_value = {"kid": "test-kid"}
+            mock_jwks.return_value = [mock_jwk]
+            mock_rsa.return_value = MagicMock()
+            mock_decode.return_value = {"iss": "https://evil.example.com", "aud": "test-app-id"}
+
+            with pytest.raises(BotAuthError) as exc_info:
+                await validate_bot_token(auth_header, app_id="test-app-id")
+
+            error_msg = str(exc_info.value)
+            assert "evil.example.com" not in error_msg, "Issuer value leaked"
+            assert "Invalid issuer" in error_msg
+
+    @pytest.mark.asyncio
+    async def test_untrusted_issuer_logs_value_server_side(self):
+        """Issuer should be logged server-side for debugging."""
+        mock_token = "mock.jwt.token"
+        auth_header = f"Bearer {mock_token}"
+
+        mock_jwk = {"kid": "test-kid", "kty": "RSA", "n": "test-modulus", "e": "AQAB"}
+
+        with (
+            patch("botas.bot_auth.jwt.get_unverified_header") as mock_header,
+            patch("botas.bot_auth.jwt.decode") as mock_decode,
+            patch("botas.bot_auth._get_jwks") as mock_jwks,
+            patch("botas.bot_auth.RSAAlgorithm.from_jwk") as mock_rsa,
+            patch("botas.bot_auth._logger") as mock_logger,
+            patch.dict("os.environ", {"CLIENT_ID": "test-app-id"}),
+        ):
+            mock_header.return_value = {"kid": "test-kid"}
+            mock_jwks.return_value = [mock_jwk]
+            mock_rsa.return_value = MagicMock()
+            mock_decode.return_value = {"iss": "https://evil.example.com", "aud": "test-app-id"}
+
+            with pytest.raises(BotAuthError):
+                await validate_bot_token(auth_header, app_id="test-app-id")
+
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args[0]
+            assert "evil.example.com" in str(call_args)
+
+
+class TestJWKSSingleFlight:
+    """Issue #114: Concurrent JWKS refreshes should be coalesced."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_jwks_refresh_triggers_only_one_fetch(self):
+        """Multiple concurrent cache misses should trigger only one fetch."""
+        import botas.bot_auth
+
+        fetch_count = 0
+
+        async def mock_fetch_jwks(uri: str):
+            nonlocal fetch_count
+            fetch_count += 1
+            await asyncio.sleep(0.1)
+            return [{"kid": "test-key", "kty": "RSA", "n": "...", "e": "AQAB"}]
+
+        # Reset state
+        botas.bot_auth._jwks_keys = []
+        botas.bot_auth._jwks_uri = None
+        botas.bot_auth._jwks_refresh_task = None
+        botas.bot_auth._jwks_lock = asyncio.Lock()
+
+        with (
+            patch("botas.bot_auth._fetch_jwks_uri", return_value="https://example.com/jwks"),
+            patch("botas.bot_auth._fetch_jwks", side_effect=mock_fetch_jwks),
+        ):
+            tasks = [asyncio.create_task(botas.bot_auth._get_jwks(force_refresh=False)) for _ in range(5)]
+            results = await asyncio.gather(*tasks)
+
+            assert all(len(r) == 1 for r in results)
+            assert fetch_count == 1, f"Expected 1 fetch, got {fetch_count}"

--- a/python/packages/botas/tests/test_conversation_client.py
+++ b/python/packages/botas/tests/test_conversation_client.py
@@ -1,0 +1,65 @@
+"""Tests for conversation_client P2 security fixes."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from botas.conversation_client import ConversationClient
+from botas.core_activity import CoreActivity
+
+
+class TestPathParameterEncoding:
+    """Issue #115: All path parameters must be URL-encoded."""
+
+    @pytest.mark.asyncio
+    async def test_update_activity_encodes_activity_id(self):
+        """activity_id with special chars should be URL-encoded."""
+        client = ConversationClient()
+
+        with patch.object(client._http, "put", new_callable=AsyncMock) as mock_put:
+            mock_put.return_value = {"id": "response-id"}
+
+            await client.update_activity_async(
+                "https://example.com",
+                "conv-123",
+                "1234/5678",
+                CoreActivity(type="message", text="updated"),
+            )
+
+            endpoint = mock_put.call_args[0][1]
+            assert "1234%2F5678" in endpoint
+
+    @pytest.mark.asyncio
+    async def test_delete_activity_encodes_activity_id(self):
+        """activity_id with query chars should be URL-encoded."""
+        client = ConversationClient()
+
+        with patch.object(client._http, "delete", new_callable=AsyncMock) as mock_delete:
+            await client.delete_activity_async("https://example.com", "conv-123", "abc?xyz")
+
+            endpoint = mock_delete.call_args[0][1]
+            assert "abc%3Fxyz" in endpoint
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_member_encodes_member_id(self):
+        """member_id with special chars should be URL-encoded."""
+        client = ConversationClient()
+
+        with patch.object(client._http, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"id": "user/123#abc", "name": "Test"}
+
+            await client.get_conversation_member_async("https://example.com", "conv-123", "user/123#abc")
+
+            endpoint = mock_get.call_args[0][1]
+            assert "user%2F123%23abc" in endpoint
+
+    @pytest.mark.asyncio
+    async def test_delete_conversation_member_encodes_member_id(self):
+        """member_id with ampersand should be URL-encoded."""
+        client = ConversationClient()
+
+        with patch.object(client._http, "delete", new_callable=AsyncMock) as mock_delete:
+            await client.delete_conversation_member_async("https://example.com", "conv-123", "user&admin")
+
+            endpoint = mock_delete.call_args[0][1]
+            assert "user%26admin" in endpoint


### PR DESCRIPTION
## Summary
Fixes three P2 security issues identified in the Python audit:

### #113 — Issuer value sanitization (info disclosure)
- **Problem:** JWT issuer claim included verbatim in BotAuthError message
- **Fix:** Generic 'Invalid issuer' message, log details server-side only
- **Impact:** No leaking of auth infrastructure details to clients

### #114 — Single-flight JWKS refresh (DoS amplification)
- **Problem:** Concurrent cache misses each trigger independent JWKS fetch
- **Fix:** Track in-progress refresh task, concurrent callers share result
- **Impact:** Prevents redundant requests that amplify DoS attacks

### #115 — URL-encode path parameters (injection vulnerability)  
- **Problem:** activity_id and member_id interpolated directly into URLs
- **Fix:** New _encode_id() helper, encode all path params consistently
- **Impact:** Prevents path traversal (/) and query injection (?)

## Testing
- 7 new tests covering all three fixes
- All existing tests pass
- Ruff lint clean

## Related
Part of the Python P2 security audit batch.