### PR TITLE
docs: improve specs based on compliance audit findings

### DIFF
--- a/specs/Architecture.md
+++ b/specs/Architecture.md
@@ -82,7 +82,6 @@ The library uses separate authentication for each direction:
 │  SendActivityAsync(coreActivity)                    │
 │    (dotnet — serviceUrl/conversationId embedded)    │
 │                                                     │
-│  ● Silently skips trace activity type                │
 │  ● TokenManager acquires/caches outbound token      │
 │    → POST {serviceUrl}v3/conversations/{id}/        │
 │           activities                                │
@@ -119,9 +118,12 @@ Handlers are registered by activity type. When an activity arrives, the matching
 
 Invoke activities are dispatched by `activity.name` instead of `activity.type`. All three languages support `OnInvoke(name, handler)` / `onInvoke(name, handler)` / `on_invoke(name, handler)` for hierarchical dispatch.
 
-Invoke handlers must return an `InvokeResponse` object containing an HTTP status code and optional response body. If no handler is registered for the incoming `activity.name`, the library returns a `501 Not Implemented` response automatically.
+Invoke handlers must return an `InvokeResponse` object containing an HTTP status code and optional response body. The default behavior depends on whether any invoke handlers are registered:
 
-See [Protocol spec — Invoke Activities](./protocol.md#invoke-activities) for the full contract.
+- **No invoke handlers registered at all** → return `200 {}` (bot doesn't handle invokes)
+- **Handlers registered but no match for `activity.name`** → return `501 Not Implemented`
+
+See [Invoke Activities spec — Dispatch Decision Table](./invoke-activities.md#quick-reference-dispatch-decision-table) for the full matrix including CatchAll interaction.
 
 ---
 
@@ -137,8 +139,8 @@ The library implements multiple layers of defense against common attack vectors:
 
 - **SSRF protection**: Service URLs are validated against an allowlist before outbound requests. Allowed patterns: `*.botframework.com`, `*.botframework.us`, `*.botframework.cn`, `*.trafficmanager.net`, and `localhost` (development only). See [Inbound Auth spec](./inbound-auth.md) for details.
 - **JWKS cache with fallback**: JWT signing keys are cached in memory and refreshed on cache miss. Prevents DoS via repeated JWKS endpoint requests while ensuring key rotation support.
-- **Request body size limits**: Node.js implementation enforces a 1 MB request body limit to prevent memory exhaustion attacks.
-- **JSON parsing hardening**: Node.js implementation blocks prototype-pollution keys (`__proto__`, `constructor`, `prototype`) during JSON parsing.
+- **Request body size limits**: Implementations enforce a 1 MB request body limit to prevent memory exhaustion attacks.
+- **JSON parsing hardening**: Node.js implementation blocks prototype-pollution keys (`__proto__`, `constructor`, `prototype`) during JSON parsing. Python strips these for defense-in-depth. .NET's strongly-typed deserialization naturally rejects unknown keys.
 
 ---
 
@@ -146,7 +148,7 @@ The library implements multiple layers of defense against common attack vectors:
 
 These hold in every language implementation. See [AGENTS.md](../AGENTS.md) for the full list.
 
-Key invariants: JWT validation before processing, `CoreActivityBuilder.withConversationReference` routing-field semantics, silent ignore of unregistered activity types, handler exception wrapping, outbound client-credentials auth, middleware registration-order execution, silent skipping of outbound `trace` activity type, and `InvokeResponse` return semantics for invoke handlers.
+Key invariants: JWT validation before processing, `CoreActivityBuilder.withConversationReference` routing-field semantics, silent ignore of unregistered activity types, handler exception wrapping, outbound client-credentials auth, middleware registration-order execution, and `InvokeResponse` return semantics for invoke handlers.
 
 ---
 

--- a/specs/Contributing.md
+++ b/specs/Contributing.md
@@ -27,7 +27,6 @@ These rules apply to **every** language implementation. Violations should be tre
 | Middleware can short-circuit by not calling `next()` | [Protocol — Middleware](./protocol.md#middleware) |
 | CatchAll handler replaces per-type dispatch when set | [Protocol — CatchAll Handler](./protocol.md#catchall-handler) |
 | Unknown JSON properties are preserved on round-trip (extension data) | [Activity Schema — Serialization Rules](./activity-schema.md#serialization-rules) |
-| Outbound `trace` activities are silently skipped | [Protocol — Outbound Activity Filtering](./protocol.md#outbound-activity-filtering) |
 | Outbound requests use OAuth2 client-credentials tokens | [Outbound Auth](./outbound-auth.md) |
 | `CoreActivityBuilder.withConversationReference` swaps from/recipient and copies routing fields | [Activity Schema](./activity-schema.md) |
 

--- a/specs/ProactiveMessaging.md
+++ b/specs/ProactiveMessaging.md
@@ -179,19 +179,6 @@ No additional configuration is needed beyond the standard `CLIENT_ID`, `CLIENT_S
 
 ---
 
-## Outbound Activity Filtering
-
-The `ConversationClient` silently skips certain activity types:
-
-| Skipped type | Reason |
-|--------------|--------|
-| `trace` | Diagnostic-only; not intended for the channel |
-| `invoke` (.NET) | Invoke activities are inbound-only |
-
-See [Protocol — Outbound Activity Filtering](./protocol.md#outbound-activity-filtering).
-
----
-
 ## Common Patterns
 
 ### Timer-based Notification

--- a/specs/inbound-auth.md
+++ b/specs/inbound-auth.md
@@ -113,6 +113,25 @@ The response body is implementation-defined but SHOULD NOT leak internal details
 
 ---
 
+## Cross-Language Auth Parity
+
+All language implementations MUST support the same authentication features. This table tracks which features are required and their implementation status:
+
+| Feature | Required | .NET | Node.js | Python |
+|---------|----------|------|---------|--------|
+| JWT signature verification (JWKS) | ✅ | MSAL + middleware | `jsonwebtoken` + `jwks-rsa` | `PyJWT` + `httpx` |
+| Audience validation (3 formats) | ✅ | ✅ | ✅ | ✅ |
+| Issuer validation (`sts.windows.net` + `login.microsoftonline.com`) | ✅ | ✅ | ✅ | ✅ |
+| Dynamic metadata URL selection by `iss` | ✅ | ✅ | ✅ | ✅ |
+| Metadata URL prefix validation (SSRF defense) | ✅ | ✅ | ✅ | ✅ |
+| JWKS key caching | ✅ | Via MSAL | Via `jwks-rsa` | Manual (in-memory) |
+| Token expiration (`exp` / `nbf`) | ✅ | ✅ | ✅ | ✅ |
+| Auth bypass when `CLIENT_ID` not configured | ✅ | ✅ | ✅ | ✅ |
+
+> **Note**: .NET uses MSAL's built-in JWT validation which handles many of these features natively. Node.js and Python implement validation manually. When adding a new language port, ensure all features in this table are covered.
+
+---
+
 ## References
 
 - [Protocol Spec](./protocol.md) — overall HTTP contract

--- a/specs/invoke-activities.md
+++ b/specs/invoke-activities.md
@@ -262,6 +262,20 @@ Middleware can:
 
 When a CatchAll handler (`OnActivity` / `onActivity` / `on_activity`) is set, **invoke activities bypass invoke-specific dispatch** and are routed to the CatchAll handler like all other activity types. The CatchAll handler replaces ALL dispatch — including invoke dispatch by `activity.name`. If the CatchAll handler needs to return an `InvokeResponse`, it must do so via the framework's invoke response mechanism (e.g., returning from `processBody` or setting the response on the HTTP context).
 
+> **Why CatchAll overrides invoke dispatch**: The CatchAll handler is an escape hatch for bots that want full control over all activity routing. If it only overrode per-type dispatch but not invoke dispatch, a bot using CatchAll would receive some activities through the CatchAll and others through invoke handlers — creating confusing split dispatch. CatchAll means "catch ALL".
+
+### Quick Reference: Dispatch Decision Table
+
+| Invoke handlers registered? | CatchAll set? | `activity.name` matches? | Result |
+|-----------------------------|---------------|--------------------------|--------|
+| None | No | — | **200 `{}`** (bot doesn't handle invokes) |
+| None | Yes | — | **CatchAll handler** receives the activity |
+| Specific only | No | Yes | **Matched handler** runs |
+| Specific only | No | No | **501** (Not Implemented) |
+| Catch-all invoke | No | — | **Catch-all invoke handler** runs |
+| Any | Yes | — | **CatchAll handler** (invoke dispatch bypassed) |
+| Specific + Catch-all invoke | — | — | **Error at registration** (conflict) |
+
 ---
 
 ## Error Handling

--- a/specs/protocol.md
+++ b/specs/protocol.md
@@ -106,7 +106,7 @@ Before processing the activity, implementations MUST:
 
 1. **Validate required fields** — `type` (non-empty string), `serviceUrl` (non-empty string), and `conversation.id` (non-empty string) MUST be present. Return `400` if missing.
 2. **Validate service URL** — see [Service URL Validation](#service-url-validation) below.
-3. **Protect against prototype pollution** — JSON parsers MUST strip keys like `__proto__`, `constructor`, and `prototype` from parsed activity payloads. This is critical for JavaScript/Node.js implementations. Languages without prototype chains (Python, .NET, Go) SHOULD still strip these keys for defense-in-depth.
+3. **Protect against prototype pollution** — In languages with prototype chains (JavaScript/Node.js), JSON parsers MUST strip keys like `__proto__`, `constructor`, and `prototype` from parsed activity payloads. Strongly-typed languages (.NET, Go, Java) naturally reject unknown properties during deserialization and do not need explicit stripping. Dynamic languages without prototype chains (Python, Ruby) SHOULD strip these keys for defense-in-depth, though the risk is lower.
 
 Implementations SHOULD enforce a maximum request body size (recommended: 1 MB) and return `413` on overflow.
 
@@ -430,16 +430,6 @@ On success the Bot Framework returns:
 { "id": "new-activity-id" }
 ```
 
-### Outbound Activity Filtering
-
-Before sending, the conversation client MUST silently skip the following activity types without raising an error:
-
-| Skipped type | Reason |
-|--------------|--------|
-| `trace` | Diagnostic-only; not intended for the channel. |
-
-Skipped activities return an empty/default result immediately.
-
 ### ConversationClient API Surface
 
 Beyond sending activities, the `ConversationClient` wraps the [Bot Framework v3 Conversations REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#conversations-object):
@@ -468,6 +458,20 @@ All methods require outbound authentication (see [Outbound Auth](./outbound-auth
 | `message` | Text message from user or bot |
 
 The type string is open-ended — implementations MUST support registering handlers for arbitrary type values.
+
+---
+
+## Resource Cleanup
+
+`BotApplication` and `ConversationClient` hold HTTP clients and other resources that should be cleaned up when the application shuts down.
+
+| Language | Cleanup mechanism | Details |
+|----------|-------------------|---------|
+| .NET | `IAsyncDisposable` / DI container | ASP.NET Core's DI container manages `HttpClient` lifetime via `IHttpClientFactory`. No explicit cleanup needed when using `BotApp.Create()`. |
+| Node.js | `process.on('SIGTERM', ...)` | The built-in `fetch` API manages connections automatically. No explicit cleanup required. |
+| Python | `async with` context manager or `aclose()` | `BotApplication` implements `__aenter__`/`__aexit__` for use with `async with`. Call `aclose()` explicitly if not using the context manager. This ensures the underlying `httpx.AsyncClient` is properly closed. |
+
+Implementations SHOULD ensure HTTP connections are closed on shutdown. The exact mechanism is language-specific and does not need to be identical across ports.
 
 ---
 


### PR DESCRIPTION
## Summary

Spec improvements based on the cross-language compliance audit. No code changes — documentation only.

### Changes

**Trace filtering removal** (was specced but unnecessary):
- Removed outbound trace activity filtering section from \protocol.md\, \Architecture.md\, \Contributing.md\, and \ProactiveMessaging.md\

**Invoke dispatch clarity**:
- Added a **dispatch decision table** to \invoke-activities.md\ covering all combinations of handler registration, CatchAll, and name matching
- Expanded CatchAll + invoke precedence documentation with rationale for why CatchAll overrides invoke dispatch
- Updated \Architecture.md\ to document the 200-vs-501 default behavior logic

**Auth parity matrix**:
- Added cross-language auth feature parity table to \inbound-auth.md\ tracking which auth features each port must implement

**Security clarifications**:
- Made prototype pollution defense language-conditional (MUST for JS, SHOULD for Python, not needed for .NET)
- Updated body size limit documentation to cover all languages (not just Node.js)

**Resource cleanup**:
- Added new \Resource Cleanup\ section to \protocol.md\ documenting cleanup patterns per language

### Motivation

During the compliance audit (\ix/spec-compliance-audit\ branch), we found several spec ambiguities and gaps that made it harder to verify implementation correctness. These improvements make the specs more precise and actionable for future porting work.