### PR TITLE
test(e2e): add Playwright invoke test and Adaptive Card handlers

### DIFF
--- a/dotnet/samples/EchoBot/Program.cs
+++ b/dotnet/samples/EchoBot/Program.cs
@@ -1,10 +1,74 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Botas;
 
 var app = BotApp.Create(args);
 
 app.On("message", async (context, ct) =>
 {
-    await context.SendAsync($"Echo: {context.Activity.Text}, from aspnet", ct);
+    var text = (context.Activity.Text ?? "").Trim();
+    if (text.Equals("card", StringComparison.OrdinalIgnoreCase))
+    {
+        var card = new JsonObject
+        {
+            ["type"] = "AdaptiveCard",
+            ["version"] = "1.5",
+            ["body"] = new JsonArray
+            {
+                new JsonObject { ["type"] = "TextBlock", ["text"] = "Invoke Test Card", ["weight"] = "bolder" },
+                new JsonObject { ["type"] = "TextBlock", ["text"] = "Click the button to trigger an invoke." }
+            },
+            ["actions"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["type"] = "Action.Execute",
+                    ["title"] = "Submit",
+                    ["verb"] = "test",
+                    ["data"] = new JsonObject { ["source"] = "e2e" }
+                }
+            }
+        };
+        var reply = new CoreActivity("message")
+        {
+            Attachments = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["contentType"] = "application/vnd.microsoft.card.adaptive",
+                    ["content"] = card
+                }
+            }
+        };
+        await context.SendAsync(reply, ct);
+    }
+    else
+    {
+        await context.SendAsync($"Echo: {context.Activity.Text}, from aspnet", ct);
+    }
+});
+
+app.OnInvoke("adaptiveCard/action", async (context, ct) =>
+{
+    var responseCard = new JsonObject
+    {
+        ["type"] = "AdaptiveCard",
+        ["version"] = "1.5",
+        ["body"] = new JsonArray
+        {
+            new JsonObject { ["type"] = "TextBlock", ["text"] = "✅ Invoke received!", ["weight"] = "bolder" }
+        }
+    };
+    return new InvokeResponse
+    {
+        Status = 200,
+        Body = new
+        {
+            statusCode = 200,
+            type = "application/vnd.microsoft.card.adaptive",
+            value = responseCard
+        }
+    };
 });
 
 app.OnInvoke("test/echo", async (context, ct) =>

--- a/e2e/playwright/.env.example
+++ b/e2e/playwright/.env.example
@@ -1,0 +1,2 @@
+# Bot display name in Teams (used for deep link navigation)
+TEAMS_BOT_NAME=MyBot

--- a/e2e/playwright/.gitignore
+++ b/e2e/playwright/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+storageState.json
+test-results/
+playwright-report/
+.env

--- a/e2e/playwright/README.md
+++ b/e2e/playwright/README.md
@@ -1,0 +1,77 @@
+# Playwright E2E Tests for Teams Bots
+
+Prototype E2E tests that drive the **Teams web client** with Playwright to verify bot behavior end-to-end.
+
+## Prerequisites
+
+1. **Node.js** 18+ installed
+2. A **Teams bot** registered and sideloaded in your test tenant (see [specs/Setup.md](../../specs/Setup.md))
+3. The bot **running** and reachable from Teams (via devtunnel or deployed endpoint)
+4. A **test user account** in the tenant where the bot is installed
+
+## Quick Start
+
+```bash
+cd e2e/playwright
+
+# Install dependencies + Playwright browsers
+npm install
+npx playwright install msedge
+
+# Copy and fill in env vars
+cp .env.example .env
+# Edit .env: set TEAMS_BOT_NAME to your bot's display name
+
+# Step 1: Authenticate (interactive — complete MFA in the browser)
+npm run setup
+
+# Step 2: Run tests (headless, uses saved session)
+npm test
+
+# Or run tests headed (useful for debugging)
+npm run test:headed
+```
+
+## How It Works
+
+### Authentication
+
+Since MFA cannot be disabled, authentication is **semi-automated**:
+
+1. `npm run setup` opens an Edge browser and navigates to `teams.microsoft.com`
+2. You complete the login flow manually (email, password, MFA)
+3. Once Teams loads, Playwright saves the browser session to `storageState.json`
+4. Subsequent test runs load this saved session — no login needed
+
+The session typically lasts 12-24 hours. When it expires, tests will fail with a clear message telling you to re-run `npm run setup`.
+
+### Test Structure
+
+- `auth.setup.ts` — Interactive login flow (run separately via `npm run setup`)
+- `teams-helpers.ts` — Reusable helpers (navigate to bot chat, send messages, wait for replies)
+- `tests/echo-bot.spec.ts` — Prototype test: sends a message, verifies the echo reply
+
+### Message Uniqueness
+
+Each test sends messages with a UUID nonce (e.g., `hello from playwright [a1b2c3d4]`) to avoid matching stale messages from previous runs.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "storageState.json not found" | Run `npm run setup` first |
+| "Session expired" | Delete `storageState.json` and re-run `npm run setup` |
+| Tests fail to find the compose box | Teams UI may have changed — update selectors in `teams-helpers.ts` |
+| Bot doesn't reply | Verify the bot is running and the devtunnel is active |
+| Edge not found | Run `npx playwright install msedge` |
+
+## Selector Maintenance
+
+Teams uses `data-tid` attributes which are more stable than CSS classes, but they are **not a public API** and can change when Teams updates. All selectors are centralized in `teams-helpers.ts` for easy maintenance.
+
+## Known Limitations
+
+- **Not CI-ready**: Requires interactive MFA login, so this is a local/manual test tool
+- **Fragile selectors**: Teams web UI can change without notice
+- **Slow**: UI tests take 10-30 seconds each
+- **Single bot**: Currently only tests the echo bot pattern

--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -1,0 +1,55 @@
+/**
+ * Interactive authentication setup for Teams web.
+ *
+ * Run with:  npm run setup
+ *
+ * This opens a headed Edge browser, navigates to Teams, and waits for you to
+ * complete the login flow (including MFA). Once Teams loads, it saves the
+ * browser session to storageState.json for headless test reuse.
+ */
+import { test as setup } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+
+const storageStatePath = path.resolve(__dirname, "storageState.json");
+
+setup("authenticate with Teams", async ({ page }) => {
+  // If we already have a valid session, skip re-authentication
+  if (fs.existsSync(storageStatePath)) {
+    const stats = fs.statSync(storageStatePath);
+    const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
+    if (ageHours < 12) {
+      console.log(
+        `storageState.json is ${ageHours.toFixed(1)}h old — reusing. Delete it to force re-auth.`
+      );
+      return;
+    }
+    console.log(
+      `storageState.json is ${ageHours.toFixed(1)}h old — re-authenticating.`
+    );
+  }
+
+  console.log(
+    "\n👉 Complete the Teams login (including MFA) in the browser window.\n" +
+      "   The test will continue automatically once Teams fully loads.\n"
+  );
+
+  await page.goto("https://teams.microsoft.com/");
+
+  // Wait for a Teams-specific UI element that only appears after successful login.
+  // Use .or() to combine multiple locator strategies for resilience.
+  const teamsLoaded = page
+    .getByPlaceholder("Type a message")
+    .or(page.getByPlaceholder("Type a new message"))
+    .or(page.getByRole("button", { name: "Chat" }))
+    .or(page.getByRole("button", { name: "Activity" }))
+    .first();
+  await teamsLoaded.waitFor({ state: "visible", timeout: 180_000 });
+
+  // Give the SPA a moment to finish settling after the shell appears
+  await page.waitForTimeout(3_000);
+
+  // Save the authenticated session
+  await page.context().storageState({ path: storageStatePath });
+  console.log(`\n✅ Session saved to ${storageStatePath}\n`);
+});

--- a/e2e/playwright/package-lock.json
+++ b/e2e/playwright/package-lock.json
@@ -1,0 +1,92 @@
+{
+  "name": "botas-e2e-playwright",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "botas-e2e-playwright",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+        "dotenv": "^16.4.7"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/playwright/package.json
+++ b/e2e/playwright/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "botas-e2e-playwright",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright E2E tests for botas bots running in Teams",
+  "scripts": {
+    "setup": "npx playwright test --project=auth-setup --headed",
+    "test": "npx playwright test --project=teams-tests",
+    "test:headed": "npx playwright test --project=teams-tests --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "dotenv": "^16.4.7"
+  }
+}

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from "@playwright/test";
+import dotenv from "dotenv";
+import path from "path";
+
+dotenv.config({ path: path.resolve(__dirname, ".env") });
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 90_000,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: false,
+  retries: 0,
+  reporter: [["html", { open: "never" }], ["list"]],
+  use: {
+    baseURL: "https://teams.microsoft.com",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "auth-setup",
+      testMatch: /auth\.setup\.ts/,
+      timeout: 180_000,
+      use: {
+        channel: "msedge",
+        headless: false,
+        actionTimeout: 180_000,
+      },
+    },
+    {
+      name: "teams-tests",
+      testMatch: /tests[\\\/].*\.spec\.ts/,
+      use: {
+        channel: "msedge",
+        storageState: "storageState.json",
+      },
+      // Do NOT depend on auth-setup — run `npm run setup` separately
+    },
+  ],
+});

