### PR TITLE
Formalize release process (#196)

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -3,6 +3,7 @@ name: CD
 on:
   push:
     branches: [main, release/**]
+    tags: ['v*']
 
 concurrency:
   group: cd-${{ github.ref }}
@@ -16,15 +17,16 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
+      is_release: ${{ steps.release.outputs.is_release }}
       dotnet: ${{ steps.release.outputs.is_release == 'true' || steps.filter.outputs.dotnet }}
       node: ${{ steps.release.outputs.is_release == 'true' || steps.filter.outputs.node }}
       python: ${{ steps.release.outputs.is_release == 'true' || steps.filter.outputs.python }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Check if release branch
+      - name: Check if release
         id: release
         run: |
-          if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
+          if [[ "${{ github.ref }}" == refs/heads/release/* ]] || [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"
           fi
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
@@ -72,11 +74,11 @@ jobs:
         run: dotnet pack src/Botas/Botas.csproj --no-build -c Release -o ./nupkg
 
       - name: Publish to NuGet
-        if: startsWith(github.ref, 'refs/heads/release/')
+        if: needs.changes.outputs.is_release == 'true'
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Publish to GitHub Packages
-        if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
+        if: needs.changes.outputs.is_release != 'true'
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/rido-min/index.json --skip-duplicate
 
   node:
@@ -96,13 +98,24 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Setup Node.js
+      - name: Setup Node.js (public npm)
+        if: needs.changes.outputs.is_release == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: node/package-lock.json
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup Node.js (GitHub Packages)
+        if: needs.changes.outputs.is_release != 'true'
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: node/package-lock.json
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@rido-min'
 
       - name: Install dependencies
         run: npm ci
@@ -122,28 +135,28 @@ jobs:
         run: npm test --workspaces --if-present
 
       - name: Publish to npm
-        if: startsWith(github.ref, 'refs/heads/release/')
+        if: needs.changes.outputs.is_release == 'true'
         run: npm publish --workspace packages/botas --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish botas-express to npm
-        if: startsWith(github.ref, 'refs/heads/release/')
+        if: needs.changes.outputs.is_release == 'true'
         run: npm publish --workspace packages/botas-express --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish to npm (dev)
-        if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-        run: npm publish --workspace packages/botas --access public --tag dev
+      - name: Publish to GitHub Packages
+        if: needs.changes.outputs.is_release != 'true'
+        run: npm publish --workspace packages/botas
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish botas-express to npm (dev)
-        if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-        run: npm publish --workspace packages/botas-express --access public --tag dev
+      - name: Publish botas-express to GitHub Packages
+        if: needs.changes.outputs.is_release != 'true'
+        run: npm publish --workspace packages/botas-express
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   python:
     needs: changes
@@ -192,7 +205,7 @@ jobs:
         run: |
           VERSION=$(nbgv get-version -v SimpleVersion)
           HEIGHT=$(nbgv get-version -v VersionHeight)
-          if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
+          if [[ "${{ needs.changes.outputs.is_release }}" == "true" ]]; then
             echo "__version__ = \"${VERSION}\"" > src/botas/_version.py
           else
             echo "__version__ = \"${VERSION}.dev${HEIGHT}\"" > src/botas/_version.py
@@ -203,14 +216,14 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/heads/release/')
+        if: needs.changes.outputs.is_release == 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: python/packages/botas/dist/
 
       - name: Publish to TestPyPI
-        if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
+        if: needs.changes.outputs.is_release != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -218,8 +231,8 @@ jobs:
           packages-dir: python/packages/botas/dist/
 
   release:
-    if: always() && startsWith(github.ref, 'refs/heads/release/') && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-    needs: [dotnet, node, python]
+    if: always() && needs.changes.outputs.is_release == 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    needs: [changes, dotnet, node, python]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -239,14 +252,30 @@ jobs:
       - name: Get version
         id: version
         run: |
-          VERSION=$(nbgv get-version -v SimpleVersion)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG="${{ github.ref_name }}"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          else
+            VERSION=$(nbgv get-version -v SimpleVersion)
+            echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cat << 'EOF' > release-body.md
+          ## Published Packages
+
+          | Language | Package | Registry |
+          |----------|---------|----------|
+          | .NET | `Botas` | [nuget.org/packages/Botas](https://www.nuget.org/packages/Botas) |
+          | Node.js | `botas` | [npmjs.com/package/botas](https://www.npmjs.com/package/botas) |
+          | Node.js | `botas-express` | [npmjs.com/package/botas-express](https://www.npmjs.com/package/botas-express) |
+          | Python | `botas` | [pypi.org/project/botas](https://pypi.org/project/botas) |
+          EOF
+
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
+            --notes-file release-body.md \
             --generate-notes

--- a/specs/releasing.md
+++ b/specs/releasing.md
@@ -1,0 +1,284 @@
+# Release Process
+
+## Overview
+
+The `botas` project uses [Nerdbank.GitVersioning (nbgv)](https://github.com/dotnet/Nerdbank.GitVersioning) for deterministic versioning across all three language implementations (.NET, Node.js, Python). Release branches trigger automated publishing to public package registries, while main branch commits publish pre-release packages to non-public feeds for early testing.
+
+## Versioning
+
+### How It Works
+
+Version configuration lives in [`version.json`](../version.json) at the repository root:
+
+```json
+{
+  "version": "0.3-alpha",
+  "publicReleaseRefSpec": [
+    "^refs/heads/release/.*$",
+    "^refs/tags/v.*$"
+  ],
+  "cloudBuild": { "buildNumber": { "enabled": true } }
+}
+```
+
+**Key fields:**
+- **`version`**: Base version string (e.g., `0.3-alpha`)
+- **`publicReleaseRefSpec`**: Regex patterns defining which refs produce stable releases (`release/*` branches and `v*` tags)
+- **`cloudBuild.buildNumber.enabled`**: Enables version height stamping for non-release builds
+
+### Version Computation
+
+| Branch Type | Example Version | Pattern |
+|------------|-----------------|---------|
+| Release branch (`release/*`) | `0.3.0` | Stable semantic version from `version.json` |
+| Main branch | `0.3.0-alpha.123` (.NET), `0.3.0-dev.123` (Node), `0.3.0.dev123` (Python) | Base version + pre-release suffix + version height |
+
+**Version height** is the number of commits since the last version change in `version.json`. It auto-increments with each commit.
+
+### Language-Specific Version Stamping
+
+Each language uses nbgv differently:
+
+| Language | Tool | Command |
+|----------|------|---------|
+| .NET | Native MSBuild integration | Automatic during build (nbgv MSBuild SDK) |
+| Node.js | `nbgv-setversion` npm package | `npx nbgv-setversion` (writes to `package.json`) |
+| Python | nbgv CLI | `nbgv get-version -v SimpleVersion` (writes to `src/botas/_version.py`) |
+
+## Package Registries
+
+Published packages follow a two-tier model: stable releases go to public registries, while pre-release packages go to testing/private feeds.
+
+| Language | Stable (release branch) | Non-stable (main branch) |
+|----------|------------------------|--------------------------|
+| **[.NET](https://www.nuget.org/packages/Botas)** | [NuGet.org](https://www.nuget.org/packages/Botas) | [GitHub Packages](https://github.com/rido-min/botas/packages) (nuget.pkg.github.com) |
+| **[Node.js](https://www.npmjs.com/package/botas)** | [npm](https://www.npmjs.com/package/botas) (latest tag) | [GitHub Packages](https://github.com/rido-min/botas/packages) (npm.pkg.github.com) |
+| **[Python](https://pypi.org/project/botas/)** | [PyPI](https://pypi.org/project/botas/) | [TestPyPI](https://test.pypi.org/project/botas/) |
+
+**Node.js note:** Non-stable packages are published to GitHub npm registry (npm.pkg.github.com) starting with version 0.3-alpha, not to public npm.
+
+## Release Process
+
+There are two ways to create a stable release: **branch-based** and **tag-based**. Both trigger the same CD pipeline and publish to the same registries.
+
+### Prerequisites
+
+1. All tests passing on main
+2. Version bumped in `version.json` (if starting a new release cycle)
+3. Write access to the repository
+4. Package registry credentials configured (handled by GitHub Actions secrets)
+
+### Option A: Branch-Based Release
+
+Use this when you want a long-lived release branch that can receive hotfixes.
+
+**1. Create a release branch**
+
+Release branches must follow the `release/*` naming pattern to match the `publicReleaseRefSpec` in `version.json`.
+
+```bash
+# Example: releasing version 0.3.0
+git checkout main
+git pull origin main
+git checkout -b release/0.3
+```
+
+**Branch naming convention:** `release/{major}.{minor}` (e.g., `release/0.3`, `release/1.0`)
+
+**2. Push the release branch**
+
+```bash
+git push origin release/0.3
+```
+
+### Option B: Tag-Based Release
+
+Use this for a quick release from any commit (typically on `main`).
+
+**1. Create and push a version tag**
+
+```bash
+git checkout main
+git pull origin main
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+**Tag naming convention:** `v{major}.{minor}.{patch}` (e.g., `v0.3.0`, `v1.0.0`). The tag must start with `v` to match the CD trigger and `publicReleaseRefSpec`.
+
+### Monitoring and Verification
+
+Both options trigger the [CD workflow](../.github/workflows/CD.yml) in release mode.
+
+**3. Monitor the CD workflow**
+
+Visit the [Actions tab](https://github.com/rido-min/botas/actions/workflows/CD.yml) and watch the triggered workflow:
+
+- **Changes job**: Forces all three languages to build (release branches skip path filtering)
+- **dotnet job**: Builds, tests, and publishes to NuGet.org
+- **node job**: Builds, tests, and publishes to npm (both `botas` and `botas-express` packages)
+- **python job**: Builds, tests, and publishes to PyPI (both `botas` and `botas-fastapi` packages)
+- **release job**: Creates a GitHub Release with auto-generated notes (only runs if all 3 language jobs succeed)
+
+Expected runtime: ~5-10 minutes for all jobs to complete.
+
+**4. Verify the GitHub Release**
+
+Once the `release` job completes, a new [GitHub Release](https://github.com/rido-min/botas/releases) is created automatically:
+
+- **Tag:** `v{version}` (e.g., `v0.3.0`)
+- **Title:** Same as tag
+- **Notes:** Auto-generated from commits since the last release
+
+The release notes will include:
+- Pull requests merged since the last tag
+- Commit history grouped by contributor
+- Link to full changelog
+
+**5. Verify published packages**
+
+Check each package registry to confirm publication:
+
+| Registry | Verification Link |
+|----------|-------------------|
+| NuGet.org | `https://www.nuget.org/packages/Botas/{version}` |
+| npm (botas) | `https://www.npmjs.com/package/botas/v/{version}` |
+| npm (botas-express) | `https://www.npmjs.com/package/botas-express/v/{version}` |
+| PyPI (botas) | `https://pypi.org/project/botas/{version}/` |
+| PyPI (botas-fastapi) | `https://pypi.org/project/botas-fastapi/{version}/` |
+
+Installation commands (stable):
+```bash
+# .NET
+dotnet add package Botas --version {version}
+
+# Node.js
+npm install botas@{version} botas-express@{version}
+
+# Python
+pip install botas=={version} botas-fastapi=={version}
+```
+
+## Non-Stable Releases
+
+Every push to the `main` branch automatically publishes pre-release packages to non-public registries for early testing.
+
+### Behavior
+
+- **Trigger:** Push to `main` branch (after PR merge)
+- **Path filtering:** Only languages with changes are built (unless path is `version.json`, which affects all)
+- **Version format:** See "Version Computation" table above
+
+### Where Non-Stable Packages Go
+
+| Language | Registry | Notes |
+|----------|----------|-------|
+| .NET | GitHub Packages (nuget.pkg.github.com) | Requires GitHub authentication |
+| Node.js | GitHub Packages (npm.pkg.github.com) | Requires GitHub authentication + `.npmrc` config |
+| Python | TestPyPI (test.pypi.org) | Public test feed; no authentication required to download |
+
+### Installing Non-Stable Packages
+
+**Node.js from GitHub Packages:**
+```bash
+# Add to .npmrc in your project root:
+@rido-min:registry=https://npm.pkg.github.com
+
+# Install with dev tag:
+npm install @rido-min/botas@dev
+```
+
+**.NET from GitHub Packages:**
+```bash
+# Add source (one-time):
+dotnet nuget add source https://nuget.pkg.github.com/rido-min/index.json -n github -u YOUR_GITHUB_USERNAME -p YOUR_PAT
+
+# Install pre-release package:
+dotnet add package Botas --prerelease
+```
+
+**Python from TestPyPI:**
+```bash
+# Install directly (with --index-url):
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple botas
+
+# Or add to requirements.txt:
+--index-url https://test.pypi.org/simple/
+--extra-index-url https://pypi.org/simple/
+botas
+```
+
+**Note:** Non-stable packages are for testing only. Do not use in production.
+
+## Version Bumping
+
+After a release is published, bump the version in `version.json` to start the next release cycle.
+
+### When to Bump
+
+- Immediately after a stable release is published (to start next cycle)
+- Before merging a PR if it introduces breaking changes that warrant a major/minor version bump
+
+### How to Bump
+
+Edit [`version.json`](../version.json):
+
+```json
+{
+  "version": "0.4-alpha",  // Increment from 0.3-alpha
+  "publicReleaseRefSpec": ["^refs/heads/release/.*$"],
+  "cloudBuild": { "buildNumber": { "enabled": true } }
+}
+```
+
+Commit directly to `main` or include in a PR:
+
+```bash
+git add version.json
+git commit -m "Bump version to 0.4-alpha for next release cycle"
+git push origin main
+```
+
+Version height resets to `0` after this commit.
+
+### Version Bump Strategies
+
+| Change Type | Example Bump | Reasoning |
+|-------------|-------------|-----------|
+| Patch fixes only | `0.3-alpha` → `0.3-alpha` | Keep same version; patch increments happen at release time |
+| New features, non-breaking | `0.3-alpha` → `0.4-alpha` | Minor version bump |
+| Breaking changes | `0.9-alpha` → `1.0-beta` | Major version bump; optionally change pre-release label |
+
+## Troubleshooting
+
+### Release job didn't create a GitHub Release
+
+**Cause:** One or more language jobs failed.
+
+**Fix:** Check the failed job logs in the workflow. Common issues:
+- Test failures (fix tests and re-push to the release branch)
+- Package registry authentication errors (check GitHub secrets: `NUGET_API_KEY`, `NPM_TOKEN`, `PYPI_API_TOKEN`)
+
+### Package published with wrong version
+
+**Cause:** `version.json` not committed before creating the release branch.
+
+**Fix:**
+1. Delete the release branch
+2. Delete the incorrect GitHub Release and tag
+3. Update `version.json` on main
+4. Recreate the release branch
+
+### Non-stable package not published after main push
+
+**Cause:** Path filtering skipped the language (no changes detected).
+
+**Fix:** This is expected behavior. If you need to force-publish all languages, push a change to `version.json`.
+
+## References
+
+- [`version.json`](../version.json) — version configuration
+- [`.github/workflows/CD.yml`](../.github/workflows/CD.yml) — continuous deployment workflow
+- [Nerdbank.GitVersioning documentation](https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/index.md)
+- [GitHub Packages: npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry)
+- [GitHub Packages: NuGet registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry)

--- a/version.json
+++ b/version.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "0.3-alpha",
   "publicReleaseRefSpec": [
-    "^refs/heads/release/.*$"
+    "^refs/heads/release/.*$",
+    "^refs/tags/v.*$"
   ],
   "cloudBuild": {
     "buildNumber": {


### PR DESCRIPTION
- Add tag-based release support (v* tags) alongside release/* branches
- Move Node.js non-stable packages from public npm to GitHub Packages
- Centralize release detection via is_release output in changes job
- Add package links table to GitHub Release notes
- Add publicReleaseRefSpec for tags in version.json
- Add specs/releasing.md documenting the full release process