### PR TITLE
fix: publish all packages on release branches

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,12 +16,19 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      dotnet: ${{ steps.filter.outputs.dotnet }}
-      node: ${{ steps.filter.outputs.node }}
-      python: ${{ steps.filter.outputs.python }}
+      dotnet: ${{ steps.release.outputs.is_release == 'true' || steps.filter.outputs.dotnet }}
+      node: ${{ steps.release.outputs.is_release == 'true' || steps.filter.outputs.node }}
+      python: ${{ steps.release.outputs.is_release == 'true' || steps.filter.outputs.python }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check if release branch
+        id: release
+        run: |
+          if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        if: steps.release.outputs.is_release != 'true'
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Problem
When a \elease/*\ branch is created from main, \dorny/paths-filter\ detects no diff → all language outputs are \alse\ → all publish jobs skip.

## Fix
On \elease/*\ branches, skip the paths filter and force all outputs to \	rue\ so all packages are built and published.

On \main\, the paths filter still runs normally for incremental dev publishes.