--- a/e2e/playwright/teams-helpers.ts
+++ b/e2e/playwright/teams-helpers.ts
@@ -1,0 +1,141 @@
+/**
+ * Reusable helpers for interacting with the Teams web client.
+ *
+ * Selectors use data-tid attributes where available (more stable than class names),
+ * but Teams can change these at any time — centralizing them here makes maintenance easier.
+ */
+import { Page, expect } from "@playwright/test";
+import { randomUUID } from "crypto";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Fail fast if the storageState is missing or clearly expired.
+ * Call this at the start of every test to give a clear error message.
+ */
+export function assertStorageStateValid(): void {
+  const statePath = path.resolve(__dirname, "storageState.json");
+  if (!fs.existsSync(statePath)) {
+    throw new Error(
+      "storageState.json not found. Run `npm run setup` to authenticate first."
+    );
+  }
+  const stats = fs.statSync(statePath);
+  const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
+  if (ageHours > 24) {
+    throw new Error(
+      `storageState.json is ${ageHours.toFixed(0)}h old and likely expired. ` +
+        "Run `npm run setup` to re-authenticate."
+    );
+  }
+}
+
+/**
+ * Ensure we're actually logged into Teams and not on a login redirect.
+ */
+export async function ensureTeamsLoaded(page: Page): Promise<void> {
+  await page.goto("https://teams.microsoft.com/");
+
+  // Wait for a Teams-specific UI element that only shows after login
+  try {
+    const teamsLoaded = page
+      .getByPlaceholder("Type a message")
+      .or(page.getByPlaceholder("Type a new message"))
+      .or(page.getByRole("button", { name: "Chat" }))
+      .or(page.getByRole("button", { name: "Activity" }))
+      .first();
+    await teamsLoaded.waitFor({ state: "visible", timeout: 30_000 });
+  } catch {
+    const url = page.url();
+    if (
+      url.includes("login.microsoftonline.com") ||
+      url.includes("login.live.com")
+    ) {
+      throw new Error(
+        "Session expired — redirected to login page. Run `npm run setup` to re-authenticate."
+      );
+    }
+    throw new Error(
+      "Teams did not load within 30 seconds. Check your network and session state."
+    );
+  }
+}
+
+/**
+ * Navigate to a 1:1 chat with the bot.
+ * Clicks the bot entry in the Chat list sidebar — more reliable than search.
+ */
+export async function navigateToBotChat(
+  page: Page,
+  botName: string
+): Promise<void> {
+  // Ensure we're on the Chat tab first
+  await page.getByRole("button", { name: "Chat" }).click();
+  await page.waitForTimeout(1_000);
+
+  // Click the bot in the chat list sidebar
+  const botEntry = page.locator(`[data-tid="chat-list"] >> text="${botName}"`).first()
+    .or(page.getByText(botName, { exact: true }).first());
+  await botEntry.click();
+  await page.waitForTimeout(2_000);
+}
+
+/**
+ * Send a message in the current Teams chat.
+ * Appends a UUID nonce to make the message unique for reply matching.
+ *
+ * @returns The full message text that was sent (including nonce)
+ */
+export async function sendMessage(
+  page: Page,
+  text: string
+): Promise<string> {
+  const nonce = randomUUID().slice(0, 8);
+  const fullText = `${text} [${nonce}]`;
+
+  // Teams compose box — the rich text editor may not respond to fill(),
+  // so use click + keyboard typing instead
+  const composeBox = page.getByPlaceholder("Type a message").first();
+
+  await composeBox.click();
+  await page.keyboard.type(fullText, { delay: 50 });
+  await page.keyboard.press("Enter");
+
+  return fullText;
+}
+
+/**
+ * Wait for the bot to reply with a message containing the expected text.
+ * Looks for messages in the chat that contain the nonce from the sent message.
+ *
+ * @param sentText - The full text that was sent (including nonce), used to extract the nonce
+ * @param timeout - How long to wait for the reply (default: 15s)
+ * @returns The text content of the bot's reply
+ */
+export async function waitForBotReply(
+  page: Page,
+  sentText: string,
+  timeout = 15_000
+): Promise<string> {
+  // Extract the nonce from the sent message
+  const nonceMatch = sentText.match(/\[([a-f0-9]+)\]/);
+  if (!nonceMatch) {
+    throw new Error(
+      `Could not extract nonce from sent message: "${sentText}"`
+    );
+  }
+  const nonce = nonceMatch[1];
+
+  // Wait for a message that contains the nonce but is NOT our sent message.
+  // Bot echo replies contain the original text. We use a broad text search
+  // since Teams message container selectors change across versions.
+  // The bot reply format is typically "user said: <text>" or "Echo: <text>".
+  const replyLocator = page
+    .getByText(new RegExp(`(echo|said).*${nonce}|${nonce}.*(echo|said)`, "i"))
+    .first();
+
+  await expect(replyLocator).toBeVisible({ timeout });
+
+  const replyText = await replyLocator.innerText();
+  return replyText;
+}

