### PR TITLE
fix: E2E Python - relax botas-fastapi dependency and fix pip install

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -186,9 +186,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Python packages
-        run: |
-          pip install -e python/packages/botas
-          pip install -e python/packages/botas-fastapi
+        run: pip install -e python/packages/botas -e python/packages/botas-fastapi
 
       - name: Build E2E tests
         run: dotnet build e2e/dotnet/Botas.E2ETests.csproj

--- a/python/packages/botas-fastapi/pyproject.toml
+++ b/python/packages/botas-fastapi/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.12"
 dependencies = [
-    "botas>=0.1.0",
+    "botas",
     "fastapi>=0.111",
     "uvicorn[standard]>=0.30",
 ]


### PR DESCRIPTION
## Problem
Python E2E job fails because \otas-fastapi\ requires \otas>=0.1.0\ but the source version is \