### PR TITLE
fix(dotnet): pin System.Security.Cryptography.Xml to 10.0.6 for CVE fix

### DIFF
--- a/dotnet/src/Botas/Botas.csproj
+++ b/dotnet/src/Botas/Botas.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
     <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.17.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Problem

\System.Security.Cryptography.Xml\ 10.0.0 (transitive dependency) has known vulnerabilities ([GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx), [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf)) that cause NU1901 restore failures with \TreatWarningsAsErrors=true\.

## Fix

Pin \System.Security.Cryptography.Xml\ to **10.0.6** in \Botas.csproj\, which includes the security fix.

## Changed file
- \dotnet/src/Botas/Botas.csproj\ — added explicit PackageReference to 10.0.6