--- a/e2e/playwright/tests/echo-bot.spec.ts
+++ b/e2e/playwright/tests/echo-bot.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Prototype E2E test: send a message to the echo bot via Teams web and verify the reply.
+ *
+ * Prerequisites:
+ *   1. Run `npm run setup` to authenticate with Teams (interactive, MFA supported)
+ *   2. Have the echo bot running and registered in Teams (see specs/Setup.md)
+ *   3. Set TEAMS_BOT_NAME in .env to the bot's display name
+ *
+ * Run with:  npm test
+ */
+import { test, expect } from "@playwright/test";
+import {
+  assertStorageStateValid,
+  ensureTeamsLoaded,
+  navigateToBotChat,
+  sendMessage,
+  waitForBotReply,
+} from "../teams-helpers";
+
+const BOT_NAME = process.env.TEAMS_BOT_NAME || "EchoBot";
+
+test.beforeEach(async () => {
+  assertStorageStateValid();
+});
+
+test("echo bot replies with the sent message", async ({ page }) => {
+  // Ensure we're logged into Teams
+  await ensureTeamsLoaded(page);
+
+  // Navigate to the bot's 1:1 chat
+  await navigateToBotChat(page, BOT_NAME);
+
+  // Send a unique message
+  const sentText = await sendMessage(page, "hello from playwright");
+
+  // Wait for the bot's echo reply
+  const replyText = await waitForBotReply(page, sentText);
+
+  // The echo bot should reply with a message containing our original text
+  expect(replyText.toLowerCase()).toContain("hello from playwright");
+  // Verify the nonce is in the reply (proves it's not a stale message)
+  const nonceMatch = sentText.match(/\[([a-f0-9]+)\]/);
+  expect(replyText).toContain(nonceMatch![1]);
+});

