### PR TITLE
Optimize CI/CD to run jobs only when relevant folders change

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,7 +9,31 @@ permissions:
   packages: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      dotnet: ${{ steps.filter.outputs.dotnet }}
+      node: ${{ steps.filter.outputs.node }}
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            dotnet:
+              - 'dotnet/**'
+              - 'version.json'
+            node:
+              - 'node/**'
+              - 'version.json'
+            python:
+              - 'python/**'
+              - 'version.json'
+
   dotnet:
+    needs: changes
+    if: needs.changes.outputs.dotnet == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -46,6 +70,8 @@ jobs:
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/rido-min/index.json --skip-duplicate
 
   node:
+    needs: changes
+    if: needs.changes.outputs.node == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -110,6 +136,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   python:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,28 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      dotnet: ${{ steps.filter.outputs.dotnet }}
+      node: ${{ steps.filter.outputs.node }}
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            dotnet:
+              - 'dotnet/**'
+            node:
+              - 'node/**'
+            python:
+              - 'python/**'
+
   dotnet:
+    needs: changes
+    if: needs.changes.outputs.dotnet == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -36,6 +57,8 @@ jobs:
         run: dotnet test Botas.slnx --no-build
 
   node:
+    needs: changes
+    if: needs.changes.outputs.node == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -71,6 +94,8 @@ jobs:
         run: npm test --workspaces --if-present
 
   python:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary

Adds path-based change detection to both CI and CD workflows using \dorny/paths-filter@v3\. Each language job now only runs when its corresponding folder has been modified, avoiding unnecessary builds and package publishes.

## Changes

- **CI workflow**: Added \changes\ job that gates \dotnet\, \
ode\, and \python\ jobs based on changes to their respective folders.
- **CD workflow**: Same change detection, plus \ersion.json\ is included as a trigger since it affects package versioning across all languages.

### Trigger matrix

| Job | CI triggers | CD triggers |
|--------|------------|------------|
| dotnet | \dotnet/**\ | \dotnet/**\, \ersion.json\ |
| node | \
ode/**\ | \
ode/**\, \ersion.json\ |
| python | \python/**\ | \python/**\, \ersion.json\ |

## Motivation

Previously, every push to \main\ or \elease/**\ would build, test, and publish all three language packages even if only one folder changed. This wastes CI minutes and can cause unnecessary package version bumps.