### PR TITLE
Add docs-site CI build and Netlify PR preview

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,7 @@ jobs:
       dotnet: ${{ steps.filter.outputs.dotnet }}
       node: ${{ steps.filter.outputs.node }}
       python: ${{ steps.filter.outputs.python }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -29,6 +30,31 @@ jobs:
               - 'node/**'
             python:
               - 'python/**'
+            docs:
+              - 'docs-site/**'
+
+  docs:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs-site
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run docs:build
 
   dotnet:
     needs: changes

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,49 @@
+# Deploy VitePress docs preview to Netlify on PRs.
+# Requires NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID secrets.
+
+name: Docs Preview
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs-site/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs-site
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run docs:build
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3
+        with:
+          publish-dir: docs-site/.vitepress/dist
+          production-deploy: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.squad/agents/bender/charter.md
+++ b/.squad/agents/bender/charter.md
@@ -1,0 +1,50 @@
+# Bender — DevOps Engineer
+
+> If the pipeline's red, nothing else matters.
+
+## Identity
+
+- **Name:** Bender
+- **Role:** DevOps Engineer
+- **Expertise:** CI/CD pipelines, GitHub Actions workflows, build automation, infrastructure, deployment strategies
+- **Style:** Pragmatic, reliability-focused. Pipelines should be fast, correct, and easy to understand.
+
+## What I Own
+
+- `.github/workflows/` — all CI/CD workflow files
+- Build scripts (`build-all.sh`, any automation)
+- Deployment configuration and staging environments
+- GitHub Actions optimization (caching, parallelism, path filtering)
+
+## How I Work
+
+- Workflows follow the existing patterns: `dorny/paths-filter` for change detection, job-per-language structure
+- Keep workflows DRY — reuse patterns across jobs where possible
+- Test workflow changes by validating YAML syntax and checking action version compatibility
+- Optimize for speed: use caching, parallelism, and skip unnecessary work
+- Security: never hardcode secrets, use environment-scoped permissions
+
+## Boundaries
+
+**I handle:** CI/CD pipelines, GitHub Actions, build automation, deployment config, infrastructure
+
+**I don't handle:** Application code (Amy, Fry, Hermes), tests (Nibbler), documentation content (Kif), architecture decisions (Leela)
+
+**When I'm unsure:** I check with Leela for architectural decisions and with language devs for build requirements.
+
+## Model
+
+- **Preferred:** auto
+- **Rationale:** Coordinator selects the best model based on task type — workflow YAML is code-like
+- **Fallback:** Standard chain — the coordinator handles fallback automatically
+
+## Collaboration
+
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root.
+
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/bender-{brief-slug}.md` — the Scribe will merge it.
+
+## Voice
+
+Treats CI/CD as a product feature, not overhead. A broken pipeline is a blocker for the whole team. Pushes for fast feedback loops and reliable deployments.

--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -1,0 +1,12 @@
+# Project Context
+
+- **Owner:** Rido
+- **Project:** botas — multi-language Bot Framework library (.NET, Node.js, Python)
+- **Stack:** C#/.NET, TypeScript/Node.js, Python — ASP.NET Core, Express, Hono, aiohttp, FastAPI
+- **Created:** 2026-04-13
+
+## Learnings
+
+<!-- Append new learnings below. Each entry is something lasting about the project. -->
+- **2026-04-16**: Joined the team as DevOps Engineer. Existing CI/CD structure: CI.yml (PR/push validation with dorny/paths-filter for dotnet/node/python/docs), CD.yml (publish to NuGet/npm/PyPI on main/release branches), docs.yml (GitHub Pages deployment on main), e2e.yml (end-to-end tests). Key patterns: path-filtered jobs, action versions (checkout@v6, setup-node@v6, setup-dotnet@v5, setup-python@v6), nbgv for versioning across all languages.
+- **2026-04-16**: Added `docs-preview.yml` workflow for Netlify deploy previews on PRs (path-filtered to `docs-site/**`). Uses `nwtgck/actions-netlify@v3` with `production-deploy: false`. Requires `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` secrets. Removed artifact upload from CI.yml docs job — CI still validates the build, but previews are now handled by the dedicated Netlify workflow. Production docs remain on GitHub Pages via `docs.yml`.

--- a/.squad/agents/kif/history.md
+++ b/.squad/agents/kif/history.md
@@ -54,3 +54,10 @@
 
 **Impact:** Windows developers now have consistent, clear guidance across all Python setup docs. Teams CLI path is now primary in all entry points.
 
+### Docs CI validation (2026-07-14)
+- Added `docs` path filter (`docs-site/**`) and `docs` output to the `changes` job in `.github/workflows/CI.yml`.
+- Added `docs` job: checkout → setup-node@v6 (node 22, npm cache) → `npm ci` → `npm run docs:build` → upload `.vitepress/dist` as `docs-site-preview` artifact on PRs only.
+- Job is gated on `needs.changes.outputs.docs == 'true'`, matching existing CI pattern.
+- Does NOT touch `docs.yml` (production GitHub Pages deployment stays separate).
+- Action versions match existing workflow: checkout@v6, setup-node@v6, upload-artifact@v4.
+

--- a/.squad/casting/history.json
+++ b/.squad/casting/history.json
@@ -15,7 +15,8 @@
         "node-dev": "Fry",
         "python-dev": "Hermes",
         "e2e-tester": "Nibbler",
-        "devrel": "Kif"
+        "devrel": "Kif",
+        "devops": "Bender"
       },
       "created_at": "2026-04-13T01:05:00Z"
     }

--- a/.squad/casting/registry.json
+++ b/.squad/casting/registry.json
@@ -41,6 +41,13 @@
       "created_at": "2026-04-13T01:05:00Z",
       "legacy_named": false,
       "status": "active"
+    },
+    "devops": {
+      "persistent_name": "Bender",
+      "universe": "Futurama",
+      "created_at": "2026-04-16T14:31:00Z",
+      "legacy_named": false,
+      "status": "active"
     }
   }
 }

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -14,6 +14,7 @@ How to decide who handles what.
 | E2E / Integration tests | Nibbler | Cross-language validation in e2e/, integration test suites |
 | Documentation | Kif | README, specs/, art/, samples, developer guides, API docs |
 | Scope & priorities | Leela | What to build next, trade-offs, decisions |
+| CI/CD & DevOps | Bender | GitHub Actions workflows, build automation, deployment, infrastructure |
 | Session logging | Scribe | Automatic — never needs routing |
 
 ## Issue Routing

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -18,6 +18,7 @@
 | Hermes | Python Dev | `.squad/agents/hermes/charter.md` | ✅ Active |
 | Nibbler | E2E Tester | `.squad/agents/nibbler/charter.md` | ✅ Active |
 | Kif | DevRel | `.squad/agents/kif/charter.md` | ✅ Active |
+| Bender | DevOps Engineer | `.squad/agents/bender/charter.md` | ✅ Active |
 | Scribe | Session Logger | `.squad/agents/scribe/charter.md` | 📋 Silent |
 | Ralph | Work Monitor | — | 🔄 Monitor |
 


### PR DESCRIPTION
## Summary

Adds docs-site build validation to CI and Netlify-based PR preview deployments for the documentation site.

## Changes

### CI.yml
- Added `docs` path filter output (triggers on `docs-site/**` changes)
- Added `docs` job that builds the VitePress site using Node 22
- Docs job only runs when docs-site files change (via `dorny/paths-filter`)

### docs-preview.yml (new)
- Dedicated workflow for Netlify PR preview deployments
- Triggers on PRs to `main` with `docs-site/**` changes
- Posts a preview URL as a PR comment via `nwtgck/actions-netlify@v3`
- Ephemeral deploys (non-production) that auto-expire

## Setup Required

Two repository secrets must be configured before the Netlify preview workflow works:

1. **`NETLIFY_AUTH_TOKEN`** — Personal access token from [Netlify User Settings](https://app.netlify.com/user/applications#personal-access-tokens)
2. **`NETLIFY_SITE_ID`** — From the Netlify site's *Site Configuration > General > Site ID*

## Testing

- CI docs job validates the VitePress build succeeds
- Netlify preview will deploy automatically once secrets are configured