### PR TITLE
docs: simplify README to 3-step quickstart with Teams CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,49 +9,84 @@
 [![npm](https://img.shields.io/npm/v/botas-core.svg)](https://www.npmjs.com/package/botas-core)
 [![PyPI](https://img.shields.io/pypi/v/botas.svg)](https://pypi.org/project/botas/)
 
-A lightweight, multi-language library for building [Microsoft Bot Framework](https://learn.microsoft.com/azure/bot-service/) bots. Implementations exist for **.NET (C#)**, **TypeScript/Node.js**, and **Python**, with behavioral parity across all three.
+A lightweight, multi-language library for building [Microsoft Bot Framework](https://learn.microsoft.com/azure/bot-service/) bots in **.NET**, **Node.js**, and **Python**.
 
 📖 **[Full Documentation](https://rido-min.github.io/botas/)** — guides, API reference, and samples for all three languages.
 
-## What it does
+---
 
-BotAS handles the plumbing so you can focus on bot logic:
-
-- Validates inbound JWT tokens from the Bot Framework Service
-- Deserializes activities and dispatches them to registered handlers
-- Runs a configurable middleware pipeline before each handler
-- Authenticates outbound HTTP calls using OAuth2 client credentials
-- Preserves unknown JSON properties so custom channel data round-trips safely
-
-## Getting started
+## Quickstart
 
 ### Prerequisites
 
-- Azure AD app registration and Bot Framework channel registration — see [Infrastructure Setup](specs/Setup.md)
-- A tunneling tool for local dev (Microsoft devtunnels or ngrok)
-- Runtime for your chosen language:
-  - .NET 10.0 SDK
-  - Node.js 20+
-  - Python 3.11+
+1. **Teams CLI** — creates bot registrations and provides credentials:
 
-### Environment variables
+   ```bash
+   npm install -g https://github.com/heyitsaamir/teamscli/releases/latest/download/teamscli.tgz
+   teams login
+   ```
 
-All three implementations read the same variables:
+   > 💡 Using GitHub Copilot? Ask the `/teams-bot-infra` skill to walk you through this interactively.
 
-| Variable | Description |
-|---|---|
-| `CLIENT_ID` | Azure AD application (bot) ID |
-| `CLIENT_SECRET` | Azure AD client secret |
-| `TENANT_ID` | Azure AD tenant ID (or `common`) |
-| `PORT` | HTTP listen port (default: `3978`) |
+2. **Dev tunnel** — exposes your local port to the Bot Framework Service. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started) or [ngrok](https://ngrok.com/).
 
-Copy `.env` from the repo root and fill in the values from your bot registration.
+3. **Language runtime** (pick one): .NET 10 SDK · Node.js 20+ · Python 3.11+
 
 ---
 
-## Echo bot — quick start
+### Step 1 — Start a dev tunnel
 
-### .NET
+```bash
+devtunnel host -p 3978 --allow-anonymous
+```
+
+Copy the HTTPS URL from the output (e.g. `https://your-tunnel.devtunnels.ms`).
+
+> Using ngrok instead? Run `ngrok http 3978` and copy the `Forwarding` URL.
+
+---
+
+### Step 2 — Create the Teams app
+
+```bash
+teams app create --name "MyBot" --endpoint "https://<tunnel-url>/api/messages" --json
+```
+
+The command outputs JSON with your credentials and an install link. Save the credentials for your language:
+
+<details>
+<summary><b>.NET</b> — add to <code>appsettings.json</code></summary>
+
+```json
+{
+  "AzureAd": {
+    "ClientId": "<CLIENT_ID from output>",
+    "ClientSecret": "<CLIENT_SECRET from output>",
+    "TenantId": "<TENANT_ID from output>"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Node.js / Python</b> — create a <code>.env</code> file</summary>
+
+```env
+CLIENT_ID=<from output>
+CLIENT_SECRET=<from output>
+TENANT_ID=<from output>
+```
+
+</details>
+
+> 📌 Keep the `installLink` from the output — you'll use it to add the bot to Teams.
+
+---
+
+### Step 3 — Run the echo bot
+
+#### .NET
 
 ```csharp
 using Botas;
@@ -66,15 +101,11 @@ app.On("message", async (ctx, ct) =>
 app.Run();
 ```
 
-Run:
 ```bash
-cd dotnet
-dotnet run --project samples/EchoBot
+cd dotnet && dotnet run --project samples/EchoBot
 ```
 
-For advanced ASP.NET Core integration scenarios (custom DI, middleware, or multi-bot hosting), see the [.NET language guide](https://rido-min.github.io/botas/languages/dotnet).
-
-### Node.js
+#### Node.js
 
 ```typescript
 import { BotApp } from 'botas-express'
@@ -88,16 +119,11 @@ app.on('message', async (ctx) => {
 app.start()
 ```
 
-Run:
 ```bash
-cd node
-npm install && npm run build
-npx tsx samples/echo-bot/index.ts
+cd node && npm install && npm run build && npx tsx samples/echo-bot/index.ts
 ```
 
-For manual Express, Hono, or other framework integration, see the [Node.js language guide](https://rido-min.github.io/botas/languages/nodejs).
-
-### Python
+#### Python
 
 ```python
 from botas_fastapi import BotApp
@@ -111,261 +137,26 @@ async def on_message(ctx):
 app.start()
 ```
 
-Run:
 ```bash
-cd python/samples/echo-bot
-pip install -e .
-python main.py
-```
-
-For manual FastAPI, aiohttp, or other framework integration, see the [Python language guide](https://rido-min.github.io/botas/languages/python).
-
----
-
-## Repository layout
-
-```
-botas/
-├── dotnet/           .NET library + ASP.NET Core integration + samples
-├── node/             TypeScript library + Express and Hono samples
-├── python/           Python library + FastAPI and aiohttp samples
-├── specs/            Protocol specs, architecture, and setup docs
-├── art/              Logo and icon assets
-├── docs-site/        Jekyll documentation website
-├── AGENTS.md         Guide for porting to new languages
-└── README.md
+cd python/samples/echo-bot && pip install -e . && python main.py
 ```
 
 ---
 
-## Teams features — mentions, cards & suggested actions
+### Try it
 
-The `TeamsActivity` and `TeamsActivityBuilder` types provide a fluent API for common Teams scenarios. See the full spec at [specs/teams-activity.md](specs/teams-activity.md).
-
-### .NET
-
-```csharp
-using Botas;
-
-var reply = new TeamsActivityBuilder()
-    .WithConversationReference(ctx.Activity)
-    .WithText($"<at>{sender.Name}</at> said: {text}")
-    .AddMention(sender)
-    .WithAdaptiveCardAttachment(cardJson)
-    .WithSuggestedActions(new SuggestedActions {
-        Actions = [new CardAction { Type = "imBack", Title = "Yes", Value = "yes" }]
-    })
-    .Build();
-await ctx.SendAsync(reply, ct);
-```
-
-### Node.js
-
-```typescript
-import { TeamsActivityBuilder } from 'botas'
-
-const reply = new TeamsActivityBuilder()
-  .withConversationReference(ctx.activity)
-  .withText(`<at>${sender.name}</at> said: ${text}`)
-  .addMention(sender)
-  .withAdaptiveCardAttachment(cardJson)
-  .withSuggestedActions({
-    actions: [{ type: 'imBack', title: 'Yes', value: 'yes' }]
-  })
-  .build()
-await ctx.send(reply)
-```
-
-### Python
-
-```python
-from botas import TeamsActivityBuilder
-from botas.suggested_actions import SuggestedActions, CardAction
-
-reply = (
-    TeamsActivityBuilder()
-    .with_conversation_reference(ctx.activity)
-    .with_text(f"<at>{sender.name}</at> said: {text}")
-    .add_mention(sender)
-    .with_adaptive_card_attachment(card_json)
-    .with_suggested_actions(SuggestedActions(
-        actions=[CardAction(type="imBack", title="Yes", value="yes")]
-    ))
-    .build()
-)
-await ctx.send(reply)
-```
-
-Run the TeamsSample for any language:
-```bash
-cd dotnet && dotnet run --project samples/TeamsSample
-cd node && npx tsx samples/teams-sample/index.ts
-cd python/samples/teams-sample && python main.py
-```
+Open the `installLink` from Step 2 in your browser to add the bot to Microsoft Teams, then send it a message. You should see your message echoed back.
 
 ---
 
-## Typing indicators
+## Learn more
 
-Show the bot is composing a reply (or react to user typing) with `sendTyping()` / `SendTypingAsync()` / `send_typing()`:
-
-```csharp
-// .NET
-await ctx.SendTypingAsync(ct);
-await Task.Delay(2000, ct);  // Long-running work
-await ctx.SendAsync("Done!", ct);
-```
-
-```typescript
-// Node.js
-await ctx.sendTyping()
-await new Promise(resolve => setTimeout(resolve, 2000))  // Long-running work
-await ctx.send('Done!')
-```
-
-```python
-# Python
-await ctx.send_typing()
-await asyncio.sleep(2)  # Long-running work
-await ctx.send("Done!")
-```
-
-Typing activities are ephemeral presence signals — useful for improving perceived responsiveness on slow operations. See [Typing Indicators](docs-site/typing-activity.md) for more.
-
----
-
-## AI bot — LLM integration with Azure Foundry
-
-Each language has an AI bot sample that forwards messages to an LLM via Azure AI Foundry and maintains multi-turn conversation history.
-
-### Environment variables (in addition to bot credentials)
-
-| Variable | Description |
+| Topic | Link |
 |---|---|
-| `AZURE_OPENAI_ENDPOINT` | Azure Foundry resource endpoint (e.g. `https://<resource>.openai.azure.com`) |
-| `AZURE_OPENAI_API_KEY` | API key for the deployed model |
-| `AZURE_OPENAI_DEPLOYMENT` | Deployment/model name (default: `gpt-4o`) |
-
-### .NET (Azure.AI.OpenAI + Microsoft.Extensions.AI)
-
-```csharp
-using System.Collections.Concurrent;
-using Azure.AI.OpenAI;
-using Botas;
-using Microsoft.Extensions.AI;
-
-IChatClient chatClient = new AzureOpenAIClient(
-    new Uri(endpoint), new System.ClientModel.ApiKeyCredential(apiKey))
-    .GetChatClient(deployment)
-    .AsIChatClient();
-
-var history = new ConcurrentDictionary<string, List<ChatMessage>>();
-var app = BotApp.Create(args);
-
-app.On("message", async (ctx, ct) =>
-{
-    var msgs = history.GetOrAdd(ctx.Activity.Conversation!.Id!, _ => []);
-    msgs.Add(new ChatMessage(ChatRole.User, ctx.Activity.Text ?? ""));
-    var response = await chatClient.GetResponseAsync(msgs, cancellationToken: ct);
-    msgs.Add(new ChatMessage(ChatRole.Assistant, response.Text ?? ""));
-    await ctx.SendAsync(response.Text ?? "", ct);
-});
-
-app.Run();
-```
-
-```bash
-cd dotnet && dotnet run --project samples/AiBot
-```
-
-### Node.js (Vercel AI SDK)
-
-```typescript
-import { BotApp } from 'botas-express'
-import { azure } from '@ai-sdk/azure'
-import { generateText, type CoreMessage } from 'ai'
-
-const history = new Map<string, CoreMessage[]>()
-const app = new BotApp()
-
-app.on('message', async (ctx) => {
-  const msgs = history.get(ctx.activity.conversation.id) ?? []
-  msgs.push({ role: 'user', content: ctx.activity.text ?? '' })
-  const { text } = await generateText({ model: azure('gpt-4o'), messages: msgs })
-  msgs.push({ role: 'assistant', content: text })
-  history.set(ctx.activity.conversation.id, msgs)
-  await ctx.send(text)
-})
-
-app.start()
-```
-
-```bash
-cd node && npx tsx samples/ai-bot/index.ts
-```
-
-### Python (LangChain)
-
-```python
-from botas_fastapi import BotApp
-from langchain_azure_ai.chat_models import AzureAIChatCompletionsModel
-from langchain_core.messages import AIMessage, HumanMessage
-
-model = AzureAIChatCompletionsModel(endpoint=endpoint, credential=api_key, model=deployment)
-history: dict[str, list] = {}
-app = BotApp()
-
-@app.on("message")
-async def on_message(ctx):
-    msgs = history.setdefault(ctx.activity.conversation.id, [])
-    msgs.append(HumanMessage(content=ctx.activity.text or ""))
-    response = await model.ainvoke(msgs)
-    msgs.append(AIMessage(content=response.content))
-    await ctx.send(response.content)
-
-app.start()
-```
-
-```bash
-cd python/samples/ai-bot && pip install -e . && python main.py
-```
-
-## Documentation
-
-| Document | Description |
-|---|---|
-| [Full Documentation Site](https://rido-min.github.io/botas/) | Complete guides, API reference, and samples for all three languages |
-| [Architecture](specs/Architecture.md) | Turn pipeline, two-auth model, middleware, schema |
-| [Infrastructure Setup](specs/Setup.md) | Register a bot and get credentials using the Azure portal |
-| [specs/README.md](specs/README.md) | Full feature specification and API surface per language |
-| [AGENTS.md](AGENTS.md) | Porting guide for new language implementations |
-
-## Additional documentation
-
-| Document | Description |
-|---|---|
-| [Activity Payloads](specs/ActivityPayloads.md) | Annotated JSON examples for each activity type (`message`, `conversationUpdate`, `messageReaction`, `invoke`, `installationUpdate`, `typing`) |
-| [Configuration](specs/Configuration.md) | Per-language configuration reference: env vars, DI wiring (.NET), options objects (Node), constructor args (Python), managed identity setup |
-| [Middleware](specs/Middleware.md) | How to write and register middleware, execution order, short-circuiting, and example patterns |
-| [Proactive Messaging](specs/ProactiveMessaging.md) | How to send messages outside of a turn using `ConversationClient` |
-| [Samples](specs/Samples.md) | Walkthrough of each sample with annotated code and expected behavior |
-| [Contributing](specs/Contributing.md) | Behavioral invariants, CI setup, how to add a new language port |
-
-## Building and testing
-
-```bash
-# .NET
-cd dotnet && dotnet build Botas && dotnet test
-
-# Node
-cd node && npm install && npm run build && npm test
-
-# Python (library development)
-cd python/packages/botas && pip install -e ".[dev]" && pytest
-# Note: Install from PyPI for end users: pip install botas-fastapi
-
-# All languages
-./build-all.sh
-```
-
-CI runs all three on every push and pull request (see `.github/workflows/CI.yml`).
+| Language guides | [.NET](https://rido-min.github.io/botas/languages/dotnet) · [Node.js](https://rido-min.github.io/botas/languages/nodejs) · [Python](https://rido-min.github.io/botas/languages/python) |
+| Teams features | [Mentions, Adaptive Cards, Suggested Actions](https://rido-min.github.io/botas/teams-features) |
+| Middleware | [Extend the turn pipeline](https://rido-min.github.io/botas/middleware) |
+| AI bots | [LLM integration samples](https://rido-min.github.io/botas/getting-started#ai-bot) |
+| Manual auth setup | [Azure portal walkthrough](https://rido-min.github.io/botas/auth-setup) (without Teams CLI) |
+| Architecture | [Turn pipeline, auth model, middleware](specs/Architecture.md) |
+| Contributing | [Build & test, CI, adding a new language](specs/Contributing.md) |

--- a/docs-site/getting-started.md
+++ b/docs-site/getting-started.md
@@ -8,40 +8,97 @@ Build and run an echo bot in under five minutes.
 
 ## Prerequisites
 
-| Requirement | Details |
-|---|---|
-| **Azure subscription** | You need an Azure AD app registration and a Bot Framework channel registration. See [Authentication & Setup](auth-setup). |
-| **Tunnel tool** | [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/) or [ngrok](https://ngrok.com/) to expose your local port to the Bot Framework Service. |
-| **.NET 10 SDK** | Required for the C# implementation. |
-| **Node.js 20+** | Required for the TypeScript implementation. |
-| **Python 3.11+** | Required for the Python implementation. |
+1. **Teams CLI** — creates bot registrations and provides credentials:
 
-You only need the runtime for the language you choose.
+   ```bash
+   npm install -g https://github.com/heyitsaamir/teamscli/releases/latest/download/teamscli.tgz
+   teams login
+   ```
+
+2. **Dev tunnel** — exposes your local port to the Bot Framework Service. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started) or [ngrok](https://ngrok.com/).
+
+3. **Language runtime** (pick one):
+   - **.NET 10 SDK** — for the C# implementation
+   - **Node.js 20+** — for the TypeScript implementation
+   - **Python 3.11+** — for the Python implementation
+
+::: tip
+Don't have the Teams CLI? You can also set up credentials manually through the Azure portal — see [Authentication & Setup](auth-setup).
+:::
 
 ---
 
-## Environment variables
-
-All three implementations read the same four variables. Set them in your shell or in a `.env` file before running.
-
-| Variable | Description |
-|---|---|
-| `CLIENT_ID` | Your Azure AD application (bot) ID |
-| `CLIENT_SECRET` | The corresponding Azure AD client secret |
-| `TENANT_ID` | Your Azure AD tenant ID (or `common` for multi-tenant) |
-| `PORT` | HTTP listen port — defaults to `3978` if not set |
+## Step 1 — Start a dev tunnel
 
 ```bash
-export CLIENT_ID="<your-app-id>"
-export CLIENT_SECRET="<your-secret>"
-export TENANT_ID="<your-tenant-id>"
+devtunnel host -p 3978 --allow-anonymous
 ```
+
+Copy the HTTPS URL from the output (e.g. `https://your-tunnel.devtunnels.ms`).
+
+::: details Using ngrok instead?
+```bash
+ngrok http 3978
+```
+Copy the `Forwarding` HTTPS URL from the output.
+:::
+
+::: warning
+Tunnel URLs are ephemeral — they change each time you restart. If you switch tunnels, update the endpoint with `teams app edit <appId> --endpoint "https://<new-url>/api/messages"`.
+:::
 
 ---
 
-## Echo bot quickstart
+## Step 2 — Create the Teams app
 
-Pick your language. Each example registers a handler for `message` activities and replies with the user's text.
+```bash
+teams app create --name "MyBot" --endpoint "https://<tunnel-url>/api/messages" --json
+```
+
+The command returns JSON with your credentials and an install link:
+
+```json
+{
+  "credentials": {
+    "CLIENT_ID": "...",
+    "CLIENT_SECRET": "...",
+    "TENANT_ID": "..."
+  },
+  "installLink": "https://teams.microsoft.com/l/app/..."
+}
+```
+
+Save the credentials for your language:
+
+::: code-group
+```json [.NET — appsettings.json]
+{
+  "AzureAd": {
+    "ClientId": "<CLIENT_ID from output>",
+    "ClientSecret": "<CLIENT_SECRET from output>",
+    "TenantId": "<TENANT_ID from output>"
+  }
+}
+```
+
+```env [Node.js — .env]
+CLIENT_ID=<from output>
+CLIENT_SECRET=<from output>
+TENANT_ID=<from output>
+```
+
+```env [Python — .env]
+CLIENT_ID=<from output>
+CLIENT_SECRET=<from output>
+TENANT_ID=<from output>
+```
+:::
+
+Keep the `installLink` — you'll use it to add the bot to Teams after the server is running.
+
+---
+
+## Step 3 — Run the echo bot
 
 ::: code-group
 ```csharp [.NET]
@@ -103,33 +160,16 @@ python main.py
 ```
 :::
 
+---
+
+## Try it
+
+1. Open the `installLink` from Step 2 in your browser to add the bot to Microsoft Teams.
+2. Send it a message — you should see your text echoed back.
+
 ::: info
 Each language provides a zero-boilerplate `BotApp` wrapper. For advanced integration (custom DI, middleware, alternative frameworks), see the language guides: [.NET](languages/dotnet) · [Node.js](languages/nodejs) · [Python](languages/python).
 :::
-
----
-
-## Test your bot
-
-1. **Start a tunnel** so the Bot Framework Service can reach your local machine:
-
-   ```bash
-   # Dev Tunnels
-   devtunnel host -p 3978 --allow-anonymous
-
-   # or ngrok
-   ngrok http 3978
-   ```
-
-2. **Update the messaging endpoint** in your Bot Framework channel registration (Azure Portal → Bot resource → Configuration) to point to your tunnel URL + `/api/messages`.
-
-3. **Send a message** using one of these options:
-
-   - **Bot Framework Emulator** — enter `http://localhost:3978/api/messages` as the endpoint, along with your `CLIENT_ID` and `CLIENT_SECRET`.
-   - **Web Chat** — open the Web Chat test panel in the Azure Portal for your bot resource.
-   - **Microsoft Teams** — if your bot is registered as a Teams app, message it directly.
-
-You should see your message echoed back.
 
 ---
 
@@ -138,4 +178,4 @@ You should see your message echoed back.
 - [Teams Features](teams-features) — send mentions, adaptive cards, and suggested actions
 - [Language guides](languages/) — deeper coverage of each implementation
 - [Middleware](middleware) — extend the turn pipeline with logging, error handling, and more
-- [Authentication & Setup](auth-setup) — full walkthrough of Azure registration and credentials
+- [Authentication & Setup](auth-setup) — manual Azure portal setup (without Teams CLI)

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -36,8 +36,8 @@ Build bots that work with Microsoft Teams, Web Chat, Slack, and other Bot Framew
 
 ## Quick Links
 
-- [Getting Started](getting-started) — Install the library and run your first bot
+- [Getting Started](getting-started) — Set up credentials and run your first bot in 5 minutes
 - [Languages](languages/) — Language-specific guides for .NET, Node.js, and Python
 - [Teams Features](teams-features) — Mentions, Adaptive Cards, and Suggested Actions
 - [Middleware](middleware) — Extend the turn pipeline with custom middleware
-- [Authentication & Setup](auth-setup) — Azure registration and credential configuration
+- [Authentication & Setup](auth-setup) — Manual Azure portal setup (without Teams CLI)

--- a/docs-site/languages/dotnet.md
+++ b/docs-site/languages/dotnet.md
@@ -259,28 +259,6 @@ For setup details on Azure Bot registration and credentials, see [Authentication
 
 ---
 
-## Build and run
-
-```bash
-cd dotnet
-
-# Restore dependencies
-dotnet restore Botas.slnx
-
-# Build all projects
-dotnet build Botas.slnx
-
-# Run tests
-dotnet test Botas.slnx
-
-# Run the EchoBot sample
-dotnet run --project samples/EchoBot
-```
-
-To test locally, expose your machine with a tunnel (e.g., [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/) or ngrok) and point your Azure Bot registration's messaging endpoint to `https://<tunnel>/api/messages`.
-
----
-
 ## Key types reference
 
 | Type | Description |

--- a/docs-site/languages/nodejs.md
+++ b/docs-site/languages/nodejs.md
@@ -420,24 +420,3 @@ All credentials are read from environment variables by default:
 | `PORT` | HTTP listen port (default: `3978`) |
 
 You can also pass these values through the `BotApplicationOptions` constructor parameter.
-
----
-
-## Build and run
-
-```bash
-cd node
-
-# Install dependencies
-npm install
-
-# Build all packages
-npm run build
-
-# Run tests
-npm test
-
-# Run a sample (requires a tunnel like ngrok or dev tunnels)
-npx tsx samples/express/index.ts
-npx tsx samples/hono/index.ts
-```

--- a/docs-site/languages/python.md
+++ b/docs-site/languages/python.md
@@ -463,28 +463,3 @@ All credentials are read from environment variables by default:
 | `PORT` | HTTP listen port (default: `3978`) |
 
 Or pass them explicitly via `BotApplicationOptions` as shown in [Creating an instance](#creating-an-instance).
-
----
-
-## Build and test
-
-```bash
-cd python/packages/botas
-
-# Install in editable mode with dev dependencies
-pip install -e ".[dev]"
-
-# Run tests
-python -m pytest tests/ -v
-
-# Lint
-ruff check .
-```
-
----
-
-## Next steps
-
-- [Architecture overview](https://github.com/rido-min/botas/blob/main/specs/Architecture.md) — understand the turn pipeline and two-auth model
-- [Spec README](https://github.com/rido-min/botas/blob/main/specs/README.md) — canonical feature specification
-- [Azure setup](../auth-setup) — register your bot and get credentials


### PR DESCRIPTION
## Summary

Simplifies the README and docs-site to a focused 3-step quickstart using the Teams CLI for credential setup.

### What changed

**README.md** — Radical simplification (−237 lines net):
- Removed: *What it does*, repo layout, Teams features, typing indicators, AI bot samples, build/test commands, env vars table, documentation tables
- Added: 3-step quickstart (dev tunnel → Teams CLI → run sample), \/teams-bot-infra\ skill callout, compact *Learn more* links table
- Handles .NET vs Node/Python credential config difference (\ppsettings.json\ vs \.env\)

**docs-site/getting-started.md** — Same 3-step flow with VitePress code-group tabs, tunnel churn warning, and auth-setup as manual fallback

**docs-site/index.md** — Updated Quick Links descriptions

**docs-site/languages/{dotnet,nodejs,python}.md** — Removed *Build and run* sections (contributor content → \specs/Contributing.md\)

### Design decisions

- **Teams CLI as primary path** — fastest way to get credentials + install link in one command
- **Auth-setup kept as manual alternative** — Azure portal walkthrough still available for users without Teams CLI
- **.NET config handled explicitly** — \AzureAd:ClientId\ in appsettings.json vs \CLIENT_ID\ in .env for Node/Python
- **No build/test in language docs** — that's contributor content, already covered in \specs/Contributing.md\
