### PR TITLE
docs: remove ngrok references, add SourceLink, enable docs-preview dispatch

### DIFF
--- a/.claude/skills/teams-bot-infra/SKILL.md
+++ b/.claude/skills/teams-bot-infra/SKILL.md
@@ -60,14 +60,12 @@ Ask the user: **"Do you have a bot messaging endpoint URL?"**
 - Confirm the endpoint format: `https://your-domain/api/messages`
 - Common formats:
   - Devtunnels: `https://your-tunnel.devtunnels.ms/api/messages`
-  - ngrok: `https://your-ngrok-id.ngrok.io/api/messages`
   - Azure: `https://your-app.azurewebsites.net/api/messages`
 - Default port for Teams SDK samples: `3978`
 
 **If NO:**
 - Recommend **Microsoft devtunnels** (recommended, Microsoft product)
 - Link: https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows
-- Alternative: ngrok
 - **Out of scope:** Setting up the tunnel itself (point user to docs)
 - User should set up tunnel first, then return to this workflow
 
@@ -194,7 +192,7 @@ teams self-update
 
 ### Update Bot Endpoint
 
-**Use case:** Endpoint URL changed (new ngrok/devtunnels session, redeployment, local → cloud migration)
+**Use case:** Endpoint URL changed (new devtunnels session, redeployment, local → cloud migration)
 
 **Command:**
 
@@ -203,8 +201,7 @@ teams app edit <appId> --endpoint "https://new-endpoint-url/api/messages"
 ```
 
 **When to use:**
-- Ngrok URL changed (new session)
-- Devtunnels URL changed
+- Devtunnels URL changed (new session)
 - Deployed bot to cloud (Azure, AWS, etc.)
 - Switched from local dev to production endpoint
 
@@ -286,15 +283,10 @@ This skill covers bot infrastructure only. To build the actual bot code:
 
 ### Setting Up Development Tunnels
 
-**Microsoft devtunnels (Recommended):**
+**Microsoft devtunnels:**
 - https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows
 - Microsoft's official tunneling solution
 - Free for development use
-
-**ngrok (Alternative):**
-- https://ngrok.com
-- Popular tunneling service
-- Free tier available
 
 ### Teams App Development Documentation
 
@@ -340,7 +332,7 @@ This skill covers bot infrastructure only. To build the actual bot code:
 This skill does NOT cover:
 - ❌ Building bot application code (see Teams SDK)
 - ❌ Hosting or deploying bot code (Azure, AWS, etc.)
-- ❌ Setting up devtunnels/ngrok (link provided to docs)
+- ❌ Setting up devtunnels (link provided to docs)
 - ❌ Bot development patterns and best practices
 - ❌ Teams app manifest customization (uses CLI defaults)
 

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   deploy-preview:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -4,6 +4,7 @@
 name: Docs Preview
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/docs-site/auth-setup.md
+++ b/docs-site/auth-setup.md
@@ -27,7 +27,7 @@ This guide walks you through getting those credentials and wiring everything up.
   teams login
   ```
 
-- **Dev tunnel** — exposes your local port to the internet. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started) or [ngrok](https://ngrok.com/).
+- **Dev tunnel** — exposes your local port to the internet. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started).
 
 ::: details Prefer Azure Portal instead?
 If you don't have the Teams CLI or prefer manual setup, see the [Appendix: Azure Portal Setup](#appendix-azure-portal-setup) section below.
@@ -56,15 +56,6 @@ devtunnel host
 ```
 
 Copy the HTTPS URL from the output — that's your tunnel URL.
-
-### Option B: ngrok (alternative)
-
-```bash
-# Install from https://ngrok.com/download, then:
-ngrok http 3978
-```
-
-Copy the `Forwarding` HTTPS URL from the ngrok output.
 
 ::: warning
 Make sure your tunnel is running *before* you test your bot. If the tunnel is down, the Bot Framework can't deliver messages and you'll see silent failures.

--- a/docs-site/getting-started.md
+++ b/docs-site/getting-started.md
@@ -15,7 +15,7 @@ Build and run an echo bot in under five minutes.
    teams login
    ```
 
-2. **Dev tunnel** — exposes your local port so Microsoft Teams can reach your bot. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started) or [ngrok](https://ngrok.com/).
+2. **Dev tunnel** — exposes your local port so Microsoft Teams can reach your bot. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started).
 
 3. **Language runtime** (pick one):
    - **.NET 10 SDK** — for the C# implementation

--- a/dotnet/src/Botas/Botas.csproj
+++ b/dotnet/src/Botas/Botas.csproj
@@ -13,6 +13,12 @@
     <PackageTags>bot;bot-framework;microsoft-teams;chatbot</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon-128.png</PackageIcon>
+
+    <!-- SourceLink: embed source info and enable deterministic builds -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/specs/Samples.md
+++ b/specs/Samples.md
@@ -26,7 +26,7 @@
 All samples require:
 
 1. Bot credentials in a `.env` file at the repo root (see [Infrastructure Setup](./Setup.md))
-2. A tunnel exposing port 3978 (devtunnels or ngrok)
+2. A tunnel exposing port 3978 (devtunnels)
 3. The language runtime installed (see [README](../README.md#prerequisites))
 
 ---

--- a/specs/Setup.md
+++ b/specs/Setup.md
@@ -32,8 +32,7 @@ Confirm with `teams status` — you should see your authenticated account.
 
 Your bot must be reachable from the internet before you register it. For local development, use a tunneling tool:
 
-- **Microsoft devtunnels (recommended):** [Get started with devtunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started?tabs=windows)
-- **ngrok (alternative):** [ngrok quickstart](https://ngrok.com/docs/getting-started/)
+- **Microsoft devtunnels:** [Get started with devtunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started?tabs=windows)
 
 BotAS samples listen on port `3978` by default, so your endpoint will look like:
 
@@ -120,7 +119,7 @@ cd python/packages/botas && uvicorn samples.fastapi.main:app --port 3978
 
 ## Update the endpoint
 
-Each time your tunnel URL changes (new ngrok or devtunnels session), update the registered endpoint:
+Each time your tunnel URL changes (new devtunnels session), update the registered endpoint:
 
 ```bash
 teams app edit <teamsAppId> --endpoint "https://<new-tunnel>/api/messages"


### PR DESCRIPTION
Changes from PR #174 that weren't covered by PR #175:

- Remove ngrok as tunneling option from all remaining docs — Dev Tunnels is the sole recommendation
- Add SourceLink properties to Botas.csproj for source-embedded NuGet packages (.snupkg)
- Add workflow_dispatch trigger to docs-preview workflow

Closes #174 (superseded)