### PR TITLE
fix: E2E Python pip install - prevent PyPI override of editable install

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -186,9 +186,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Python packages
-        run: |
-          pip install -e python/packages/botas
-          pip install -e python/packages/botas-fastapi
+        run: pip install -e python/packages/botas -e python/packages/botas-fastapi
 
       - name: Build E2E tests
         run: dotnet build e2e/dotnet/Botas.E2ETests.csproj


### PR DESCRIPTION
## Problem
The Python E2E job was failing with 401 errors because the wrong version of \otas\ was running.

**Root cause**: The e2e.yml installed packages in two separate pip commands:
1. \pip install -e python/packages/botas\ → editable install version \