### PR TITLE
fix: E2E workflow .NET outbound auth and Python debug logging

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,8 +49,10 @@ jobs:
           echo "BOT_PID=$!" >> "$GITHUB_ENV"
         env:
           AzureAd__ClientId: ${{ secrets.CLIENT_ID }}
+          AzureAd__ClientCredentials__0__SourceType: ClientSecret
           AzureAd__ClientCredentials__0__ClientSecret: ${{ secrets.CLIENT_SECRET }}
           AzureAd__TenantId: ${{ secrets.TENANT_ID }}
+          AzureAd__Instance: https://login.microsoftonline.com/
 
       - name: Wait for bot
         run: |

--- a/python/samples/test-bot/main.py
+++ b/python/samples/test-bot/main.py
@@ -3,10 +3,10 @@
 
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
-
 from botas import InvokeResponse
 from botas_fastapi import BotApp
+
+logging.basicConfig(level=logging.DEBUG)
 
 app = BotApp()
 

--- a/python/samples/test-bot/main.py
+++ b/python/samples/test-bot/main.py
@@ -1,6 +1,10 @@
 # Test Bot — feature-rich bot for E2E/Playwright testing
 # Run: python main.py
 
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
 from botas import InvokeResponse
 from botas_fastapi import BotApp
 


### PR DESCRIPTION
## Fixes

### .NET E2E (500 InternalServerError on echo)
**Root cause**: Missing \AzureAd__ClientCredentials__0__SourceType=ClientSecret\ and \AzureAd__Instance\ env vars. Without \SourceType\, Microsoft.Identity.Web can't identify the credential type for outbound token acquisition. Inbound JWT validation passes, but \ConversationClient.SendActivityAsync()\ fails when acquiring outbound tokens → handler throws → 500.

**Fix**: Add the two missing env vars to the .NET bot start step.

### Python E2E (401 on authenticated requests)  
**Investigation**: Auth code is correct (audience, issuer, JWKS all match). Tests pass locally. Added \logging.basicConfig(level=logging.DEBUG)\ to the test-bot to capture the exact JWT validation failure in CI. The bot log artifact will now contain detailed auth debugging info.

## Verification
- Both .NET and Python E2E tests pass locally with credentials from \.env\
- Node.js E2E already passes in CI (no changes needed)