### PR TITLE
test(e2e): add Playwright tests for Teams web client

### DIFF
--- a/e2e/playwright/.env.example
+++ b/e2e/playwright/.env.example
@@ -1,0 +1,2 @@
+# Bot display name in Teams (used for deep link navigation)
+TEAMS_BOT_NAME=MyBot

--- a/e2e/playwright/.gitignore
+++ b/e2e/playwright/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+storageState.json
+test-results/
+playwright-report/
+.env

--- a/e2e/playwright/README.md
+++ b/e2e/playwright/README.md
@@ -1,0 +1,77 @@
+# Playwright E2E Tests for Teams Bots
+
+Prototype E2E tests that drive the **Teams web client** with Playwright to verify bot behavior end-to-end.
+
+## Prerequisites
+
+1. **Node.js** 18+ installed
+2. A **Teams bot** registered and sideloaded in your test tenant (see [specs/Setup.md](../../specs/Setup.md))
+3. The bot **running** and reachable from Teams (via devtunnel or deployed endpoint)
+4. A **test user account** in the tenant where the bot is installed
+
+## Quick Start
+
+```bash
+cd e2e/playwright
+
+# Install dependencies + Playwright browsers
+npm install
+npx playwright install msedge
+
+# Copy and fill in env vars
+cp .env.example .env
+# Edit .env: set TEAMS_BOT_NAME to your bot's display name
+
+# Step 1: Authenticate (interactive — complete MFA in the browser)
+npm run setup
+
+# Step 2: Run tests (headless, uses saved session)
+npm test
+
+# Or run tests headed (useful for debugging)
+npm run test:headed
+```
+
+## How It Works
+
+### Authentication
+
+Since MFA cannot be disabled, authentication is **semi-automated**:
+
+1. `npm run setup` opens an Edge browser and navigates to `teams.microsoft.com`
+2. You complete the login flow manually (email, password, MFA)
+3. Once Teams loads, Playwright saves the browser session to `storageState.json`
+4. Subsequent test runs load this saved session — no login needed
+
+The session typically lasts 12-24 hours. When it expires, tests will fail with a clear message telling you to re-run `npm run setup`.
+
+### Test Structure
+
+- `auth.setup.ts` — Interactive login flow (run separately via `npm run setup`)
+- `teams-helpers.ts` — Reusable helpers (navigate to bot chat, send messages, wait for replies)
+- `tests/echo-bot.spec.ts` — Prototype test: sends a message, verifies the echo reply
+
+### Message Uniqueness
+
+Each test sends messages with a UUID nonce (e.g., `hello from playwright [a1b2c3d4]`) to avoid matching stale messages from previous runs.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "storageState.json not found" | Run `npm run setup` first |
+| "Session expired" | Delete `storageState.json` and re-run `npm run setup` |
+| Tests fail to find the compose box | Teams UI may have changed — update selectors in `teams-helpers.ts` |
+| Bot doesn't reply | Verify the bot is running and the devtunnel is active |
+| Edge not found | Run `npx playwright install msedge` |
+
+## Selector Maintenance
+
+Teams uses `data-tid` attributes which are more stable than CSS classes, but they are **not a public API** and can change when Teams updates. All selectors are centralized in `teams-helpers.ts` for easy maintenance.
+
+## Known Limitations
+
+- **Not CI-ready**: Requires interactive MFA login, so this is a local/manual test tool
+- **Fragile selectors**: Teams web UI can change without notice
+- **Slow**: UI tests take 10-30 seconds each
+- **Single bot**: Currently only tests the echo bot pattern

--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -1,0 +1,55 @@
+/**
+ * Interactive authentication setup for Teams web.
+ *
+ * Run with:  npm run setup
+ *
+ * This opens a headed Edge browser, navigates to Teams, and waits for you to
+ * complete the login flow (including MFA). Once Teams loads, it saves the
+ * browser session to storageState.json for headless test reuse.
+ */
+import { test as setup } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+
+const storageStatePath = path.resolve(__dirname, "storageState.json");
+
+setup("authenticate with Teams", async ({ page }) => {
+  // If we already have a valid session, skip re-authentication
+  if (fs.existsSync(storageStatePath)) {
+    const stats = fs.statSync(storageStatePath);
+    const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
+    if (ageHours < 12) {
+      console.log(
+        `storageState.json is ${ageHours.toFixed(1)}h old — reusing. Delete it to force re-auth.`
+      );
+      return;
+    }
+    console.log(
+      `storageState.json is ${ageHours.toFixed(1)}h old — re-authenticating.`
+    );
+  }
+
+  console.log(
+    "\n👉 Complete the Teams login (including MFA) in the browser window.\n" +
+      "   The test will continue automatically once Teams fully loads.\n"
+  );
+
+  await page.goto("https://teams.microsoft.com/");
+
+  // Wait for a Teams-specific UI element that only appears after successful login.
+  // Use .or() to combine multiple locator strategies for resilience.
+  const teamsLoaded = page
+    .getByPlaceholder("Type a message")
+    .or(page.getByPlaceholder("Type a new message"))
+    .or(page.getByRole("button", { name: "Chat" }))
+    .or(page.getByRole("button", { name: "Activity" }))
+    .first();
+  await teamsLoaded.waitFor({ state: "visible", timeout: 180_000 });
+
+  // Give the SPA a moment to finish settling after the shell appears
+  await page.waitForTimeout(3_000);
+
+  // Save the authenticated session
+  await page.context().storageState({ path: storageStatePath });
+  console.log(`\n✅ Session saved to ${storageStatePath}\n`);
+});

