### PR TITLE
CI/CD hardening: SHA pinning, caching, concurrency, version alignment

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main, release/**]
 
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   packages: write
@@ -16,8 +20,8 @@ jobs:
       node: ${{ steps.filter.outputs.node }}
       python: ${{ steps.filter.outputs.python }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -39,15 +43,14 @@ jobs:
       run:
         working-directory: dotnet
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
 
       - name: Restore
         run: dotnet restore Botas.slnx
@@ -77,17 +80,17 @@ jobs:
       run:
         working-directory: node
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -143,22 +146,21 @@ jobs:
     permissions:
       actions: read
       contents: read
-      id-token: write
     defaults:
       run:
         working-directory: python/packages/botas
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 
@@ -194,14 +196,14 @@ jobs:
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/heads/release/')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: python/packages/botas/dist/
 
       - name: Publish to TestPyPI
         if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
@@ -214,14 +216,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Install nbgv
         run: dotnet tool install --global nbgv

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -18,8 +22,8 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -41,10 +45,10 @@ jobs:
       run:
         working-directory: docs-site
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -64,12 +68,12 @@ jobs:
       run:
         working-directory: dotnet
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -93,17 +97,17 @@ jobs:
       run:
         working-directory: node
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: '10.0.x'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -130,19 +134,21 @@ jobs:
       run:
         working-directory: python/packages/botas
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: python/packages/botas/pyproject.toml
 
       - name: Install nbgv CLI
         run: dotnet tool install --global nbgv

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -20,10 +20,10 @@ jobs:
       run:
         working-directory: docs-site
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -36,7 +36,7 @@ jobs:
         run: npm run docs:build
 
       - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v3
+        uses: nwtgck/actions-netlify@13eaa50a52af3944ac07286543eba6545d35aa08 # v3
         with:
           publish-dir: docs-site/.vitepress/dist
           production-deploy: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,11 +21,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
+          cache: 'npm'
+          cache-dependency-path: docs-site/package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -35,9 +37,9 @@ jobs:
         run: npm run docs:build
         working-directory: docs-site
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs-site/.vitepress/dist
 
@@ -48,5 +50,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         id: deployment

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,15 +10,14 @@ jobs:
   dotnet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
 
       - name: Restore
         run: dotnet restore e2e/dotnet/Botas.E2ETests.csproj

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -29,7 +29,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check triage script
         id: check-script
@@ -52,7 +52,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -104,7 +104,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -116,7 +116,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -15,10 +15,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -7,6 +7,60 @@
 
 ## Learnings
 
+### CI/CD Pipeline Security & Reliability Improvements (2026-04-16)
+
+Implemented comprehensive CI/CD fixes based on security audit findings. All critical and should-fix items addressed:
+
+**SHA Pinning (Security):**
+- All GitHub Actions now pinned to full commit SHAs instead of mutable version tags
+- Applied consistent pattern: `uses: owner/action@<sha> # <version>`
+- Key SHAs used:
+  - `actions/checkout@v6` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd`
+  - `actions/setup-node@v6` → `53b83947a5a98c8d113130e565377fae1a50d02f`
+  - `actions/setup-dotnet@v5` → `c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7`
+  - `actions/setup-python@v6` → `a309ff8b426b58ec0e2a45f0f869d46889d02405`
+  - `dorny/paths-filter@v3` → `d1c1ffe0248fe513906c8e24db8ea791d46f8590`
+  - `nwtgck/actions-netlify@v3` → `13eaa50a52af3944ac07286543eba6545d35aa08`
+  - `actions/github-script@v7` → `f28e40c7f34bde8b3046d885e986cb6290c5673b`
+  - `pypa/gh-action-pypi-publish@release/v1` → `cef221092ed1bacb1cc03d23a2d87d1d172e277b`
+  - `actions/configure-pages@v5` → `983d7736d9b0ae728b81ab479565c72886d7745b`
+  - `actions/upload-pages-artifact@v3` → `56afc609e74202658d3ffba0e8f6dda462b719fa`
+  - `actions/deploy-pages@v4` → `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e`
+
+**SDK Standardization (Reliability):**
+- Standardized all .NET SDK versions to `10.0.x` (removed inconsistent 8.0.x and preview flags)
+- Removed `dotnet-quality: preview` from all workflows (project uses net10.0 stable TFM)
+- Ensures CI and CD test against the same runtime environment
+
+**Concurrency Management (Cost/Speed):**
+- Added concurrency groups to CI.yml: `cancel-in-progress: true` (saves resources on rapid pushes)
+- Added concurrency groups to CD.yml: `cancel-in-progress: false` (prevents deployment cancellations)
+
+**Caching Improvements (Speed):**
+- Added npm caching to docs.yml (`cache: 'npm'`, `cache-dependency-path: docs-site/package-lock.json`)
+- Added pip caching to CI.yml python job (`cache: 'pip'`, `cache-dependency-path: python/packages/botas/pyproject.toml`)
+- Upgraded docs.yml from setup-node@v4 to @v6 for latest cache features
+
+**Python CD Auth Cleanup (Security):**
+- Removed `id-token: write` from CD.yml python job (not using trusted publishing)
+- Clarified auth model: using password-based API tokens for PyPI/TestPyPI
+
+**Documentation:**
+- Added clear comment to build-all.sh indicating it's build-only (tests run separately in CI)
+
+**Squad Workflows:**
+- Updated all squad-*.yml workflows from checkout@v4 to SHA-pinned v6 for consistency
+- Reviewed token fallback pattern in squad-heartbeat.yml (working as designed)
+
+**Pattern for future action updates:**
+1. Use `git ls-remote https://github.com/<owner>/<action>.git refs/tags/<version>` to get SHA
+2. For annotated tags, use the dereferenced commit SHA (the one shown with `^{}`)
+3. Always add version comment: `@<sha> # <version>`
+4. Update all workflows simultaneously to maintain consistency
+
+All changes verified and passing validation checks.
+
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 - **2026-04-16**: Joined the team as DevOps Engineer. Existing CI/CD structure: CI.yml (PR/push validation with dorny/paths-filter for dotnet/node/python/docs), CD.yml (publish to NuGet/npm/PyPI on main/release branches), docs.yml (GitHub Pages deployment on main), e2e.yml (end-to-end tests). Key patterns: path-filtered jobs, action versions (checkout@v6, setup-node@v6, setup-dotnet@v5, setup-python@v6), nbgv for versioning across all languages.
 - **2026-04-16**: Added `docs-preview.yml` workflow for Netlify deploy previews on PRs (path-filtered to `docs-site/**`). Uses `nwtgck/actions-netlify@v3` with `production-deploy: false`. Requires `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` secrets. Removed artifact upload from CI.yml docs job — CI still validates the build, but previews are now handled by the dedicated Netlify workflow. Production docs remain on GitHub Pages via `docs.yml`.
+- **2026-04-16**: Full CI/CD review completed. Top findings: (1) All actions pinned by mutable tags not SHAs — security risk. (2) .NET SDK version inconsistency: CI uses 10.0.x stable, CD uses 10.0.x preview, python jobs use 8.0.x. (3) No concurrency groups on CI/CD. (4) docs.yml uses setup-node@v4 while all others use @v6. (5) Squad workflows all on checkout@v4 vs @v6 elsewhere. (6) Python CI missing pip cache. (7) CD python has both id-token:write and password-based PyPI auth — conflicting patterns. Full report in `.squad/decisions/inbox/bender-cicd-review.md`.

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Build-only script for all languages
+# Tests are run separately by CI workflows (CI.yml)
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

CI/CD hardening based on Bender's comprehensive audit. Addresses all 3 critical and 8 should-fix findings.

## 🔴 Critical Fixes

### 1. SHA-pinned all GitHub Actions
Every action across all 9 workflows is now pinned to a full commit SHA with version comment. Eliminates supply-chain risk from mutable tags.

### 2. `dorny/paths-filter` SHA-pinned
Third-party action pinned to `d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3`.

### 3. .NET SDK version standardized
- All jobs now use `10.0.x` consistently
- Removed `dotnet-quality: preview` from CD (was causing CI/CD divergence)
- Removed `8.0.x` from CD node/python jobs (aligned to `10.0.x`)

## 🟡 Should-Fix Improvements

| # | Fix | Files |
|---|-----|-------|
| 4 | Concurrency groups (CI: cancel-in-progress, CD: protected) | CI.yml, CD.yml |
| 5 | `setup-node@v4` → `@v6` (SHA-pinned) | docs.yml |
| 6 | npm cache added | docs.yml |
| 7 | pip cache added | CI.yml (python job) |
| 8 | Removed `id-token: write` (uses API token auth, not OIDC) | CD.yml |
| 9 | Documented as build-only | build-all.sh |
| 10 | Squad workflows updated to SHA-pinned checkout | squad-*.yml |

## Files Changed

- `.github/workflows/CI.yml` — SHA pins, concurrency, pip cache
- `.github/workflows/CD.yml` — SHA pins, concurrency, .NET alignment, id-token cleanup
- `.github/workflows/docs.yml` — SHA pins, setup-node upgrade, npm cache
- `.github/workflows/docs-preview.yml` — SHA pins
- `.github/workflows/e2e.yml` — SHA pins, .NET alignment
- `.github/workflows/squad-*.yml` (4 files) — SHA pins
- `build-all.sh` — build-only documentation

## 🟢 Not in This PR (nice-to-haves for future)

- Status badges in README (#12)
- Composite actions for DRY Node/Python setup (#14, #15)
- E2E schedule trigger (#16)
- npm publish idempotency (#17)
