### PR TITLE
feat(samples): adopt FluentCards & remove double serialization

### DIFF
--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -77,3 +77,20 @@
 - **Fixed remaining audit findings from #75** (PR #137): Input validation for required Activity fields (Type, Conversation.Id, ServiceUrl); removed misleading async from JWT event handlers; improved catch block to re-throw OperationCanceledException and BotHandlerException; added Kestrel MaxRequestBodySize (1 MB); reduced PII in trace logs (log type only, not full JSON); documented Use() as startup-only.
 - **Skipped items:** HttpClient lifecycle (#101) already fixed in open PR #133; ValueTask over-optimization is informational only.
 - **All 48 tests pass.**
+
+### FluentCards Refactor — TeamsSample (2026-04-13)
+- **Refactored `dotnet/samples/TeamsSample/Program.cs`** to replace raw JSON Adaptive Card strings with the `FluentCards` NuGet package (v0.2.0-beta-0001, prerelease).
+- **Welcome card** ("cards" handler): uses `AdaptiveCardBuilder` with TextBlock, Input.Text, and Action.Execute (verb="submitAction").
+- **Invoke response card**: extracts verb and data from `ctx.Activity.Value`, echoes them back as TextBlocks, adds Action.Execute with verb="refresh" for round-trip testing.
+- **Unchanged handlers:** SuggestedActions and mention echo remain untouched.
+- **Pattern:** `card.ToJson()` feeds into `TeamsActivityBuilder.WithAdaptiveCardAttachment()`.
+- **Build:** 0 compilation errors; 73 tests pass. Pre-existing NU1901 vulnerability warnings on `System.Security.Cryptography.Xml` are unrelated.
+- **Key files:** `dotnet/samples/TeamsSample/Program.cs`, `dotnet/samples/TeamsSample/TeamsSample.csproj`.
+
+### FluentCards Adoption Cross-Language Session (2026-04-15)
+- **Cross-language decision approved and implemented.** All three language teams (Amy .NET, Fry Node, Hermes Python) adopted fluent-cards/FluentCards builder libraries for Adaptive Card construction in teams-samples.
+- **Amy:** Refactored .NET TeamsSample with FluentCards NuGet (v0.2.0-beta-0001). 73 tests pass.
+- **Fry:** Refactored Node teams-sample with fluent-cards npm (v0.2.0-beta.1). 7 tests pass.
+- **Hermes:** Refactored Python teams-sample with fluent-cards PyPI. 94 tests pass, ruff clean.
+- **Pattern parity:** All three implementations now use fluent builders; welcome → invoke echo pattern consistent across languages.
+- **Decision logged:** `.squad/decisions.md` entry #15 (FluentCards Adoption).

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -109,6 +109,26 @@
   - `p2-fixes.spec.ts` — new test file with 8 tests
   - `package.json` — add `p2-fixes.spec.ts` to test script
 - **Status:** PR #121 open, awaiting review.
+
+### FluentCards Refactor — TeamsSample (2026-04-15)
+- **Refactored:** `node/samples/teams-sample/index.ts` to use `fluent-cards` npm package instead of raw JSON objects for Adaptive Cards.
+- **Package:** Added `fluent-cards@0.2.0-beta.1` dependency (only pre-release versions available on npm).
+- **Changes:**
+  - Welcome card ("cards" command): uses `AdaptiveCardBuilder` with `addTextBlock`, `addInputText`, `addAction(.execute())` — replaces ~30 lines of raw JSON with fluent builder calls.
+  - Invoke response card: now reads `verb` and `data` from `ctx.activity.value.action` and echoes them back as TextBlocks, plus an Action.Execute with verb="refresh" for round-trip testing.
+  - Suggested actions and mention echo handlers left unchanged.
+  - `TeamsActivityBuilder.withAdaptiveCardAttachment()` accepts JSON string, so `toJson(card)` is used for message cards; invoke response uses `JSON.parse(toJson(card))` since the Bot Framework invoke response expects an object, not a string.
+- **Key pattern:** `toJson()` returns a string; invoke `value` field needs an object → use `JSON.parse(toJson(card))`.
+- **Build/Tests:** All 7 express tests pass, TypeScript build clean.
+
+### FluentCards Adoption Cross-Language Session (2026-04-15)
+- **Cross-language decision approved and implemented.** All three language teams (Amy .NET, Fry Node, Hermes Python) adopted fluent-cards/FluentCards builder libraries for Adaptive Card construction in teams-samples.
+- **Amy:** Refactored .NET TeamsSample with FluentCards NuGet (v0.2.0-beta-0001). 73 tests pass.
+- **Fry:** Refactored Node teams-sample with fluent-cards npm (v0.2.0-beta.1). 7 tests pass.
+- **Hermes:** Refactored Python teams-sample with fluent-cards PyPI. 94 tests pass, ruff clean.
+- **Pattern parity:** All three implementations now use fluent builders; welcome → invoke echo pattern consistent across languages.
+- **Decision logged:** `.squad/decisions.md` entry #15 (FluentCards Adoption).
+
 # Node.js Umbrella Audit Fixes Summary (2026-04-14)
 
 ## Context

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -185,3 +185,17 @@ Fixed remaining medium and low findings from umbrella issue #74. Created PR #139
 MEDIUM: body size limit, type hints docs  
 LOW: HTTP security warning, CORS comment, Python version alignment, model docstrings, TokenManager.aclose(), event loop docs
 
+### FluentCards Refactor (teams-sample)
+
+Refactored `python/samples/teams-sample/main.py` to use the `fluent-cards` PyPI package instead of raw dict card construction.
+
+- **Import**: `from fluent_cards import AdaptiveCardBuilder, TextColor, TextSize, TextWeight, to_json`
+- **Removed**: `import json` — no longer needed for card building
+- **Welcome card** ("cards" handler): Uses `AdaptiveCardBuilder` fluent API with `add_text_block`, `add_input_text`, `add_action` (Action.Execute with verb + data)
+- **Invoke response card**: Reads `verb` and `data` from `ctx.activity.value` for round-trip echo, adds "Refresh" Action.Execute for re-invoke testing
+- **SuggestedActions and mention handlers**: Unchanged
+- **`to_json(card)`** passed to `TeamsActivityBuilder.with_adaptive_card_attachment()` — it expects a JSON string
+- **Dependency**: Added `fluent-cards` to `python/samples/teams-sample/pyproject.toml`
+- **Lint**: ruff clean (E, F, W, I rules, line length 120)
+- **Tests**: All 94 botas tests pass (no regressions)
+

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -199,3 +199,11 @@ Refactored `python/samples/teams-sample/main.py` to use the `fluent-cards` PyPI 
 - **Lint**: ruff clean (E, F, W, I rules, line length 120)
 - **Tests**: All 94 botas tests pass (no regressions)
 
+### FluentCards Adoption Cross-Language Session (2026-04-15)
+- **Cross-language decision approved and implemented.** All three language teams (Amy .NET, Fry Node, Hermes Python) adopted fluent-cards/FluentCards builder libraries for Adaptive Card construction in teams-samples.
+- **Amy:** Refactored .NET TeamsSample with FluentCards NuGet (v0.2.0-beta-0001). 73 tests pass.
+- **Fry:** Refactored Node teams-sample with fluent-cards npm (v0.2.0-beta.1). 7 tests pass.
+- **Hermes:** Refactored Python teams-sample with fluent-cards PyPI. 94 tests pass, ruff clean.
+- **Pattern parity:** All three implementations now use fluent builders; welcome → invoke echo pattern consistent across languages.
+- **Decision logged:** `.squad/decisions.md` entry #15 (FluentCards Adoption).
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -417,6 +417,43 @@ Consolidated botas spec structure from 18 fragmented files into a clear 11-core 
 - `.squad/orchestration-log/2026-04-13T2331-kif-merges.md`
 - `.squad/orchestration-log/2026-04-13T2331-amy-fix.md`
 
+### 15. FluentCards Adoption — Cross-Language Sample Refactor (2026-04-15)
+
+**Coordinated by:** Squad | **Status:** Implemented
+
+Adopted fluent-cards/FluentCards builder libraries for Adaptive Card construction in teams-sample across all three language implementations.
+
+**Decision Details:**
+
+| Language | Package | Version | Files Modified | Tests | Status |
+|----------|---------|---------|-----------------|-------|--------|
+| .NET | FluentCards (NuGet) | v0.2.0-beta-0001 | `TeamsSample/Program.cs` | 73 ✅ | Implemented |
+| Node.js | fluent-cards (npm) | v0.2.0-beta.1 | `teams-sample/index.ts` | 7 ✅ | Implemented |
+| Python | fluent-cards (PyPI) | Latest | `teams-sample/main.py` | 94 ✅ | Implemented |
+
+**Implementation Notes:**
+
+1. **Amy (.NET):** Refactored `TeamsSample/Program.cs` to replace raw JSON Adaptive Card strings with `AdaptiveCardBuilder` fluent API. Welcome card uses TextBlock + Input.Text + Action.Execute; invoke response echoes verb/data. Package added to `.csproj`.
+
+2. **Fry (Node.js):** Refactored `teams-sample/index.ts` using `AdaptiveCardBuilder` fluent calls. Pattern: `toJson(card)` for message attachments; `JSON.parse(toJson(card))` for invoke response objects. Package pinned to exact pre-release version.
+
+3. **Hermes (Python):** Refactored `teams-sample/main.py` with fluent-cards `AdaptiveCardBuilder`. Invoke handler echoes verb/data from `ctx.activity.value`. Added to `pyproject.toml`.
+
+**Design Decision:**
+
+All three implementations use fluent builders instead of raw JSON/dicts for improved maintainability and type safety. This is a samples-only change — no impact to library code. When fluent-cards reaches stable release, versions should be updated accordingly.
+
+**Cross-Language Consistency:**
+
+All three samples now follow identical patterns: welcome card receives user input, invoke handler echoes back the verb and data for round-trip testing, suggested actions remain unchanged.
+
+**Session Log:** `.squad/log/2026-04-15T17-30-fluentcards-adoption.md`
+
+**Orchestration Logs:**
+- `.squad/orchestration-log/2026-04-15T17-30-amy.md`
+- `.squad/orchestration-log/2026-04-15T17-30-fry.md`
+- `.squad/orchestration-log/2026-04-15T17-30-hermes.md`
+
 ### 12. VitePress Docs-Site Migration (2026-04-13)
 
 **Author:** Kif (DevRel) | **Status:** Implemented

--- a/docs-site/teams-features.md
+++ b/docs-site/teams-features.md
@@ -90,7 +90,7 @@ var card = AdaptiveCardBuilder.Create()
         .Execute()
         .WithTitle("Submit")
         .WithVerb("submitAction")
-        .WithData(System.Text.Json.JsonSerializer.SerializeToElement(new { action = "submit" })))
+        .WithData("{\"action\":\"submit\"}"))
     .Build();
 
 var reply = new TeamsActivityBuilder()