--- a/e2e/playwright/package-lock.json
+++ b/e2e/playwright/package-lock.json
@@ -1,0 +1,92 @@
+{
+  "name": "botas-e2e-playwright",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "botas-e2e-playwright",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+        "dotenv": "^16.4.7"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/playwright/package.json
+++ b/e2e/playwright/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "botas-e2e-playwright",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright E2E tests for botas bots running in Teams",
+  "scripts": {
+    "setup": "npx playwright test --project=auth-setup --headed",
+    "test": "npx playwright test --project=teams-tests",
+    "test:headed": "npx playwright test --project=teams-tests --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "dotenv": "^16.4.7"
+  }
+}

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from "@playwright/test";
+import dotenv from "dotenv";
+import path from "path";
+
+dotenv.config({ path: path.resolve(__dirname, ".env") });
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 90_000,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: false,
+  retries: 0,
+  reporter: [["html", { open: "never" }], ["list"]],
+  use: {
+    baseURL: "https://teams.microsoft.com",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "auth-setup",
+      testMatch: /auth\.setup\.ts/,
+      timeout: 180_000,
+      use: {
+        channel: "msedge",
+        headless: false,
+        actionTimeout: 180_000,
+      },
+    },
+    {
+      name: "teams-tests",
+      testMatch: /tests[\\\/].*\.spec\.ts/,
+      use: {
+        channel: "msedge",
+        storageState: "storageState.json",
+      },
+      // Do NOT depend on auth-setup — run `npm run setup` separately
+    },
+  ],
+});

--- a/e2e/playwright/teams-helpers.ts
+++ b/e2e/playwright/teams-helpers.ts
@@ -1,0 +1,141 @@
+/**
+ * Reusable helpers for interacting with the Teams web client.
+ *
+ * Selectors use data-tid attributes where available (more stable than class names),
+ * but Teams can change these at any time — centralizing them here makes maintenance easier.
+ */
+import { Page, expect } from "@playwright/test";
+import { randomUUID } from "crypto";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Fail fast if the storageState is missing or clearly expired.
+ * Call this at the start of every test to give a clear error message.
+ */
+export function assertStorageStateValid(): void {
+  const statePath = path.resolve(__dirname, "storageState.json");
+  if (!fs.existsSync(statePath)) {
+    throw new Error(
+      "storageState.json not found. Run `npm run setup` to authenticate first."
+    );
+  }
+  const stats = fs.statSync(statePath);
+  const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
+  if (ageHours > 24) {
+    throw new Error(
+      `storageState.json is ${ageHours.toFixed(0)}h old and likely expired. ` +
+        "Run `npm run setup` to re-authenticate."
+    );
+  }
+}
+
+/**
+ * Ensure we're actually logged into Teams and not on a login redirect.
+ */
+export async function ensureTeamsLoaded(page: Page): Promise<void> {
+  await page.goto("https://teams.microsoft.com/");
+
+  // Wait for a Teams-specific UI element that only shows after login
+  try {
+    const teamsLoaded = page
+      .getByPlaceholder("Type a message")
+      .or(page.getByPlaceholder("Type a new message"))
+      .or(page.getByRole("button", { name: "Chat" }))
+      .or(page.getByRole("button", { name: "Activity" }))
+      .first();
+    await teamsLoaded.waitFor({ state: "visible", timeout: 30_000 });
+  } catch {
+    const url = page.url();
+    if (
+      url.includes("login.microsoftonline.com") ||
+      url.includes("login.live.com")
+    ) {
+      throw new Error(
+        "Session expired — redirected to login page. Run `npm run setup` to re-authenticate."
+      );
+    }
+    throw new Error(
+      "Teams did not load within 30 seconds. Check your network and session state."
+    );
+  }
+}
+
+/**
+ * Navigate to a 1:1 chat with the bot.
+ * Clicks the bot entry in the Chat list sidebar — more reliable than search.
+ */
+export async function navigateToBotChat(
+  page: Page,
+  botName: string
+): Promise<void> {
+  // Ensure we're on the Chat tab first
+  await page.getByRole("button", { name: "Chat" }).click();
+  await page.waitForTimeout(1_000);
+
+  // Click the bot in the chat list sidebar
+  const botEntry = page.locator(`[data-tid="chat-list"] >> text="${botName}"`).first()
+    .or(page.getByText(botName, { exact: true }).first());
+  await botEntry.click();
+  await page.waitForTimeout(2_000);
+}
+
+/**
+ * Send a message in the current Teams chat.
+ * Appends a UUID nonce to make the message unique for reply matching.
+ *
+ * @returns The full message text that was sent (including nonce)
+ */
+export async function sendMessage(
+  page: Page,
+  text: string
+): Promise<string> {
+  const nonce = randomUUID().slice(0, 8);
+  const fullText = `${text} [${nonce}]`;
+
+  // Teams compose box — the rich text editor may not respond to fill(),
+  // so use click + keyboard typing instead
+  const composeBox = page.getByPlaceholder("Type a message").first();
+
+  await composeBox.click();
+  await page.keyboard.type(fullText, { delay: 50 });
+  await page.keyboard.press("Enter");
+
+  return fullText;
+}
+
+/**
+ * Wait for the bot to reply with a message containing the expected text.
+ * Looks for messages in the chat that contain the nonce from the sent message.
+ *
+ * @param sentText - The full text that was sent (including nonce), used to extract the nonce
+ * @param timeout - How long to wait for the reply (default: 15s)
+ * @returns The text content of the bot's reply
+ */
+export async function waitForBotReply(
+  page: Page,
+  sentText: string,
+  timeout = 15_000
+): Promise<string> {
+  // Extract the nonce from the sent message
+  const nonceMatch = sentText.match(/\[([a-f0-9]+)\]/);
+  if (!nonceMatch) {
+    throw new Error(
+      `Could not extract nonce from sent message: "${sentText}"`
+    );
+  }
+  const nonce = nonceMatch[1];
+
+  // Wait for a message that contains the nonce but is NOT our sent message.
+  // Bot echo replies contain the original text. We use a broad text search
+  // since Teams message container selectors change across versions.
+  // The bot reply format is typically "user said: <text>" or "Echo: <text>".
+  const replyLocator = page
+    .getByText(new RegExp(`(echo|said).*${nonce}|${nonce}.*(echo|said)`, "i"))
+    .first();
+
+  await expect(replyLocator).toBeVisible({ timeout });
+
+  const replyText = await replyLocator.innerText();
+  return replyText;
+}

