### PR TITLE
feat: E2E as release gate for CD pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,20 @@ on:
           - dotnet
           - node
           - python
+  workflow_call:
+    inputs:
+      language:
+        description: 'Language to test (dotnet, node, python, or all)'
+        required: false
+        default: 'all'
+        type: string
+    secrets:
+      CLIENT_ID:
+        required: true
+      CLIENT_SECRET:
+        required: true
+      TENANT_ID:
+        required: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Changes
- **e2e.yml**: Add \workflow_call\ trigger so it can be invoked from CD
- **cd.yml**: Add \2e\ job that calls E2E workflow as a gate before publishing

## Behavior
- **\elease/*\ branches**: E2E must pass before dotnet/node/python publish jobs run
- **\main\ branch**: E2E is skipped, publish proceeds normally (dev packages)