### PR TITLE
docs(dotnet): add \ URL to appsettings.json example

### DIFF
--- a/docs-site/languages/dotnet.md
+++ b/docs-site/languages/dotnet.md
@@ -254,10 +254,11 @@ node dotnet/env-to-launch-settings.mjs
 
 ### Option 2 — `appsettings.json`
 
-Minimal `appsettings.json`:
+Minimal `appsettings.json` (add the `$schema` for IntelliSense in VS / VS Code):
 
 ```json
 {
+  "$schema": "https://json.schemastore.org/appsettings.json",
   "AzureAd": {
     "ClientId": "<your-bot-app-id>",
     "TenantId": "<your-tenant-id>",


### PR DESCRIPTION
Adds the [SchemaStore.org](https://json.schemastore.org/appsettings.json) \\\ URL to the \ppsettings.json\ example in the .NET docs page, enabling IntelliSense for ASP.NET Core settings in VS and VS Code.