--- a/e2e/playwright/tests/echo-bot.spec.ts
+++ b/e2e/playwright/tests/echo-bot.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Prototype E2E test: send a message to the echo bot via Teams web and verify the reply.
+ *
+ * Prerequisites:
+ *   1. Run `npm run setup` to authenticate with Teams (interactive, MFA supported)
+ *   2. Have the echo bot running and registered in Teams (see specs/Setup.md)
+ *   3. Set TEAMS_BOT_NAME in .env to the bot's display name
+ *
+ * Run with:  npm test
+ */
+import { test, expect } from "@playwright/test";
+import {
+  assertStorageStateValid,
+  ensureTeamsLoaded,
+  navigateToBotChat,
+  sendMessage,
+  waitForBotReply,
+} from "../teams-helpers";
+
+const BOT_NAME = process.env.TEAMS_BOT_NAME || "EchoBot";
+
+test.beforeEach(async () => {
+  assertStorageStateValid();
+});
+
+test("echo bot replies with the sent message", async ({ page }) => {
+  // Ensure we're logged into Teams
+  await ensureTeamsLoaded(page);
+
+  // Navigate to the bot's 1:1 chat
+  await navigateToBotChat(page, BOT_NAME);
+
+  // Send a unique message
+  const sentText = await sendMessage(page, "hello from playwright");
+
+  // Wait for the bot's echo reply
+  const replyText = await waitForBotReply(page, sentText);
+
+  // The echo bot should reply with a message containing our original text
+  expect(replyText.toLowerCase()).toContain("hello from playwright");
+  // Verify the nonce is in the reply (proves it's not a stale message)
+  const nonceMatch = sentText.match(/\[([a-f0-9]+)\]/);
+  expect(replyText).toContain(nonceMatch![1]);
+});


### PR DESCRIPTION
## Summary

Adds Playwright-based E2E tests that automate the real Teams web client to validate bot interactions end-to-end.

### What's included

- **\uth.setup.ts\** — Interactive Teams login with MFA support, saves \storageState.json\ for reuse across test runs
- **\	eams-helpers.ts\** — Centralized helpers: \
avigateToBotChat()\, \sendMessage()\ (with UUID nonce for message matching), \waitForBotReply()\
- **\	ests/echo-bot.spec.ts\** — Sends a message to the bot via Teams compose box, verifies the echo reply appears
- **\playwright.config.ts\** — Two projects: auth-setup (headed, 180s timeout for MFA) + teams-tests (headless, msedge channel)
- **\README.md\** — Setup guide, usage instructions, and troubleshooting

### How it works

1. \
pm run setup\ opens Teams in a headed browser for interactive login (one-time, session lasts ~24h)
2. \
pm test\ runs tests headless using the saved session
3. Messages include a UUID nonce so assertions match the exact reply

### Tested
- ✅ Headed mode (interactive login + test)
- ✅ Headless mode (reusing saved session)

### Notes
- \.env\, \storageState.json\, \
ode_modules/\, and test output are gitignored
- Requires \TEAMS_BOT_NAME\ in \.env\ (see \.env.example\)
- Auth session expires after ~24 hours; re-run \
pm run setup\ to refresh