### PR TITLE
fix: accept object types in adaptive card attachment methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,18 @@ Rules: `E`, `F`, `W`, `I` — line length **120** (see `python/packages/botas/py
 
 ---
 
+## Docs & Samples Sync
+
+When updating samples or library API signatures, **always update the corresponding docs and specs in the same change**:
+
+- `docs-site/` — user-facing documentation (code examples must match current samples)
+- `specs/future/` — API surface specs (signatures must match current implementations)
+- `specs/README.md` — overview examples (must reflect current API)
+
+Verify with a quick grep: `grep -rn 'oldPattern' docs-site/ specs/` before committing.
+
+---
+
 ## References
 
 - [specs/](specs/README.md) — canonical feature specification (start here)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,4 +108,6 @@ POST /api/messages
 
 When a spec change affects behavior, update all three language implementations. Intentional language-specific differences belong in `specs/README.md` under "Language-Specific Intentional Differences".
 
+When updating samples or library API signatures, always update the corresponding docs (`docs-site/`) and specs (`specs/`) in the same change. Verify with grep before committing.
+
 Do not duplicate spec content — link to `specs/` instead.

--- a/docs-site/public/_redirects
+++ b/docs-site/public/_redirects
@@ -1,0 +1,1 @@
+/botas/* /:splat 200

--- a/docs-site/teams-features.md
+++ b/docs-site/teams-features.md
@@ -66,7 +66,7 @@ await ctx.send(reply)
 
 Send rich interactive cards using `addAdaptiveCardAttachment()` (appends) or `withAdaptiveCardAttachment()` (replaces all attachments with one card).
 
-Both methods accept a JSON string, parse it, and wrap it in an attachment with `contentType: "application/vnd.microsoft.card.adaptive"`.
+Both methods accept a JSON string or a pre-parsed object (to avoid double serialization), and wrap it in an attachment with `contentType: "application/vnd.microsoft.card.adaptive"`.
 
 We recommend using [FluentCards](https://github.com/rido-min/FluentCards) to build Adaptive Cards with a fluent, strongly-typed API instead of raw JSON. FluentCards is available for all three languages: NuGet [`FluentCards`](https://www.nuget.org/packages/FluentCards), npm [`fluent-cards`](https://www.npmjs.com/package/fluent-cards), and PyPI [`fluent-cards`](https://pypi.org/project/fluent-cards/).
 
@@ -94,13 +94,13 @@ var card = AdaptiveCardBuilder.Create()
     .Build();
 
 var reply = new TeamsActivityBuilder()
-    .WithAdaptiveCardAttachment(card.ToJson())
+    .WithAdaptiveCardAttachment(card.ToJsonElement())
     .Build();
 await ctx.SendAsync(reply, ct);
 ```
 
 ```typescript [Node.js]
-import { AdaptiveCardBuilder, TextSize, TextWeight, toJson } from 'fluent-cards'
+import { AdaptiveCardBuilder, TextSize, TextWeight, toObject } from 'fluent-cards'
 
 const card = AdaptiveCardBuilder.create()
   .withVersion('1.5')
@@ -122,13 +122,13 @@ const card = AdaptiveCardBuilder.create()
   .build()
 
 const reply = new TeamsActivityBuilder()
-  .withAdaptiveCardAttachment(toJson(card))
+  .withAdaptiveCardAttachment(toObject(card))
   .build()
 await ctx.send(reply)
 ```
 
 ```python [Python]
-from fluent_cards import AdaptiveCardBuilder, TextSize, TextWeight, to_json
+from fluent_cards import AdaptiveCardBuilder, TextSize, TextWeight, to_dict
 
 card = (
     AdaptiveCardBuilder.create()
@@ -151,7 +151,7 @@ card = (
 
 reply = (
     TeamsActivityBuilder()
-    .with_adaptive_card_attachment(to_json(card))
+    .with_adaptive_card_attachment(to_dict(card))
     .build()
 )
 await ctx.send(reply)

--- a/dotnet/samples/TeamsSample/Program.cs
+++ b/dotnet/samples/TeamsSample/Program.cs
@@ -80,7 +80,7 @@ app.On("message", async (ctx, ct) =>
 
         var reply = new TeamsActivityBuilder()
             .WithConversationReference(ctx.Activity)
-            .WithAdaptiveCardAttachment(card.ToJson())
+            .WithAdaptiveCardAttachment(card.ToJsonElement())
             .Build();
 
         await ctx.SendAsync(reply, ct);

--- a/dotnet/src/Botas/TeamsActivity.cs
+++ b/dotnet/src/Botas/TeamsActivity.cs
@@ -225,10 +225,18 @@ public class TeamsActivityBuilder
     public TeamsActivityBuilder AddAdaptiveCardAttachment(string cardJson)
     {
         var content = JsonSerializer.Deserialize<JsonElement>(cardJson);
+        return AddAdaptiveCardAttachment(content);
+    }
+
+    /// <summary>
+    /// Appends a pre-parsed Adaptive Card as an attachment, avoiding double serialization.
+    /// </summary>
+    public TeamsActivityBuilder AddAdaptiveCardAttachment(JsonElement content)
+    {
         var attachment = new Attachment
         {
             ContentType = "application/vnd.microsoft.card.adaptive",
-            Content = content
+            Content = content.Clone()
         };
         return AddAttachment(attachment);
     }
@@ -239,10 +247,18 @@ public class TeamsActivityBuilder
     public TeamsActivityBuilder WithAdaptiveCardAttachment(string cardJson)
     {
         var content = JsonSerializer.Deserialize<JsonElement>(cardJson);
+        return WithAdaptiveCardAttachment(content);
+    }
+
+    /// <summary>
+    /// Sets a pre-parsed Adaptive Card as the only attachment, avoiding double serialization.
+    /// </summary>
+    public TeamsActivityBuilder WithAdaptiveCardAttachment(JsonElement content)
+    {
         var attachment = new Attachment
         {
             ContentType = "application/vnd.microsoft.card.adaptive",
-            Content = content
+            Content = content.Clone()
         };
         var node = JsonSerializer.SerializeToNode(attachment, CoreActivity.DefaultJsonOptions);
         _activity.Attachments = [node];

--- a/node/packages/botas/src/teams-activity.ts
+++ b/node/packages/botas/src/teams-activity.ts
@@ -197,11 +197,11 @@ export class TeamsActivityBuilder {
   }
 
   /**
-   * Parses JSON as an Adaptive Card and appends it as an attachment.
-   * @throws {SyntaxError} If cardJson is not valid JSON.
+   * Parses JSON string or accepts a pre-parsed object as an Adaptive Card and appends it as an attachment.
+   * @throws {SyntaxError} If cardJson is a string and not valid JSON.
    */
-  addAdaptiveCardAttachment (cardJson: string): this {
-    const content = JSON.parse(cardJson)
+  addAdaptiveCardAttachment (card: string | Record<string, unknown>): this {
+    const content = typeof card === 'string' ? JSON.parse(card) : structuredClone(card)
     this.addAttachment({
       contentType: 'application/vnd.microsoft.card.adaptive',
       content
@@ -210,11 +210,11 @@ export class TeamsActivityBuilder {
   }
 
   /**
-   * Parses JSON as an Adaptive Card and sets it as the only attachment.
-   * @throws {SyntaxError} If cardJson is not valid JSON.
+   * Parses JSON string or accepts a pre-parsed object as an Adaptive Card and sets it as the only attachment.
+   * @throws {SyntaxError} If cardJson is a string and not valid JSON.
    */
-  withAdaptiveCardAttachment (cardJson: string): this {
-    const content = JSON.parse(cardJson)
+  withAdaptiveCardAttachment (card: string | Record<string, unknown>): this {
+    const content = typeof card === 'string' ? JSON.parse(card) : structuredClone(card)
     this.withAttachment({
       contentType: 'application/vnd.microsoft.card.adaptive',
       content

--- a/node/samples/teams-sample/index.ts
+++ b/node/samples/teams-sample/index.ts
@@ -6,7 +6,7 @@
 
 import { BotApp } from 'botas-express'
 import { TeamsActivityBuilder } from 'botas-core'
-import { AdaptiveCardBuilder, TextSize, TextWeight, TextColor, toJson, toObject } from 'fluent-cards'
+import { AdaptiveCardBuilder, TextSize, TextWeight, TextColor, toObject } from 'fluent-cards'
 
 const app = new BotApp()
 
@@ -70,7 +70,7 @@ app.on('message', async (ctx) => {
 
     const reply = new TeamsActivityBuilder()
       .withConversationReference(ctx.activity)
-      .withAdaptiveCardAttachment(toJson(card))
+      .withAdaptiveCardAttachment(toObject(card))
       .build()
 
     await ctx.send(reply)

--- a/python/packages/botas/src/botas/teams_activity.py
+++ b/python/packages/botas/src/botas/teams_activity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 from typing import Any
 
@@ -229,18 +230,18 @@ class TeamsActivityBuilder:
         entity = Entity(type="mention", mentioned=account.model_dump(), text=text)
         return self.add_entity(entity)
 
-    def add_adaptive_card_attachment(self, card_json: str) -> "TeamsActivityBuilder":
-        """Parses JSON as an Adaptive Card and appends it as an attachment."""
-        content = json.loads(card_json)
+    def add_adaptive_card_attachment(self, card: str | dict) -> "TeamsActivityBuilder":
+        """Parses JSON string or accepts a pre-parsed dict as an Adaptive Card and appends it as an attachment."""
+        content = json.loads(card) if isinstance(card, str) else copy.deepcopy(card)
         attachment = Attachment(
             content_type="application/vnd.microsoft.card.adaptive",
             content=content,
         )
         return self.add_attachment(attachment)
 
-    def with_adaptive_card_attachment(self, card_json: str) -> "TeamsActivityBuilder":
-        """Parses JSON as an Adaptive Card and sets it as the only attachment."""
-        content = json.loads(card_json)
+    def with_adaptive_card_attachment(self, card: str | dict) -> "TeamsActivityBuilder":
+        """Parses JSON string or accepts a pre-parsed dict as an Adaptive Card and sets it as the only attachment."""
+        content = json.loads(card) if isinstance(card, str) else copy.deepcopy(card)
         attachment = Attachment(
             content_type="application/vnd.microsoft.card.adaptive",
             content=content,

--- a/python/samples/teams-sample/main.py
+++ b/python/samples/teams-sample/main.py
@@ -6,7 +6,7 @@
 
 from botas_fastapi import BotApp
 
-from fluent_cards import AdaptiveCardBuilder, TextColor, TextSize, TextWeight, to_dict, to_json
+from fluent_cards import AdaptiveCardBuilder, TextColor, TextSize, TextWeight, to_dict
 
 from botas import InvokeResponse, TeamsActivityBuilder
 from botas.suggested_actions import CardAction, SuggestedActions
@@ -74,7 +74,7 @@ async def on_message(ctx):
         reply = (
             TeamsActivityBuilder()
             .with_conversation_reference(ctx.activity)
-            .with_adaptive_card_attachment(to_json(card))
+            .with_adaptive_card_attachment(to_dict(card))
             .build()
         )
 

--- a/specs/future/teams-activity.md
+++ b/specs/future/teams-activity.md
@@ -377,7 +377,9 @@ public class TeamsActivityBuilder : CoreActivityBuilder
     public TeamsActivityBuilder AddAttachment(Attachment attachment) { ... }
     public TeamsActivityBuilder AddMention(ChannelAccount account, string? mentionText = null) { ... }
     public TeamsActivityBuilder AddAdaptiveCardAttachment(string cardJson) { ... }
+    public TeamsActivityBuilder AddAdaptiveCardAttachment(JsonElement content) { ... }
     public TeamsActivityBuilder WithAdaptiveCardAttachment(string cardJson) { ... }
+    public TeamsActivityBuilder WithAdaptiveCardAttachment(JsonElement content) { ... }
     
     // Override to return TeamsActivity instead of CoreActivity
     public new TeamsActivity Build() { ... }
@@ -424,8 +426,8 @@ export class TeamsActivityBuilder extends CoreActivityBuilder {
   addEntity(entity: Entity): this { ... }
   addAttachment(attachment: Attachment): this { ... }
   addMention(account: ChannelAccount, mentionText?: string): this { ... }
-  addAdaptiveCardAttachment(cardJson: string): this { ... }
-  withAdaptiveCardAttachment(cardJson: string): this { ... }
+  addAdaptiveCardAttachment(card: string | Record<string, unknown>): this { ... }
+  withAdaptiveCardAttachment(card: string | Record<string, unknown>): this { ... }
   
   // Override to return TeamsActivity instead of CoreActivity
   build(): TeamsActivity { ... }
@@ -484,10 +486,10 @@ class TeamsActivityBuilder(CoreActivityBuilder):
     def add_mention(self, account: ChannelAccount, mention_text: str | None = None) -> "TeamsActivityBuilder":
         ...
     
-    def add_adaptive_card_attachment(self, card_json: str) -> "TeamsActivityBuilder":
+    def add_adaptive_card_attachment(self, card: str | dict) -> "TeamsActivityBuilder":
         ...
     
-    def with_adaptive_card_attachment(self, card_json: str) -> "TeamsActivityBuilder":
+    def with_adaptive_card_attachment(self, card: str | dict) -> "TeamsActivityBuilder":
         ...
     
     # Override to return TeamsActivity instead of CoreActivity


### PR DESCRIPTION
## Summary

Completes the double-serialization removal started in PR #166. That PR fixed invoke responses but left the card attachment path with a serialize→parse round-trip when using FluentCards.

### Changes

**Library (all 3 languages):**
- Add \JsonElement\/object/dict overloads to \WithAdaptiveCardAttachment\ and \AddAdaptiveCardAttachment\
- .NET: \JsonElement\ overload with \Clone()\ for safety; string overload delegates to it
- Node: union type \string | Record<string, unknown>\ with \structuredClone\ for object inputs
- Python: union type \str | dict\ with \deepcopy\ for dict inputs
- String overloads preserved for backward compatibility

**Samples:** Updated all 3 to use \ToJsonElement()\/\	oObject()\/\	o_dict()\ instead of \ToJson()\/\	oJson()\/\	o_json()\ for card attachments

**Docs & specs:** Updated \docs-site/teams-features.md\ and \specs/future/teams-activity.md\ to reflect new API

**Process:** Added docs-sync convention to \AGENTS.md\ and \CLAUDE.md\ — when updating samples or API signatures, always update docs/specs in the same change

### Test results
- .NET: 73 passed
- Node: 106 passed
- Python: 94 passed