--- a/e2e/playwright/tests/invoke-bot.spec.ts
+++ b/e2e/playwright/tests/invoke-bot.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * E2E test: trigger an invoke via Adaptive Card button click in Teams.
+ *
+ * The echo bot sends an Adaptive Card when it receives "card".
+ * Clicking the card's "Submit" button triggers an adaptiveCard/action invoke.
+ * The bot responds by updating the card to show "Invoke received!".
+ *
+ * Prerequisites:
+ *   1. Run `npm run setup` to authenticate with Teams
+ *   2. Have the echo bot running with the card/invoke handlers
+ *   3. Set TEAMS_BOT_NAME in .env
+ */
+import { test, expect } from "@playwright/test";
+import {
+  assertStorageStateValid,
+  ensureTeamsLoaded,
+  navigateToBotChat,
+  sendMessage,
+} from "../teams-helpers";
+
+const BOT_NAME = process.env.TEAMS_BOT_NAME || "EchoBot";
+
+test.beforeEach(async () => {
+  assertStorageStateValid();
+});
+
+test("adaptive card invoke updates the card", async ({ page }) => {
+  await ensureTeamsLoaded(page);
+  await navigateToBotChat(page, BOT_NAME);
+
+  // Send "card" to trigger the bot to send an Adaptive Card
+  await sendMessage(page, "card");
+
+  // Wait for the Adaptive Card to appear with the Submit button
+  const submitButton = page.getByRole("button", { name: "Submit" }).last();
+  await expect(submitButton).toBeVisible({ timeout: 15_000 });
+
+  // Click the Submit button to trigger the invoke
+  await submitButton.click();
+
+  // Wait for the card to update with the invoke response
+  const invokeResult = page.getByText("Invoke received!").last();
+  await expect(invokeResult).toBeVisible({ timeout: 15_000 });
+});

