### PR TITLE
specs: close gaps found by clean-room implementation validation

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -190,7 +190,7 @@ class BotApplication {
     processAsync(req: IncomingMessage, res: ServerResponse): Promise<void>
 
     // For Hono and other response-owning frameworks
-    processBody(body: string): Promise<void>
+    processBody(body: string): Promise<InvokeResponse | undefined>
 
     // Proactive send
     sendActivityAsync(serviceUrl: string, conversationId: string, activity: Partial<CoreActivity>): Promise<ResourceResponse | undefined>
@@ -208,7 +208,7 @@ class BotApplication:
     on_activity: Optional[Callable[[TurnContext], Awaitable[None]]] = None
 
     # Process incoming activity
-    async def process_body(self, body: str) -> None
+    async def process_body(self, body: str) -> InvokeResponse | None
 
     # Send outbound activity
     async def send_activity_async(
@@ -427,16 +427,20 @@ class BotHandlerException : Exception {
 |---------|--------|------|--------|
 | Simple bot API | `BotApp.Create()` + `app.On()` | `BotApp` (botas-express) | `BotApp()` |
 | Web framework | ASP.NET Core (built-in) | Express (via botas-express) or manual | aiohttp (built-in) or manual FastAPI |
-| Handler registration | `app.On(type, handler)` receiving `TurnContext` | `app.on(type, handler)` receiving `TurnContext` | `@app.on(type)` receiving `TurnContext` |
+| Handler registration | `app.On(type, handler)` receiving `TurnContext` | `app.on(type, handler)` receiving `TurnContext` | `@app.on(type)` decorator or `app.on(type, handler)` receiving `TurnContext` |
 | CatchAll handler | `OnActivity` property | `onActivity` property | `on_activity` property |
 | HTTP integration | `ProcessAsync(HttpContext)` | `processAsync(req, res)` or `processBody(body)` | `process_body(body)` |
 | Auth middleware | ASP.NET authentication scheme | `botAuthExpress()` / `botAuthHono()` factory | `bot_auth_dependency()` / `validate_bot_token()` |
 | SendActivityAsync args | Single `CoreActivity` (carries serviceUrl/conversationId) | `(serviceUrl, conversationId, activity)` | `(service_url, conversation_id, activity)` |
-| TurnContext.send | `SendAsync(string)` / `SendAsync(CoreActivity)` | `send(string \| Partial<CoreActivity>)` | `send(str \| dict)` |
+| TurnContext.send | `SendAsync(string)` / `SendAsync(CoreActivity)` | `send(string \| Partial<CoreActivity>)` | `send(str \| CoreActivity \| dict)` |
 | TurnContext.sendTyping | `SendTypingAsync()` returns `Task<string>` | `sendTyping()` returns `Promise<void>` | `send_typing()` returns `None` |
 | Exception class name | `BotHandlerException` | `BotHandlerException` (correct spelling) | `BotHandlerException` |
 | DI registration | `AddBotApplication<TApp>()` — generic; TApp must extend `BotApplication` | Not applicable | Not applicable |
 | App builder | `UseBotApplication<TApp>()` — returns typed `TApp` instance | Not applicable | Not applicable |
+| Resource cleanup | Handled by DI container | No explicit cleanup needed | `async with bot:` context manager or `await bot.aclose()` |
+| Activity model | `CoreActivity` class with `[JsonExtensionData]` | `CoreActivity` interface with `properties?` dict | `CoreActivity` Pydantic model with `model_extra` |
+| Prototype pollution | Not applicable (strongly typed) | `safeJsonParse` strips dangerous keys | Not vulnerable (no prototype chain), but SHOULD strip for defense-in-depth |
+| `from` field naming | `From` (C# allows it) | `from` (JS allows it) | `from_account` (`from` is reserved in Python) |
 
 These differences are intentional and should be preserved per language when porting.
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -97,12 +97,16 @@ A developer uses `TeamsActivityBuilder` to send mentions, suggested actions, and
 
 **Purpose:** Zero-boilerplate bot setup for simple bots. Automatically configures web server, JWT auth, and `/api/messages` endpoint.
 
-**Node.js** uses a separate package `botas-express` that composes a `BotApplication` with an Express server. It wraps `BotApplication` and an Express server via composition (not inheritance), providing:
-- `POST /api/messages` — JWT auth middleware + activity processing
-- `GET /health` — returns `{ status: 'ok' }`
-- `GET /` — returns `Bot {clientId} is running`
+**Common behaviors across all languages:**
 
-The `botas-express` package re-exports all core `botas` types for convenience, so developers can import everything from one package.
+- `POST /api/messages` — JWT auth middleware + activity processing
+- `GET /health` — returns `{ status: 'ok' }` (health check endpoint)
+- `GET /` — returns a status message identifying the bot (e.g., `Bot {clientId} is running`)
+- When `CLIENT_ID` is not configured, runs without authentication (dev/testing mode)
+- Handler and middleware registration is deferred — `On()`/`on()`/`Use()`/`use()` calls are collected and wired when `Run()`/`start()` is called
+- Implementations SHOULD enforce a maximum request body size (recommended: 1 MB)
+
+**Node.js** uses a separate package `botas-express` that composes a `BotApplication` with an Express server. It wraps `BotApplication` and an Express server via composition (not inheritance), re-exporting all core `botas` types for convenience.
 
 **.NET:**
 

--- a/specs/activity-schema.md
+++ b/specs/activity-schema.md
@@ -53,12 +53,16 @@ The core message/event model. Only the fields below are explicitly typed; everyt
 | `serviceUrl` | `string` | Yes | Callback URL for this conversation's channel |
 | `channelId` | `string` | No | Channel identifier (e.g., `"msteams"`, `"webchat"`) |
 | `text` | `string` | No | Message text content |
+| `name` | `string` | No | Invoke action name (e.g., `"adaptiveCard/action"`, `"task/fetch"`). Used for [invoke dispatch](./invoke-activities.md). |
+| `value` | `any` | No | Action-specific payload for invoke activities (card data, task module input, etc.) |
 | `from` | [ChannelAccount](#channelaccount) | Yes | Sender information |
 | `recipient` | [ChannelAccount](#channelaccount) | Yes | Recipient information |
 | `conversation` | [Conversation](#conversation) | Yes | Conversation context |
 | `entities` | `array` | No | Mentions, card actions, and other entities |
 | `attachments` | `array` | No | File or card attachments |
 | *(any other)* | *any* | No | Preserved as extension data |
+
+> **Python note**: `from` is a reserved keyword in Python. The Python implementation maps this field to `from_account` in the typed model, while serializing to/from `"from"` in JSON.
 
 ---
 

--- a/specs/activity-schema.md
+++ b/specs/activity-schema.md
@@ -64,6 +64,8 @@ The core message/event model. Only the fields below are explicitly typed; everyt
 
 > **Python note**: `from` is a reserved keyword in Python. The Python implementation maps this field to `from_account` in the typed model, while serializing to/from `"from"` in JSON.
 
+> **Default values**: When constructing a new `CoreActivity` programmatically (not deserializing), the `type` field defaults to `"message"` in the existing .NET implementation. Other implementations MAY use an empty string default. Callers should always set `type` explicitly.
+
 ---
 
 ## ChannelAccount

--- a/specs/inbound-auth.md
+++ b/specs/inbound-auth.md
@@ -25,7 +25,15 @@ The token is a standard JSON Web Token (JWT) signed by Microsoft identity platfo
 
 ### 1. Audience (`aud`)
 
-The token's `aud` claim MUST match the bot's **Client ID** (Azure AD App ID), read from the `CLIENT_ID` environment variable.
+The token's `aud` claim MUST match one of the following:
+
+| Audience format | Example |
+|-----------------|---------|
+| Bot's Client ID (plain) | `{CLIENT_ID}` |
+| Bot's Client ID with `api://` prefix | `api://{CLIENT_ID}` |
+| Bot Framework global issuer | `https://api.botframework.com` |
+
+The Client ID is read from the `CLIENT_ID` environment variable.
 
 ### 2. Issuer (`iss`)
 
@@ -36,6 +44,7 @@ The following issuers MUST be accepted:
 | `https://api.botframework.com` | Tokens from the global Bot Framework channel |
 | `https://sts.windows.net/{tenantId}/` | Tokens from Azure AD v1 endpoints |
 | `https://login.microsoftonline.com/{tenantId}/v2` | Tokens from Azure AD v2 endpoints |
+| `https://login.microsoftonline.com/{tenantId}/v2.0` | Tokens from Azure AD v2 endpoints (alternate format) |
 
 Where `{tenantId}` is the Azure AD tenant ID from the token's `tid` claim.
 
@@ -74,6 +83,19 @@ Where `{tid}` is the token's `tid` claim.
 ### Key Caching
 
 Implementations SHOULD cache the JWKS keys and OpenID configuration to avoid fetching on every request. A reasonable cache duration is 24 hours, with a fallback re-fetch on key-not-found errors.
+
+### Metadata URL Validation
+
+Before fetching an OpenID configuration URL, implementations MUST validate that the URL starts with one of these trusted prefixes:
+
+- `https://login.botframework.com/`
+- `https://login.microsoftonline.com/`
+
+This prevents SSRF attacks where a crafted token could point the bot to an attacker-controlled metadata endpoint.
+
+### Rate Limiting Failed Validations
+
+Implementations SHOULD cache recently-failed tokens (by hash) for a short cooldown period (e.g., 5 seconds) to prevent repeated validation attempts for the same invalid token. This mitigates denial-of-service attacks that exploit expensive JWKS fetches and crypto operations.
 
 ---
 

--- a/specs/invoke-activities.md
+++ b/specs/invoke-activities.md
@@ -180,9 +180,22 @@ When `activity.type === "invoke"` and NO handlers (specific or catch-all) are re
 activity.type = "invoke"
 activity.name = "unknown/operation"
 
-→ No dispatch (silently ignored per botas protocol)
+→ No invoke handler registered
 → HTTP Response: 200, body {}
 ```
+
+When specific invoke handlers ARE registered but the incoming `activity.name` does NOT match any of them (and no catch-all is set):
+
+```
+activity.type = "invoke"
+activity.name = "unknown/operation"
+
+→ No matching specific handler
+→ Return InvokeResponse { status: 501 }
+→ HTTP Response: status 501, no body
+```
+
+> **Rationale**: When a bot has registered specific invoke handlers, an unrecognized invoke name likely indicates a misconfiguration or version mismatch — returning 501 signals this clearly. When no invoke handlers exist at all, the bot simply doesn't handle invoke activities, so the default 200 `{}` applies.
 
 ### 4. Conflict Prevention
 
@@ -373,7 +386,8 @@ app.onInvoke('task/fetch', async (ctx) => {
 | Return type | `InvokeResponse` class | `InvokeResponse` interface | `InvokeResponse` dataclass |
 | Response fields | `Status: int, Body: object?` | `status: number, body?: any` | `status: int, body: Any \| None` |
 | Conflict detection | Exception on registration | Exception on registration | Exception on registration |
-| Default response (no handler) | HTTP 200, body `{}` | HTTP 200, body `{}` | HTTP 200, body `{}` |
+| Default response (no invoke handlers at all) | HTTP 200, body `{}` | HTTP 200, body `{}` | HTTP 200, body `{}` |
+| Unmatched name (handlers exist, no match) | HTTP 501 | HTTP 501 | HTTP 501 |
 
 ---
 

--- a/specs/invoke-activities.md
+++ b/specs/invoke-activities.md
@@ -258,6 +258,10 @@ Middleware can:
 - Short-circuit by NOT calling `next()` (must handle HTTP response manually)
 - Perform post-processing after handler execution
 
+### CatchAll Handler Interaction
+
+When a CatchAll handler (`OnActivity` / `onActivity` / `on_activity`) is set, **invoke activities bypass invoke-specific dispatch** and are routed to the CatchAll handler like all other activity types. The CatchAll handler replaces ALL dispatch — including invoke dispatch by `activity.name`. If the CatchAll handler needs to return an `InvokeResponse`, it must do so via the framework's invoke response mechanism (e.g., returning from `processBody` or setting the response on the HTTP context).
+
 ---
 
 ## Error Handling

--- a/specs/outbound-auth.md
+++ b/specs/outbound-auth.md
@@ -83,6 +83,34 @@ Implementations MUST cache the access token and reuse it until it expires. Best 
 
 Implementations SHOULD NOT request a new token for every outbound call.
 
+### Negative Caching
+
+Implementations SHOULD cache failed token acquisition attempts for a short period (e.g., 30 seconds) to avoid hammering the Azure AD token endpoint during transient failures. After the negative cache expires, the next outbound request should retry token acquisition.
+
+---
+
+## Alternative Authentication Flows
+
+Beyond client credentials with a secret, implementations MAY support additional Azure AD authentication flows:
+
+| Flow | When to use | Required config |
+|------|-------------|-----------------|
+| **Client credentials** (secret) | Standard bots with a client secret | `CLIENT_ID`, `CLIENT_SECRET`, `TENANT_ID` |
+| **User managed identity** | Bots hosted in Azure (no secret needed) | `CLIENT_ID` (matches the managed identity) |
+| **Federated identity** (user-assigned MI) | Bot's `CLIENT_ID` differs from the managed identity | `CLIENT_ID`, `MANAGED_IDENTITY_CLIENT_ID` |
+| **Federated identity** (system-assigned MI) | Uses the VM/container's system-assigned MI | `CLIENT_ID`, `MANAGED_IDENTITY_CLIENT_ID="system"` |
+| **Custom token factory** | Testing or custom auth scenarios | `CLIENT_ID`, custom callback |
+
+Flow selection logic:
+
+1. If a custom token factory/callback is provided → use it.
+2. If `CLIENT_SECRET` is set → client credentials flow.
+3. If `MANAGED_IDENTITY_CLIENT_ID` is set and differs from `CLIENT_ID` → federated identity.
+4. If `CLIENT_ID` is set (no secret, no MI override) → user managed identity.
+5. If nothing is set → no auth (dev/testing mode).
+
+See [Configuration](./Configuration.md) for the full per-language configuration reference.
+
 ---
 
 ## Configuration
@@ -92,8 +120,9 @@ Implementations SHOULD NOT request a new token for every outbound call.
 | `CLIENT_ID` | Azure AD application (bot) ID |
 | `CLIENT_SECRET` | Azure AD client secret |
 | `TENANT_ID` | Azure AD tenant ID |
+| `MANAGED_IDENTITY_CLIENT_ID` | User-assigned managed identity client ID, or `"system"` for system-assigned MI |
 
-All three are required for outbound authentication.
+`CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` are required for client credentials authentication. See [Alternative Authentication Flows](#alternative-authentication-flows) for other combinations.
 
 ---
 

--- a/specs/protocol.md
+++ b/specs/protocol.md
@@ -69,6 +69,8 @@ After middleware, the activity is dispatched to a registered handler based on `a
 - If a handler IS registered for the type → invoke it.
 - If NO handler is registered for the type → **silently ignore** the activity (no error).
 
+**Case sensitivity**: Handler lookup by `activity.type` SHOULD use **case-insensitive** comparison. Activity type strings from the Bot Framework (e.g., `"message"`, `"invoke"`) are lowercase by convention, but implementations should tolerate case variations for robustness.
+
 ##### CatchAll Handler
 
 A CatchAll handler is an optional, application-level callback that, when set, **replaces per-type handler dispatch entirely**:
@@ -85,6 +87,8 @@ Any exception thrown inside a handler MUST be wrapped in a language-specific `Bo
 
 - The original exception/error as the inner cause.
 - A reference to the activity that triggered the error.
+
+**Cancellation exceptions**: `OperationCanceledException` (.NET), `AbortError` (Node.js), and `asyncio.CancelledError` (Python) SHOULD be re-thrown without wrapping. These indicate a cancelled request, not a handler error.
 
 ### Response
 
@@ -399,10 +403,10 @@ See [CatchAll Handler](#catchall-handler) for details.
 ### Endpoint
 
 ```
-POST {serviceUrl}v3/conversations/{conversationId}/activities
+POST {serviceUrl}/v3/conversations/{conversationId}/activities
 ```
 
-- `{serviceUrl}` — the `serviceUrl` from the original inbound activity (unique per conversation).
+- `{serviceUrl}` — the `serviceUrl` from the original inbound activity (unique per conversation). Implementations MUST normalize trailing slashes — the URL should have exactly one `/` between `{serviceUrl}` and `v3` regardless of whether `serviceUrl` ends with `/`.
 - `{conversationId}` — `activity.conversation.id`.
 
 > **Note**: Some channels (e.g., Microsoft Teams agents channel) include semicolons in conversation IDs (e.g., `a]concat-123;messageid=9876`). When constructing the URL, implementations MUST truncate the conversation ID at the first `;` character before URL-encoding it. The full conversation ID is still used in the activity body.

--- a/specs/protocol.md
+++ b/specs/protocol.md
@@ -96,6 +96,35 @@ Any exception thrown inside a handler MUST be wrapped in a language-specific `Bo
 
 On success the response body MUST be `{}` (empty JSON object).
 
+### Input Validation
+
+Before processing the activity, implementations MUST:
+
+1. **Validate required fields** — `type` (non-empty string), `serviceUrl` (non-empty string), and `conversation.id` (non-empty string) MUST be present. Return `400` if missing.
+2. **Validate service URL** — see [Service URL Validation](#service-url-validation) below.
+3. **Protect against prototype pollution** — JSON parsers MUST strip keys like `__proto__`, `constructor`, and `prototype` from parsed activity payloads. This is critical for JavaScript/Node.js implementations. Languages without prototype chains (Python, .NET, Go) SHOULD still strip these keys for defense-in-depth.
+
+Implementations SHOULD enforce a maximum request body size (recommended: 1 MB) and return `413` on overflow.
+
+### Service URL Validation
+
+The `serviceUrl` from inbound activities MUST be validated against an allowlist before processing. This prevents SSRF attacks where a malicious activity could trick the bot into making requests to arbitrary URLs.
+
+**Allowed hosts:**
+
+| Host pattern | Description |
+|--------------|-------------|
+| `*.botframework.com` | Global Bot Framework service |
+| `*.botframework.us` | US government cloud |
+| `*.botframework.cn` | China cloud |
+| `*.trafficmanager.net` | Azure Traffic Manager (used by some channels) |
+| `localhost` / `127.0.0.1` | Local development only |
+
+**Rules:**
+
+- HTTPS is required for all hosts except `localhost` / `127.0.0.1`.
+- The same validation MUST apply to `serviceUrl` used in outbound requests (see [Outbound: Sending Activities](#outbound-sending-activities)).
+
 ---
 
 ## Middleware
@@ -376,6 +405,8 @@ POST {serviceUrl}v3/conversations/{conversationId}/activities
 - `{serviceUrl}` — the `serviceUrl` from the original inbound activity (unique per conversation).
 - `{conversationId}` — `activity.conversation.id`.
 
+> **Note**: Some channels (e.g., Microsoft Teams agents channel) include semicolons in conversation IDs (e.g., `a]concat-123;messageid=9876`). When constructing the URL, implementations MUST truncate the conversation ID at the first `;` character before URL-encoding it. The full conversation ID is still used in the activity body.
+
 ### Request
 
 | Header | Value |
@@ -404,6 +435,25 @@ Before sending, the conversation client MUST silently skip the following activit
 | `trace` | Diagnostic-only; not intended for the channel. |
 
 Skipped activities return an empty/default result immediately.
+
+### ConversationClient API Surface
+
+Beyond sending activities, the `ConversationClient` wraps the [Bot Framework v3 Conversations REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#conversations-object):
+
+| Method | HTTP | Path | Description |
+|--------|------|------|-------------|
+| Send activity | `POST` | `v3/conversations/{id}/activities` | Send an activity to a conversation |
+| Update activity | `PUT` | `v3/conversations/{id}/activities/{activityId}` | Update an existing activity |
+| Delete activity | `DELETE` | `v3/conversations/{id}/activities/{activityId}` | Delete an activity |
+| Create conversation | `POST` | `v3/conversations` | Create a new 1:1 or group conversation |
+| Get members | `GET` | `v3/conversations/{id}/members` | List all conversation members |
+| Get member | `GET` | `v3/conversations/{id}/members/{memberId}` | Get a single member by ID |
+| Get paged members | `GET` | `v3/conversations/{id}/pagedmembers` | List members with pagination |
+| Delete member | `DELETE` | `v3/conversations/{id}/members/{memberId}` | Remove a member from a conversation |
+| Get conversations | `GET` | `v3/conversations` | List conversations the bot is in |
+| Send history | `POST` | `v3/conversations/{id}/activities/history` | Upload a conversation transcript |
+
+All methods require outbound authentication (see [Outbound Auth](./outbound-auth.md)) and service URL validation.
 
 ---
 


### PR DESCRIPTION
## Summary

Validated whether the botas specs are sufficient to implement the library from scratch in any language. Implemented clean-room versions in **JS ES6** and **Python** using only the specs, compared against all 3 existing implementations (Node.js, Python, .NET), and updated specs to close all discovered gaps.

### Process
1. **JS ES6 Round 1** — clean-room implementation (9 modules, 22 tests) → found 17+ gaps
2. **JS ES6 Round 2** — re-implemented from updated specs → all gaps closed (35/35 tests)
3. **Python Round 1** — clean-room implementation (8 modules, 35 tests) → found 10 new gaps
4. **.NET exploration** — read all source files to confirm findings
5. **Spec updates** — applied all findings across 2 rounds (+131 lines)
6. **Final validation** — all existing test suites pass unchanged (Node 115, Python 94, .NET 73)

### Spec changes (6 files)

| File | Key additions |
|------|--------------|
| \ctivity-schema.md\ | \
ame\, \alue\ as typed fields; Python \rom_account\ note |
| \inbound-auth.md\ | 3 audience formats (\pi://\), \2.0\ issuer variant, metadata URL allowlist, rate limiting |
| \outbound-auth.md\ | Negative caching, all 5 auth flows with selection logic, \MANAGED_IDENTITY_CLIENT_ID\ |
| \protocol.md\ | SSRF service URL allowlist, input validation, prototype pollution (per-language), conversation ID truncation, full ConversationClient REST API (10 methods) |
| \README.md\ | \processBody\ return type fix, 5 new rows in language-specific differences table |
| \invoke-activities.md\ | 501 vs 200 dispatch clarification for unhandled invokes |

### Implementation bugs found (not fixed in this PR)
- All 3 languages: missing catch-all invoke handler support
- Node.js + Python: missing outbound trace activity filtering
- Python: returns 501 for invokes when no handlers registered (should be 200 \{}\)