@@ -197,14 +197,14 @@ app.OnInvoke("adaptiveCard/action", async (ctx, ct) =>
         {
             statusCode = 200,
             type = "application/vnd.microsoft.card.adaptive",
-            value = System.Text.Json.JsonSerializer.Deserialize<object>(responseCard.ToJson())
+            value = responseCard.ToJsonElement()
         }
     };
 });
 ```
 
 ```typescript [Node.js]
-import { AdaptiveCardBuilder, TextSize, TextWeight, TextColor, toJson } from 'fluent-cards'
+import { AdaptiveCardBuilder, TextSize, TextWeight, TextColor, toJson, toObject } from 'fluent-cards'
 
 app.onInvoke('adaptiveCard/action', async (ctx) => {
   const value = ctx.activity.value as any
@@ -227,15 +227,14 @@ app.onInvoke('adaptiveCard/action', async (ctx) => {
     body: {
       statusCode: 200,
       type: 'application/vnd.microsoft.card.adaptive',
-      value: JSON.parse(toJson(card))
+      value: toObject(card)
     }
   }
 })
 ```
 
 ```python [Python]
-import json
-from fluent_cards import AdaptiveCardBuilder, TextSize, TextWeight, TextColor, to_json
+from fluent_cards import AdaptiveCardBuilder, TextSize, TextWeight, TextColor, to_dict
 
 @app.on_invoke("adaptiveCard/action")
 async def on_card_action(ctx):
@@ -261,7 +260,7 @@ async def on_card_action(ctx):
         body={
             "statusCode": 200,
             "type": "application/vnd.microsoft.card.adaptive",
-            "value": json.loads(to_json(response_card)),
+            "value": to_dict(response_card),
         },
     )
 ```

--- a/docs-site/teams-features.md
+++ b/docs-site/teams-features.md
@@ -68,59 +68,212 @@ Send rich interactive cards using `addAdaptiveCardAttachment()` (appends) or `wi
 
 Both methods accept a JSON string, parse it, and wrap it in an attachment with `contentType: "application/vnd.microsoft.card.adaptive"`.
 