--- a/node/samples/echo-bot/index.ts
+++ b/node/samples/echo-bot/index.ts
@@ -6,7 +6,48 @@ import { BotApp } from 'botas-express'
 const app = new BotApp()
 
 app.on('message', async (ctx) => {
-  await ctx.send(`You said: ${ctx.activity.text}`)
+  const text = (ctx.activity.text ?? '').trim()
+  if (text.toLowerCase() === 'card') {
+    await ctx.send({
+      type: 'message',
+      attachments: [{
+        contentType: 'application/vnd.microsoft.card.adaptive',
+        content: {
+          type: 'AdaptiveCard',
+          version: '1.5',
+          body: [
+            { type: 'TextBlock', text: 'Invoke Test Card', weight: 'bolder' },
+            { type: 'TextBlock', text: 'Click the button to trigger an invoke.' }
+          ],
+          actions: [{
+            type: 'Action.Execute',
+            title: 'Submit',
+            verb: 'test',
+            data: { source: 'e2e' }
+          }]
+        }
+      }]
+    })
+  } else {
+    await ctx.send(`You said: ${ctx.activity.text}`)
+  }
+})
+
+app.onInvoke('adaptiveCard/action', async (ctx) => {
+  return {
+    status: 200,
+    body: {
+      statusCode: 200,
+      type: 'application/vnd.microsoft.card.adaptive',
+      value: {
+        type: 'AdaptiveCard',
+        version: '1.5',
+        body: [
+          { type: 'TextBlock', text: '✅ Invoke received!', weight: 'bolder' }
+        ]
+      }
+    }
+  }
 })
 
 app.onInvoke('test/echo', async (ctx) => {

--- a/python/samples/echo-bot/main.py
+++ b/python/samples/echo-bot/main.py
@@ -9,7 +9,52 @@ app = BotApp()
 
 @app.on("message")
 async def on_message(ctx):
-    await ctx.send(f"You said: {ctx.activity.text}")
+    text = (ctx.activity.text or "").strip()
+    if text.lower() == "card":
+        await ctx.send(
+            {
+                "type": "message",
+                "attachments": [
+                    {
+                        "contentType": "application/vnd.microsoft.card.adaptive",
+                        "content": {
+                            "type": "AdaptiveCard",
+                            "version": "1.5",
+                            "body": [
+                                {"type": "TextBlock", "text": "Invoke Test Card", "weight": "bolder"},
+                                {"type": "TextBlock", "text": "Click the button to trigger an invoke."},
+                            ],
+                            "actions": [
+                                {
+                                    "type": "Action.Execute",
+                                    "title": "Submit",
+                                    "verb": "test",
+                                    "data": {"source": "e2e"},
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+    else:
+        await ctx.send(f"You said: {ctx.activity.text}")
+
+
+@app.on_invoke("adaptiveCard/action")
+async def on_invoke_action(ctx):
+    return InvokeResponse(
+        status=200,
+        body={
+            "statusCode": 200,
+            "type": "application/vnd.microsoft.card.adaptive",
+            "value": {
+                "type": "AdaptiveCard",
+                "version": "1.5",
+                "body": [{"type": "TextBlock", "text": "✅ Invoke received!", "weight": "bolder"}],
+            },
+        },
+    )
 
 
 @app.on_invoke("test/echo")


### PR DESCRIPTION
## Summary

Adds a Playwright E2E test for invoke activities (Adaptive Card button clicks) and the supporting handlers in all 3 echo bot samples.

### Changes

**Playwright test** (\2e/playwright/tests/invoke-bot.spec.ts\):
- Sends \card\ to the bot → bot replies with an Adaptive Card
- Clicks the \Submit\ button → triggers \daptiveCard/action\ invoke
- Verifies the card updates with \✅ Invoke received!\

**Echo bot samples** (all 3 languages):
- Added \card\ message handler — sends an Adaptive Card with an Action.Execute button
- Added \daptiveCard/action\ invoke handler — returns updated card on button click
- Kept existing \	est/echo\ invoke handler for API-level E2E tests

### E2E Results (API tests, 5 per language)

| Language | Result |
|----------|--------|
| .NET     | 5/5 ✅ |
| Node.js  | 5/5 ✅ |
| Python   | 5/5 ✅ |

Depends on #184 (Playwright infrastructure).