### PR TITLE
fix: E2E workflow reliability and CD Python permissions

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -146,6 +146,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
     defaults:
       run:
         working-directory: python/packages/botas

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,7 @@ jobs:
   e2e-dotnet:
     if: inputs.language == 'all' || inputs.language == 'dotnet'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       CLIENT_ID: ${{ secrets.CLIENT_ID }}
       CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
@@ -43,13 +44,18 @@ jobs:
 
       - name: Start .NET test-bot
         run: |
-          dotnet run --project dotnet/samples/TestBot --no-build &
+          dotnet run --project dotnet/samples/TestBot --no-build --urls http://0.0.0.0:3978 \
+            > bot.log 2>&1 &
           echo "BOT_PID=$!" >> "$GITHUB_ENV"
+        env:
+          AzureAd__ClientId: ${{ secrets.CLIENT_ID }}
+          AzureAd__ClientCredentials__0__ClientSecret: ${{ secrets.CLIENT_SECRET }}
+          AzureAd__TenantId: ${{ secrets.TENANT_ID }}
 
       - name: Wait for bot
         run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3978/api/messages -X POST -H "Content-Type: application/json" -d '{}' > /dev/null 2>&1; then
+          for i in $(seq 1 60); do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:3978/api/messages -X POST -H "Content-Type: application/json" -d '{}' 2>/dev/null | grep -qE "^(200|401|405)"; then
               echo "Bot is ready"
               exit 0
             fi
@@ -72,9 +78,17 @@ jobs:
         if: always()
         run: kill $BOT_PID 2>/dev/null || true
 
+      - name: Upload bot logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bot-logs-dotnet
+          path: bot.log
+
   e2e-node:
     if: inputs.language == 'all' || inputs.language == 'node'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       CLIENT_ID: ${{ secrets.CLIENT_ID }}
       CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
@@ -110,13 +124,13 @@ jobs:
       - name: Start Node.js test-bot
         run: |
           cd node
-          npx tsx samples/test-bot/index.ts &
+          npx tsx samples/test-bot/index.ts > ../bot.log 2>&1 &
           echo "BOT_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for bot
         run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3978/api/messages -X POST -H "Content-Type: application/json" -d '{}' > /dev/null 2>&1; then
+          for i in $(seq 1 60); do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:3978/api/messages -X POST -H "Content-Type: application/json" -d '{}' 2>/dev/null | grep -qE "^(200|401|405)"; then
               echo "Bot is ready"
               exit 0
             fi
@@ -139,9 +153,17 @@ jobs:
         if: always()
         run: kill $BOT_PID 2>/dev/null || true
 
+      - name: Upload bot logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bot-logs-node
+          path: bot.log
+
   e2e-python:
     if: inputs.language == 'all' || inputs.language == 'python'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       CLIENT_ID: ${{ secrets.CLIENT_ID }}
       CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
@@ -172,13 +194,13 @@ jobs:
       - name: Start Python test-bot
         run: |
           cd python/samples/test-bot
-          python main.py &
+          python main.py > ../../../bot.log 2>&1 &
           echo "BOT_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for bot
         run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3978/api/messages -X POST -H "Content-Type: application/json" -d '{}' > /dev/null 2>&1; then
+          for i in $(seq 1 60); do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:3978/api/messages -X POST -H "Content-Type: application/json" -d '{}' 2>/dev/null | grep -qE "^(200|401|405)"; then
               echo "Bot is ready"
               exit 0
             fi
@@ -200,3 +222,10 @@ jobs:
       - name: Stop bot
         if: always()
         run: kill $BOT_PID 2>/dev/null || true
+
+      - name: Upload bot logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bot-logs-python
+          path: bot.log


### PR DESCRIPTION
## Fixes

### E2E workflow (\2e.yml\)
- **Fix .NET bot startup**: pass \--urls http://0.0.0.0:3978\ (launchSettings.json is gitignored) and \AzureAd__*\ env vars
- **Fix health check**: accept HTTP 401 as 'bot is ready' (auth-protected bots reject unauthenticated probes)
- **Add \	imeout-minutes: 15\** to all jobs — prevents 6-hour hangs if a bot deadlocks
- **Bot log capture**: redirect bot stdout/stderr to \ot.log\, upload as artifact on failure for debugging
- **Increase health check timeout** to 60 seconds for slower CI runners

### CD workflow (\CD.yml\)
- **Add \id-token: write\** to Python job permissions — required for PyPI trusted publishing via OIDC

## Review
Reviewed by DevOps specialist (Squad). All findings addressed.