### PR TITLE
fix(dotnet): remaining medium and low audit findings from #75

### DIFF
--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -73,3 +73,7 @@
 - **Testing:** All 48 tests pass. Build succeeds with no warnings.
 - **Files changed:** `BotApplicationConfigurationExtensions.cs` (DI fixes + timeout), `JwtExtensions.cs` (DI fixes + caching), `ConversationClient.cs` (error sanitization). **New files:** `AgentScopeProvider.cs`, `BotAuthenticationOptions.cs`, `BotAuthenticationMultiOptions.cs`, `ConfigurationManagerCache.cs`.
 - **PR:** #135 merged into main. All four issues resolved in a single PR for atomic fix.
+### .NET Audit Medium/Low Findings (2026-04-13)
+- **Fixed remaining audit findings from #75** (PR #137): Input validation for required Activity fields (Type, Conversation.Id, ServiceUrl); removed misleading async from JWT event handlers; improved catch block to re-throw OperationCanceledException and BotHandlerException; added Kestrel MaxRequestBodySize (1 MB); reduced PII in trace logs (log type only, not full JSON); documented Use() as startup-only.
+- **Skipped items:** HttpClient lifecycle (#101) already fixed in open PR #133; ValueTask over-optimization is informational only.
+- **All 48 tests pass.**

--- a/dotnet/src/Botas/BotApp.cs
+++ b/dotnet/src/Botas/BotApp.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -33,6 +34,10 @@ public class BotApp
     private BotApp(string[]? args, string routePath)
     {
         _builder = WebApplication.CreateSlimBuilder(args ?? []);
+        _builder.Services.Configure<KestrelServerOptions>(options =>
+        {
+            options.Limits.MaxRequestBodySize = 1_048_576; // 1 MB
+        });
         _routePath = routePath;
 
         string? clientId = _builder.Configuration["AzureAd:ClientId"];

--- a/dotnet/src/Botas/BotApplication.cs
+++ b/dotnet/src/Botas/BotApplication.cs
@@ -66,9 +66,22 @@ public class BotApplication
 
         CoreActivity activity = await CoreActivity.FromJsonStreamAsync(httpContext.Request.Body, cancellationToken) ?? throw new InvalidOperationException("Invalid Activity");
 
+        if (string.IsNullOrEmpty(activity.Type))
+        {
+            throw new InvalidOperationException("Activity Type is required");
+        }
+        if (activity.Conversation?.Id is null)
+        {
+            throw new InvalidOperationException("Activity Conversation.Id is required");
+        }
+        if (string.IsNullOrEmpty(activity.ServiceUrl))
+        {
+            throw new InvalidOperationException("Activity ServiceUrl is required");
+        }
+
         if (_logger.IsEnabled(LogLevel.Trace))
         {
-            _logger.LogTrace("Received activity: {Activity}", activity.ToJson());
+            _logger.LogTrace("Received activity type: {Type}", activity.Type);
         }
 
         using (_logger.BeginScope("Processing activity {Type}", activity.Type))
@@ -81,6 +94,14 @@ public class BotApplication
             }
             catch (Exception ex)
             {
+                if (ex is OperationCanceledException)
+                {
+                    throw;
+                }
+                if (ex is BotHandlerException)
+                {
+                    throw;
+                }
                 _logger.LogError(ex, "Error processing activity {Type}", activity.Type);
                 throw new BotHandlerException("Error processing activity", ex, activity);
             }
@@ -92,6 +113,11 @@ public class BotApplication
         }
     }
 
+    /// <summary>
+    /// Register middleware to run before handlers on every turn.
+    /// Middleware executes in registration order.
+    /// IMPORTANT: Call this method only during application startup, not per-request.
+    /// </summary>
     public ITurnMiddleWare Use(ITurnMiddleWare middleware)
     {
         _turnMiddleware.Use(middleware);

--- a/dotnet/src/Botas/JwtExtensions.cs
+++ b/dotnet/src/Botas/JwtExtensions.cs
@@ -137,7 +137,7 @@ public static class JwtExtensions
                      if (!IsKnownIssuer(issuer, validIssuers))
                      {
                          context.Fail("Token issuer is not in the allowed issuers list.");
-                         return;
+                         return Task.CompletedTask;
                      }
 
                      string oidcAuthority;
@@ -152,7 +152,7 @@ public static class JwtExtensions
                      else
                      {
                          context.Fail("Token tenant ID does not match the configured tenant.");
-                         return;
+                         return Task.CompletedTask;
                      }
 
                      jwtOptions.ConfigurationManager = ConfigurationManagerCache.GetOrCreate(

--- a/dotnet/src/Botas/JwtExtensions.cs
+++ b/dotnet/src/Botas/JwtExtensions.cs
@@ -112,23 +112,21 @@ public static class JwtExtensions
              jwtOptions.MapInboundClaims = true;
              jwtOptions.Events = new JwtBearerEvents
              {
-                 OnMessageReceived = async context =>
+                 OnMessageReceived = context =>
                  {
                      string authorizationHeader = context.Request.Headers.Authorization.ToString();
 
                      if (string.IsNullOrEmpty(authorizationHeader))
                      {
                          context.Options.TokenValidationParameters.ConfigurationManager ??= jwtOptions.ConfigurationManager as BaseConfigurationManager;
-                         await Task.CompletedTask.ConfigureAwait(false);
-                         return;
+                         return Task.CompletedTask;
                      }
 
                      string[] parts = authorizationHeader?.Split(' ')!;
                      if (parts.Length != 2 || parts[0] != "Bearer")
                      {
                          context.Options.TokenValidationParameters.ConfigurationManager ??= jwtOptions.ConfigurationManager as BaseConfigurationManager;
-                         await Task.CompletedTask.ConfigureAwait(false);
-                         return;
+                         return Task.CompletedTask;
                      }
 
                      JwtSecurityToken token = new(parts[1]);
@@ -161,7 +159,7 @@ public static class JwtExtensions
                          oidcAuthority,
                          jwtOptions.RequireHttpsMetadata);
 
-                     await Task.CompletedTask.ConfigureAwait(false);
+                     return Task.CompletedTask;
                  },
                  OnTokenValidated = context =>
                  {


### PR DESCRIPTION
Fixes remaining medium and low priority audit findings from #75.

## Changes

### MEDIUM Priority
✅ **Input validation gaps** - Added validation for required Activity fields (Type, Conversation.Id, ServiceUrl) after deserialization to prevent null reference exceptions
✅ **Misleading async event handlers** - Removed \sync\ keyword from JWT event handlers that just return \Task.CompletedTask\ (cleaner, no state machine overhead)
✅ **Catch-all too broad** - Improved exception handling to re-throw \OperationCanceledException\ and \BotHandlerException\ to avoid hiding important errors

### LOW Priority
✅ **No request body size limit** - Added Kestrel \MaxRequestBodySize\ configuration (1 MB limit) to prevent unbounded payload attacks
✅ **Trace logging PII exposure** - Changed trace logging to log only activity type instead of full JSON to reduce PII exposure
✅ **Middleware pipeline unbounded** - Added XML doc comment to \Use()\ method documenting it should only be called during startup

### SKIPPED
⏭️ **HttpClient lifecycle** (#101) - Already fixed in open PR #133, will be merged separately
⏭️ **ValueTask over-optimization** - Informational only, no action needed

## Testing
All 48 tests pass.

## References
Fixes #75