### PR TITLE
docs: Rebrand from Bot Framework to Microsoft Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![npm](https://img.shields.io/npm/v/botas-core.svg)](https://www.npmjs.com/package/botas-core)
 [![PyPI](https://img.shields.io/pypi/v/botas.svg)](https://pypi.org/project/botas/)
 
-A lightweight, multi-language library for building [Microsoft Bot Framework](https://learn.microsoft.com/azure/bot-service/) bots in **.NET**, **Node.js**, and **Python**.
+A lightweight, multi-language library for building [Microsoft Teams](https://learn.microsoft.com/azure/bot-service/) bots in **.NET**, **Node.js**, and **Python**.
 
 📖 **[Full Documentation](https://rido-min.github.io/botas/)** — guides, API reference, and samples for all three languages.
 
@@ -28,7 +28,7 @@ A lightweight, multi-language library for building [Microsoft Bot Framework](htt
 
    > 💡 Using GitHub Copilot? Ask the `/teams-bot-infra` skill to walk you through this interactively.
 
-2. **Dev tunnel** — exposes your local port to the Bot Framework Service. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started) or [ngrok](https://ngrok.com/).
+2. **Dev tunnel** — exposes your local port so Microsoft Teams can reach your bot. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started) or [ngrok](https://ngrok.com/).
 
 3. **Language runtime** (pick one): .NET 10 SDK · Node.js 20+ · Python 3.11+
 

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vitepress'
 
 export default defineConfig({
-  title: 'BotAS Documentation',
-  description: 'Multi-language Bot Framework library documentation',
+  title: 'BotAS Bot Application SDK',
+  description: 'Multi-language Microsoft Teams bot library documentation',
   base: '/botas/',
   appearance: 'dark',
 
@@ -58,7 +58,7 @@ export default defineConfig({
     },
 
     footer: {
-      message: 'BotAS — Multi-language Bot Framework library',
+      message: 'BotAS — Multi-language Microsoft Teams bot library',
     },
   },
 })

--- a/docs-site/getting-started.md
+++ b/docs-site/getting-started.md
@@ -15,7 +15,7 @@ Build and run an echo bot in under five minutes.
    teams login
    ```
 
-2. **Dev tunnel** — exposes your local port to the Bot Framework Service. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started) or [ngrok](https://ngrok.com/).
+2. **Dev tunnel** — exposes your local port so Microsoft Teams can reach your bot. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started) or [ngrok](https://ngrok.com/).
 
 3. **Language runtime** (pick one):
    - **.NET 10 SDK** — for the C# implementation

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: BotAS
   text: Documentation
-  tagline: A lightweight, multi-language library for building Microsoft Bot Framework bots with minimal overhead.
+  tagline: A lightweight, multi-language library for building Microsoft Teams bots with minimal overhead.
   image:
     src: /logo.svg
     alt: BotAS Logo
@@ -30,9 +30,9 @@ features:
 
 ## What is BotAS?
 
-**BotAS** provides idiomatic implementations of the Bot Framework protocol in three languages — **.NET (C#)**, **Node.js (TypeScript)**, and **Python** — with full behavioral parity across all ports.
+**BotAS** provides idiomatic implementations for building Microsoft Teams bots in three languages — **.NET (C#)**, **Node.js (TypeScript)**, and **Python** — with full behavioral parity across all ports.
 
-Build bots that work with Microsoft Teams, Web Chat, Slack, and other Bot Framework channels using the language and web framework you already know.
+Build bots that work with Microsoft Teams using the language and web framework you already know.
 
 ## Quick Links
 

--- a/docs-site/languages/nodejs.md
+++ b/docs-site/languages/nodejs.md
@@ -96,7 +96,7 @@ For advanced scenarios — using Hono, custom Express middleware, or other frame
 
 ## BotApplication
 
-`BotApplication` is the central class that processes incoming Bot Framework activities. It is **web-framework-agnostic** — you wire it into Express, Hono, or any HTTP server you like.
+`BotApplication` is the central class that processes incoming activities. It is **web-framework-agnostic** — you wire it into Express, Hono, or any HTTP server you like.
 
 ### Creating an instance
 

--- a/docs-site/languages/python.md
+++ b/docs-site/languages/python.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Python
 
-Build Microsoft Bot Framework bots in Python with **botas** — a lightweight, async-first library that works with any ASGI/WSGI framework.
+Build Microsoft Teams bots in Python with **botas** — a lightweight, async-first library that works with any ASGI/WSGI framework.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Replaces branding references from **Microsoft Bot Framework** to **Microsoft Teams** across public docs and README.

### Changes
- **Site title**: 'BotAS Documentation' → 'BotAS Bot Application SDK'
- **Headline/tagline**: 'Microsoft Bot Framework' → 'Microsoft Teams' in positioning text
- **Dev tunnel description**: Updated to reference Teams instead of Bot Framework Service

### Files changed (6)
- \README.md\
- \docs-site/.vitepress/config.mts\
- \docs-site/index.md\
- \docs-site/getting-started.md\
- \docs-site/languages/python.md\
- \docs-site/languages/nodejs.md\

### Not changed
Technical references to Bot Framework REST API, Emulator, JWKS endpoint, and JWT validation are preserved — these are actual Microsoft product names.