+We recommend using [FluentCards](https://github.com/rido-min/FluentCards) to build Adaptive Cards with a fluent, strongly-typed API instead of raw JSON. FluentCards is available for all three languages: NuGet [`FluentCards`](https://www.nuget.org/packages/FluentCards), npm [`fluent-cards`](https://www.npmjs.com/package/fluent-cards), and PyPI [`fluent-cards`](https://pypi.org/project/fluent-cards/).
+
 ::: code-group
 ```csharp [.NET]
-var cardJson = """
-{
-    "type": "AdaptiveCard",
-    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-    "version": "1.5",
-    "body": [
-        { "type": "TextBlock", "text": "Hello!", "size": "Large", "weight": "Bolder" }
-    ]
-}
-""";
+using FluentCards;
+
+var card = AdaptiveCardBuilder.Create()
+    .WithVersion(AdaptiveCardVersion.V1_5)
+    .AddTextBlock(tb => tb
+        .WithText("Hello from TeamsSample!")
+        .WithSize(TextSize.Large)
+        .WithWeight(TextWeight.Bolder))
+    .AddTextBlock(tb => tb
+        .WithText("Click the button below to trigger an invoke action.")
+        .WithWrap(true))
+    .AddInputText(it => it
+        .WithId("userInput")
+        .WithPlaceholder("Type something here..."))
+    .AddAction(a => a
+        .Execute()
+        .WithTitle("Submit")
+        .WithVerb("submitAction")
+        .WithData(System.Text.Json.JsonSerializer.SerializeToElement(new { action = "submit" })))
+    .Build();
 
 var reply = new TeamsActivityBuilder()
-    .WithAdaptiveCardAttachment(cardJson)
+    .WithAdaptiveCardAttachment(card.ToJson())
     .Build();
 await ctx.SendAsync(reply, ct);
 ```
 
 ```typescript [Node.js]
-const cardJson = JSON.stringify({
-  type: 'AdaptiveCard',
-  $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
-  version: '1.5',
-  body: [
-    { type: 'TextBlock', text: 'Hello!', size: 'Large', weight: 'Bolder' }
-  ]
-})
+import { AdaptiveCardBuilder, TextSize, TextWeight, toJson } from 'fluent-cards'
+
+const card = AdaptiveCardBuilder.create()
+  .withVersion('1.5')
+  .addTextBlock(tb => tb
+    .withText('Hello from TeamsSample!')
+    .withSize(TextSize.Large)
+    .withWeight(TextWeight.Bolder))
+  .addTextBlock(tb => tb
+    .withText('Click the button below to trigger an invoke action.')
+    .withWrap(true))
+  .addInputText(it => it
+    .withId('userInput')
+    .withPlaceholder('Type something here...'))
+  .addAction(a => a
+    .execute()
+    .withTitle('Submit')
+    .withVerb('submitAction')
+    .withData({ action: 'submit' }))
+  .build()
 
 const reply = new TeamsActivityBuilder()
-  .withAdaptiveCardAttachment(cardJson)
+  .withAdaptiveCardAttachment(toJson(card))
   .build()
 await ctx.send(reply)
 ```
 
 ```python [Python]
-import json
+from fluent_cards import AdaptiveCardBuilder, TextSize, TextWeight, to_json
 
-card_json = json.dumps({
-    "type": "AdaptiveCard",
-    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-    "version": "1.5",
-    "body": [
-        {"type": "TextBlock", "text": "Hello!", "size": "Large", "weight": "Bolder"}
-    ],
-})
+card = (
+    AdaptiveCardBuilder.create()
+    .with_version("1.5")
+    .add_text_block(
+        lambda tb: tb.with_text("Hello from TeamsSample!")
+        .with_size(TextSize.Large)
+        .with_weight(TextWeight.Bolder)
+    )
+    .add_text_block(
+        lambda tb: tb.with_text("Click the button below to trigger an invoke action.")
+        .with_wrap(True)
+    )
+    .add_input_text(lambda it: it.with_id("userInput").with_placeholder("Type something here..."))
+    .add_action(
+        lambda a: a.execute().with_title("Submit").with_verb("submitAction").with_data({"action": "submit"})
+    )
+    .build()
+)
 
 reply = (
     TeamsActivityBuilder()
-    .with_adaptive_card_attachment(card_json)
+    .with_adaptive_card_attachment(to_json(card))
     .build()
 )
 await ctx.send(reply)
+```
+:::
+
+---
+
+## Invoke Handling (Action.Execute)
+
+When a user clicks an `Action.Execute` button on an Adaptive Card, Teams sends an **invoke** activity with `name: "adaptiveCard/action"`. The invoke payload contains the `verb` and `data` you specified when building the card.
+
+Register an invoke handler to process the action and return a response card:
+
+::: code-group
+```csharp [.NET]
+using FluentCards;
+
+app.OnInvoke("adaptiveCard/action", async (ctx, ct) =>
+{
+    var valueJson = ctx.Activity.Value?.ToString() ?? "{}";
+    var valueDoc = System.Text.Json.JsonDocument.Parse(valueJson);
+    var verb = valueDoc.RootElement.TryGetProperty("action", out var actionProp)
+        ? actionProp.TryGetProperty("verb", out var verbProp) ? verbProp.GetString() ?? "unknown" : "unknown"
+        : "unknown";
+
+    var responseCard = AdaptiveCardBuilder.Create()
+        .WithVersion(AdaptiveCardVersion.V1_5)
+        .AddTextBlock(tb => tb
+            .WithText("✅ Action received!")
+            .WithSize(TextSize.Large)
+            .WithWeight(TextWeight.Bolder)
+            .WithColor(TextColor.Good))
+        .AddTextBlock(tb => tb
+            .WithText($"Verb: {verb}")
+            .WithWrap(true))
+        .Build();
+
+    return new InvokeResponse
+    {
+        Status = 200,
+        Body = new
+        {
+            statusCode = 200,
+            type = "application/vnd.microsoft.card.adaptive",
+            value = System.Text.Json.JsonSerializer.Deserialize<object>(responseCard.ToJson())
+        }
+    };
+});
+```
+
+```typescript [Node.js]
+import { AdaptiveCardBuilder, TextSize, TextWeight, TextColor, toJson } from 'fluent-cards'
+
+app.onInvoke('adaptiveCard/action', async (ctx) => {
+  const value = ctx.activity.value as any
+  const verb = value?.action?.verb ?? 'unknown'
+
+  const card = AdaptiveCardBuilder.create()
+    .withVersion('1.5')
+    .addTextBlock(tb => tb
+      .withText('✅ Action received!')
+      .withSize(TextSize.Large)
+      .withWeight(TextWeight.Bolder)
+      .withColor(TextColor.Good))
+    .addTextBlock(tb => tb
+      .withText(`Verb: ${verb}`)
+      .withWrap(true))
+    .build()
+
+  return {
+    status: 200,
+    body: {
+      statusCode: 200,
+      type: 'application/vnd.microsoft.card.adaptive',
+      value: JSON.parse(toJson(card))
+    }
+  }
+})
+```
+
+```python [Python]
+import json
+from fluent_cards import AdaptiveCardBuilder, TextSize, TextWeight, TextColor, to_json
+
+@app.on_invoke("adaptiveCard/action")
+async def on_card_action(ctx):
+    value = ctx.activity.value or {}
+    action_info = value.get("action", {})
+    verb = action_info.get("verb", "unknown")
+
+    response_card = (
+        AdaptiveCardBuilder.create()
+        .with_version("1.5")
+        .add_text_block(
+            lambda tb: tb.with_text("✅ Action received!")
+            .with_size(TextSize.Large)
+            .with_weight(TextWeight.Bolder)
+            .with_color(TextColor.Good)
+        )
+        .add_text_block(lambda tb: tb.with_text(f"Verb: {verb}").with_wrap(True))
+        .build()
+    )
+
+    return InvokeResponse(
+        status=200,
+        body={
+            "statusCode": 200,
+            "type": "application/vnd.microsoft.card.adaptive",
+            "value": json.loads(to_json(response_card)),
+        },
+    )
+```
+:::
+
+::: tip Invoke flow
+```
+Card (Action.Execute with verb + data)
+  → User clicks button in Teams
+    → Teams sends invoke activity (name="adaptiveCard/action")
+      → Bot invoke handler reads verb + data from activity.value.action
+        → Handler returns an Adaptive Card response
 ```
 :::
 
@@ -227,13 +380,15 @@ Unknown fields in `channelData` are preserved as extension data, so new Teams fe
 
 ## Running the TeamsSample
 
-Each language has a complete sample in the repository. The sample responds to three commands:
+Each language has a complete sample in the repository using [FluentCards](https://github.com/rido-min/FluentCards) for Adaptive Card construction. The sample responds to three commands:
 
 | Command | Response |
 |---------|----------|
-| `cards` | Sends an Adaptive Card |
+| `cards` | Sends an Adaptive Card with an `Action.Execute` button |
 | `actions` | Sends Suggested Actions (quick-reply buttons) |
 | *(anything else)* | Echoes back with an @mention of the sender |
+
+When you click the **Submit** button on the Adaptive Card, Teams sends an invoke activity. The bot processes the verb and data, then responds with a confirmation card — demonstrating the full card → invoke → response round-trip.
 
 ::: code-group
 ```bash [.NET]

--- a/dotnet/samples/TeamsSample/Program.cs
+++ b/dotnet/samples/TeamsSample/Program.cs
@@ -37,7 +37,7 @@ app.OnInvoke("adaptiveCard/action", async (ctx, ct) =>
             .Execute()
             .WithTitle("Refresh")
             .WithVerb("refresh")
-            .WithData(System.Text.Json.JsonSerializer.SerializeToElement(new { action = "refresh" })))
+            .WithData("{\"action\":\"refresh\"}"))
         .Build();
 
     return new InvokeResponse
@@ -47,7 +47,7 @@ app.OnInvoke("adaptiveCard/action", async (ctx, ct) =>
         {
             statusCode = 200,
             type = "application/vnd.microsoft.card.adaptive",
-            value = System.Text.Json.JsonSerializer.Deserialize<object>(responseCard.ToJson())
+            value = responseCard.ToJsonElement()
         }
     };
 });
@@ -75,7 +75,7 @@ app.On("message", async (ctx, ct) =>
                 .Execute()
                 .WithTitle("Submit")
                 .WithVerb("submitAction")
-                .WithData(System.Text.Json.JsonSerializer.SerializeToElement(new { action = "submit" })))
+                .WithData("{\"action\":\"submit\"}"))
             .Build();
 
         var reply = new TeamsActivityBuilder()

--- a/dotnet/samples/TeamsSample/Program.cs
+++ b/dotnet/samples/TeamsSample/Program.cs
@@ -5,6 +5,7 @@
 //   • Invoke handling — respond to adaptiveCard/action
 
 using Botas;
+using FluentCards;
 
 var app = BotApp.Create(args);
 
@@ -12,28 +13,32 @@ app.Use(new RemoveMentionMiddleware());
 
 app.OnInvoke("adaptiveCard/action", async (ctx, ct) =>
 {
-    var data = ctx.Activity.Value?.ToString() ?? "{}";
-    var updatedCardJson = $$"""
-    {
-        "type": "AdaptiveCard",
-        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-        "version": "1.5",
-        "body": [
-            {
-                "type": "TextBlock",
-                "text": "✅ Action received!",
-                "size": "Large",
-                "weight": "Bolder",
-                "color": "Good"
-            },
-            {
-                "type": "TextBlock",
-                "text": "Your submission was processed successfully.",
-                "wrap": true
-            }
-        ]
-    }
-    """;
+    // Extract verb and data from the invoke payload
+    var valueJson = ctx.Activity.Value?.ToString() ?? "{}";
+    var valueDoc = System.Text.Json.JsonDocument.Parse(valueJson);
+    var verb = valueDoc.RootElement.TryGetProperty("action", out var actionProp)
+        ? actionProp.TryGetProperty("verb", out var verbProp) ? verbProp.GetString() ?? "unknown" : "unknown"
+        : "unknown";
+
+    var responseCard = AdaptiveCardBuilder.Create()
+        .WithVersion(AdaptiveCardVersion.V1_5)
+        .AddTextBlock(tb => tb
+            .WithText("✅ Action received!")
+            .WithSize(TextSize.Large)
+            .WithWeight(TextWeight.Bolder)
+            .WithColor(TextColor.Good))
+        .AddTextBlock(tb => tb
+            .WithText($"Verb: {verb}")
+            .WithWrap(true))
+        .AddTextBlock(tb => tb
+            .WithText($"Data: {valueJson}")
+            .WithWrap(true))
+        .AddAction(a => a
+            .Execute()
+            .WithTitle("Refresh")
+            .WithVerb("refresh")
+            .WithData(System.Text.Json.JsonSerializer.SerializeToElement(new { action = "refresh" })))
+        .Build();
 
     return new InvokeResponse
     {
@@ -42,7 +47,7 @@ app.OnInvoke("adaptiveCard/action", async (ctx, ct) =>
         {
             statusCode = 200,
             type = "application/vnd.microsoft.card.adaptive",
-            value = System.Text.Json.JsonSerializer.Deserialize<object>(updatedCardJson)
+            value = System.Text.Json.JsonSerializer.Deserialize<object>(responseCard.ToJson())
         }
     };
 });
@@ -53,46 +58,29 @@ app.On("message", async (ctx, ct) =>
 
     if (text.Equals("cards", StringComparison.OrdinalIgnoreCase))
     {
-        // Send an Adaptive Card with Action.Execute
-        var cardJson = """
-        {
-            "type": "AdaptiveCard",
-            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-            "version": "1.5",
-            "body": [
-                {
-                    "type": "TextBlock",
-                    "text": "Hello from TeamsSample!",
-                    "size": "Large",
-                    "weight": "Bolder"
-                },
-                {
-                    "type": "TextBlock",
-                    "text": "Click the button below to trigger an invoke action.",
-                    "wrap": true
-                },
-                {
-                    "type": "Input.Text",
-                    "id": "userInput",
-                    "placeholder": "Type something here..."
-                }
-            ],
-            "actions": [
-                {
-                    "type": "Action.Execute",
-                    "title": "Submit",
-                    "verb": "submitAction",
-                    "data": {
-                        "action": "submit"
-                    }
-                }
-            ]
-        }
-        """;
+        // Send an Adaptive Card with Action.Execute using FluentCards
+        var card = AdaptiveCardBuilder.Create()
+            .WithVersion(AdaptiveCardVersion.V1_5)
+            .AddTextBlock(tb => tb
+                .WithText("Hello from TeamsSample!")
+                .WithSize(TextSize.Large)
+                .WithWeight(TextWeight.Bolder))
+            .AddTextBlock(tb => tb
+                .WithText("Click the button below to trigger an invoke action.")
+                .WithWrap(true))
+            .AddInputText(it => it
+                .WithId("userInput")
+                .WithPlaceholder("Type something here..."))
+            .AddAction(a => a
+                .Execute()
+                .WithTitle("Submit")
+                .WithVerb("submitAction")
+                .WithData(System.Text.Json.JsonSerializer.SerializeToElement(new { action = "submit" })))
+            .Build();
 
         var reply = new TeamsActivityBuilder()
             .WithConversationReference(ctx.Activity)
-            .WithAdaptiveCardAttachment(cardJson)
+            .WithAdaptiveCardAttachment(card.ToJson())
             .Build();
 
         await ctx.SendAsync(reply, ct);

--- a/dotnet/samples/TeamsSample/TeamsSample.csproj
+++ b/dotnet/samples/TeamsSample/TeamsSample.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentCards" Version="0.2.0-beta-0001" />
+    <PackageReference Include="FluentCards" Version="0.2.0-beta-0004" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/samples/TeamsSample/TeamsSample.csproj
+++ b/dotnet/samples/TeamsSample/TeamsSample.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\..\src\Botas\Botas.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentCards" Version="0.2.0-beta-0001" />
+  </ItemGroup>
+
 </Project>

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -2718,9 +2718,9 @@
       "license": "ISC"
     },
     "node_modules/fluent-cards": {
-      "version": "0.2.0-beta.1",
-      "resolved": "https://registry.npmjs.org/fluent-cards/-/fluent-cards-0.2.0-beta.1.tgz",
-      "integrity": "sha512-DBliI8PW+Wnd/OL6Ha4d2TOGnFIBDFwpq0lD96U7A8cN5n04w37os0hJAT8EDEfbslMMB8yVoZ9WMwpt6U5qkQ==",
+      "version": "0.2.0-beta.4",
+      "resolved": "https://registry.npmjs.org/fluent-cards/-/fluent-cards-0.2.0-beta.4.tgz",
+      "integrity": "sha512-W0xe80YQX6gvP8x1aYdgUVa87G7oD6+QkywfKjjWoPn980Dl2wKR6qoqgsizhQ7BkOinDnl2mHIdI6UzEfCb4g==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -5584,7 +5584,7 @@
       "version": "0.1.0",
       "dependencies": {
         "botas-express": "*",
-        "fluent-cards": "0.2.0-beta.1"
+        "fluent-cards": "0.2.0-beta.4"
       }
     },
     "samples/typing-indicator": {

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -2717,6 +2717,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fluent-cards": {
+      "version": "0.2.0-beta.1",
+      "resolved": "https://registry.npmjs.org/fluent-cards/-/fluent-cards-0.2.0-beta.1.tgz",
+      "integrity": "sha512-DBliI8PW+Wnd/OL6Ha4d2TOGnFIBDFwpq0lD96U7A8cN5n04w37os0hJAT8EDEfbslMMB8yVoZ9WMwpt6U5qkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -5574,7 +5583,8 @@
     "samples/teams-sample": {
       "version": "0.1.0",
       "dependencies": {
-        "botas-express": "*"
+        "botas-express": "*",
+        "fluent-cards": "0.2.0-beta.1"
       }
     },
     "samples/typing-indicator": {

--- a/node/samples/teams-sample/index.ts
+++ b/node/samples/teams-sample/index.ts
@@ -6,7 +6,7 @@
 
 import { BotApp } from 'botas-express'
 import { TeamsActivityBuilder } from 'botas-core'
-import { AdaptiveCardBuilder, TextSize, TextWeight, TextColor, toJson } from 'fluent-cards'
+import { AdaptiveCardBuilder, TextSize, TextWeight, TextColor, toJson, toObject } from 'fluent-cards'
 
 const app = new BotApp()
 
@@ -40,7 +40,7 @@ app.onInvoke('adaptiveCard/action', async (ctx) => {
     body: {
       statusCode: 200,
       type: 'application/vnd.microsoft.card.adaptive',
-      value: JSON.parse(toJson(card))
+      value: toObject(card)
     }
   }
 })

--- a/node/samples/teams-sample/index.ts
+++ b/node/samples/teams-sample/index.ts
@@ -1,39 +1,46 @@
 // TeamsSample — demonstrates TeamsActivity features:
 //   • Mentions — echo back with an @mention of the sender
 //   • Suggested Actions — offer quick-reply buttons
-//   • Adaptive Cards — send a rich card with Action.Execute
+//   • Adaptive Cards — send a rich card with Action.Execute (via fluent-cards)
 //   • Invoke handling — respond to adaptiveCard/action
 
 import { BotApp } from 'botas-express'
 import { TeamsActivityBuilder } from 'botas-core'
+import { AdaptiveCardBuilder, TextSize, TextWeight, TextColor, toJson } from 'fluent-cards'
 
 const app = new BotApp()
 
 app.onInvoke('adaptiveCard/action', async (ctx) => {
+  const value = ctx.activity.value as any
+  const verb = value?.action?.verb ?? 'unknown'
+  const data = JSON.stringify(value?.action?.data ?? {})
+
+  const card = AdaptiveCardBuilder.create()
+    .withVersion('1.5')
+    .addTextBlock(tb => tb
+      .withText('✅ Action received!')
+      .withSize(TextSize.Large)
+      .withWeight(TextWeight.Bolder)
+      .withColor(TextColor.Good))
+    .addTextBlock(tb => tb
+      .withText(`Verb: ${verb}`)
+      .withWrap(true))
+    .addTextBlock(tb => tb
+      .withText(`Data: ${data}`)
+      .withWrap(true))
+    .addAction(a => a
+      .execute()
+      .withTitle('Refresh')
+      .withVerb('refresh')
+      .withData({ action: 'refresh' }))
+    .build()
+
   return {
     status: 200,
     body: {
       statusCode: 200,
       type: 'application/vnd.microsoft.card.adaptive',
-      value: {
-        type: 'AdaptiveCard',
-        $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
-        version: '1.5',
-        body: [
-          {
-            type: 'TextBlock',
-            text: '✅ Action received!',
-            size: 'Large',
-            weight: 'Bolder',
-            color: 'Good'
-          },
-          {
-            type: 'TextBlock',
-            text: 'Your submission was processed successfully.',
-            wrap: true
-          }
-        ]
-      }
+      value: JSON.parse(toJson(card))
     }
   }
 })
@@ -42,44 +49,28 @@ app.on('message', async (ctx) => {
   const text = (ctx.activity.text ?? '').trim()
 
   if (text.toLowerCase() === 'cards') {
-    // Send an Adaptive Card with Action.Execute
-    const cardJson = JSON.stringify({
-      type: 'AdaptiveCard',
-      $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
-      version: '1.5',
-      body: [
-        {
-          type: 'TextBlock',
-          text: 'Hello from TeamsSample!',
-          size: 'Large',
-          weight: 'Bolder'
-        },
-        {
-          type: 'TextBlock',
-          text: 'Click the button below to trigger an invoke action.',
-          wrap: true
-        },
-        {
-          type: 'Input.Text',
-          id: 'userInput',
-          placeholder: 'Type something here...'
-        }
-      ],
-      actions: [
-        {
-          type: 'Action.Execute',
-          title: 'Submit',
-          verb: 'submitAction',
-          data: {
-            action: 'submit'
-          }
-        }
-      ]
-    })
+    const card = AdaptiveCardBuilder.create()
+      .withVersion('1.5')
+      .addTextBlock(tb => tb
+        .withText('Hello from TeamsSample!')
+        .withSize(TextSize.Large)
+        .withWeight(TextWeight.Bolder))
+      .addTextBlock(tb => tb
+        .withText('Click the button below to trigger an invoke action.')
+        .withWrap(true))
+      .addInputText(it => it
+        .withId('userInput')
+        .withPlaceholder('Type something here...'))
+      .addAction(a => a
+        .execute()
+        .withTitle('Submit')
+        .withVerb('submitAction')
+        .withData({ action: 'submit' }))
+      .build()
 
     const reply = new TeamsActivityBuilder()
       .withConversationReference(ctx.activity)
-      .withAdaptiveCardAttachment(cardJson)
+      .withAdaptiveCardAttachment(toJson(card))
       .build()
 
     await ctx.send(reply)

--- a/node/samples/teams-sample/package.json
+++ b/node/samples/teams-sample/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "botas-express": "*",
-    "fluent-cards": "0.2.0-beta.1"
+    "fluent-cards": "0.2.0-beta.4"
   }
 }

--- a/node/samples/teams-sample/package.json
+++ b/node/samples/teams-sample/package.json
@@ -7,6 +7,7 @@
     "dev": "node --import tsx --watch index.ts"
   },
   "dependencies": {
-    "botas-express": "*"
+    "botas-express": "*",
+    "fluent-cards": "0.2.0-beta.1"
   }
 }

--- a/python/samples/teams-sample/main.py
+++ b/python/samples/teams-sample/main.py
@@ -5,6 +5,8 @@
 #   • Invoke handling — respond to adaptiveCard/action
 
 from botas_fastapi import BotApp
+import json
+
 from fluent_cards import AdaptiveCardBuilder, TextColor, TextSize, TextWeight, to_json
 
 from botas import InvokeResponse, TeamsActivityBuilder
@@ -42,7 +44,7 @@ async def on_card_action(ctx):
         body={
             "statusCode": 200,
             "type": "application/vnd.microsoft.card.adaptive",
-            "value": response_card,
+            "value": json.loads(to_json(response_card)),
         },
     )
 

--- a/python/samples/teams-sample/main.py
+++ b/python/samples/teams-sample/main.py
@@ -5,9 +5,8 @@
 #   • Invoke handling — respond to adaptiveCard/action
 
 from botas_fastapi import BotApp
-import json
 
-from fluent_cards import AdaptiveCardBuilder, TextColor, TextSize, TextWeight, to_json
+from fluent_cards import AdaptiveCardBuilder, TextColor, TextSize, TextWeight, to_dict, to_json
 
 from botas import InvokeResponse, TeamsActivityBuilder
 from botas.suggested_actions import CardAction, SuggestedActions
@@ -44,7 +43,7 @@ async def on_card_action(ctx):
         body={
             "statusCode": 200,
             "type": "application/vnd.microsoft.card.adaptive",
-            "value": json.loads(to_json(response_card)),
+            "value": to_dict(response_card),
         },
     )
 

--- a/python/samples/teams-sample/main.py
+++ b/python/samples/teams-sample/main.py
@@ -4,41 +4,45 @@
 #   • Adaptive Cards — send a rich card with Action.Execute
 #   • Invoke handling — respond to adaptiveCard/action
 
-import json
+from botas_fastapi import BotApp
+from fluent_cards import AdaptiveCardBuilder, TextColor, TextSize, TextWeight, to_json
 
 from botas import InvokeResponse, TeamsActivityBuilder
 from botas.suggested_actions import CardAction, SuggestedActions
-from botas_fastapi import BotApp
 
 app = BotApp()
 
 
 @app.on_invoke("adaptiveCard/action")
 async def on_card_action(ctx):
+    value = ctx.activity.value or {}
+    action_info = value.get("action", {})
+    verb = action_info.get("verb", "unknown")
+    data = str(action_info.get("data", {}))
+
+    response_card = (
+        AdaptiveCardBuilder.create()
+        .with_version("1.5")
+        .add_text_block(
+            lambda tb: (
+                tb.with_text("✅ Action received!")
+                .with_size(TextSize.Large)
+                .with_weight(TextWeight.Bolder)
+                .with_color(TextColor.Good)
+            )
+        )
+        .add_text_block(lambda tb: tb.with_text(f"Verb: {verb}").with_wrap(True))
+        .add_text_block(lambda tb: tb.with_text(f"Data: {data}").with_wrap(True))
+        .add_action(lambda a: a.execute().with_title("Refresh").with_verb("refresh").with_data({"action": "refresh"}))
+        .build()
+    )
+
     return InvokeResponse(
         status=200,
         body={
             "statusCode": 200,
             "type": "application/vnd.microsoft.card.adaptive",
-            "value": {
-                "type": "AdaptiveCard",
-                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-                "version": "1.5",
-                "body": [
-                    {
-                        "type": "TextBlock",
-                        "text": "✅ Action received!",
-                        "size": "Large",
-                        "weight": "Bolder",
-                        "color": "Good",
-                    },
-                    {
-                        "type": "TextBlock",
-                        "text": "Your submission was processed successfully.",
-                        "wrap": True,
-                    },
-                ],
-            },
+            "value": response_card,
         },
     )
 
@@ -48,45 +52,28 @@ async def on_message(ctx):
     text = (ctx.activity.text or "").strip()
 
     if text.lower() == "cards":
-        # Send an Adaptive Card with Action.Execute
-        card_json = json.dumps(
-            {
-                "type": "AdaptiveCard",
-                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-                "version": "1.5",
-                "body": [
-                    {
-                        "type": "TextBlock",
-                        "text": "Hello from TeamsSample!",
-                        "size": "Large",
-                        "weight": "Bolder",
-                    },
-                    {
-                        "type": "TextBlock",
-                        "text": "Click the button below to trigger an invoke action.",
-                        "wrap": True,
-                    },
-                    {
-                        "type": "Input.Text",
-                        "id": "userInput",
-                        "placeholder": "Type something here...",
-                    },
-                ],
-                "actions": [
-                    {
-                        "type": "Action.Execute",
-                        "title": "Submit",
-                        "verb": "submitAction",
-                        "data": {"action": "submit"},
-                    }
-                ],
-            }
+        card = (
+            AdaptiveCardBuilder.create()
+            .with_version("1.5")
+            .add_text_block(
+                lambda tb: (
+                    tb.with_text("Hello from TeamsSample!").with_size(TextSize.Large).with_weight(TextWeight.Bolder)
+                )
+            )
+            .add_text_block(
+                lambda tb: tb.with_text("Click the button below to trigger an invoke action.").with_wrap(True)
+            )
+            .add_input_text(lambda it: it.with_id("userInput").with_placeholder("Type something here..."))
+            .add_action(
+                lambda a: a.execute().with_title("Submit").with_verb("submitAction").with_data({"action": "submit"})
+            )
+            .build()
         )
 
         reply = (
             TeamsActivityBuilder()
             .with_conversation_reference(ctx.activity)
-            .with_adaptive_card_attachment(card_json)
+            .with_adaptive_card_attachment(to_json(card))
             .build()
         )
 

--- a/python/samples/teams-sample/pyproject.toml
+++ b/python/samples/teams-sample/pyproject.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "botas-fastapi",
+    "fluent-cards",
 ]


### PR DESCRIPTION
## Summary

Adopt [FluentCards](https://github.com/rido-min/FluentCards) for Adaptive Cards in all three TeamsSample implementations, replacing raw JSON construction with fluent, strongly-typed builders.

### Changes

**FluentCards adoption** (all 3 languages):
- Replace manual JSON card construction with \AdaptiveCardBuilder\ fluent API
- Add \Action.Execute\ with verb + data to test invoke round-trips
- Add input fields with Execute actions for form submission testing

**Remove double serialization** (FluentCards#75 fix):
- .NET: Use \card.ToJsonElement()\ instead of \Deserialize<object>(card.ToJson())\
- .NET: Use \WithData(string)\ instead of \WithData(SerializeToElement(...))\
- Node: Use \	oObject(card)\ instead of \JSON.parse(toJson(card))\
- Python: Use \	o_dict(card)\ instead of \json.loads(to_json(card))\

**Package versions**: FluentCards 0.2.0-beta.4 across all languages

**Docs**: Updated \docs-site/teams-features.md\ with FluentCards examples and new Invoke Handling section

### Files changed
- \dotnet/samples/TeamsSample/Program.cs\ + \.csproj\
- \
ode/samples/teams-sample/index.ts\ + \package.json\
- \python/samples/teams-sample/main.py\
- \docs-site/teams-features.md\
- \
ode/package-lock.json\

Closes #161 (supersedes)