### PR TITLE
Rename botas-core, minor e2e fixes

### DIFF
--- a/dotnet/samples/TestBot/Program.cs
+++ b/dotnet/samples/TestBot/Program.cs
@@ -1,6 +1,10 @@
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Botas;
+
+var version = BotApplication.Version;
+var platform = RuntimeInformation.FrameworkDescription;
 
 var app = BotApp.Create(args);
 
@@ -44,7 +48,7 @@ app.On("message", async (context, ct) =>
     }
     else
     {
-        await context.SendAsync($"Echo: {context.Activity.Text}, from aspnet", ct);
+        await context.SendAsync($"Echo: {context.Activity.Text} [botas-dotnet v{version} | {platform}]", ct);
     }
 });
 

--- a/dotnet/src/Botas/BotApplication.cs
+++ b/dotnet/src/Botas/BotApplication.cs
@@ -34,6 +34,9 @@ public interface ITurnMiddleWare
 
 public class BotApplication
 {
+    /// <summary>The Botas SDK version.</summary>
+    public static string Version => ThisAssembly.AssemblyInformationalVersion;
+
     private readonly ILogger<BotApplication> _logger;
     private readonly IConfiguration _configuration;
     private ConversationClient? _conversationClient;

--- a/e2e/env2azad.ps1
+++ b/e2e/env2azad.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+  Reads CLIENT_ID, CLIENT_SECRET, TENANT_ID, and PORT from a .env file
+  and writes them into a .NET launchSettings.json as AzureAd environment variables.
+
+.PARAMETER EnvFile
+  Path to the .env file (default: <repo-root>/.env).
+
+.PARAMETER LaunchSettingsFile
+  Path to the launchSettings.json to update
+  (default: <repo-root>/dotnet/samples/EchoBot/Properties/launchSettings.json).
+
+.EXAMPLE
+  .\env2azad.ps1
+  .\env2azad.ps1 -EnvFile ..\.env -LaunchSettingsFile ..\dotnet\samples\TestBot\Properties\launchSettings.json
+#>
+param(
+    [string]$EnvFile,
+    [string]$LaunchSettingsFile
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = Split-Path -Parent $ScriptDir
+
+if (-not $EnvFile) {
+    $EnvFile = Join-Path $RepoRoot ".env"
+}
+if (-not $LaunchSettingsFile) {
+    $LaunchSettingsFile = Join-Path $RepoRoot "dotnet\samples\EchoBot\Properties\launchSettings.json"
+}
+
+if (-not (Test-Path $EnvFile)) {
+    Write-Error "Error: env file not found: $EnvFile"
+}
+if (-not (Test-Path $LaunchSettingsFile)) {
+    Write-Error "Error: launchSettings file not found: $LaunchSettingsFile"
+}
+
+# Parse .env
+$ClientId     = ""
+$ClientSecret = ""
+$TenantId     = ""
+$Port         = ""
+
+Get-Content $EnvFile | ForEach-Object {
+    $line = $_.Trim()
+    if ($line -eq "" -or $line.StartsWith("#")) { return }
+    switch -Wildcard ($line) {
+        "CLIENT_ID=*"     { $script:ClientId     = ($line -split "=", 2)[1] }
+        "CLIENT_SECRET=*" { $script:ClientSecret = ($line -split "=", 2)[1] }
+        "TENANT_ID=*"     { $script:TenantId     = ($line -split "=", 2)[1] }
+        "PORT=*"          { $script:Port         = ($line -split "=", 2)[1] }
+    }
+}
+
+# Read and update launchSettings.json
+$LaunchSettingsFile = (Resolve-Path $LaunchSettingsFile).Path
+$data = Get-Content $LaunchSettingsFile -Raw | ConvertFrom-Json
+
+# Ensure profiles.http exists
+if (-not $data.profiles) {
+    $data | Add-Member -NotePropertyName "profiles" -NotePropertyValue ([PSCustomObject]@{})
+}
+$profileName = ($data.profiles.PSObject.Properties | Select-Object -First 1).Name
+if (-not $profileName) {
+    $profileName = "http"
+    $data.profiles | Add-Member -NotePropertyName $profileName -NotePropertyValue ([PSCustomObject]@{})
+}
+$profile = $data.profiles.$profileName
+
+# Update port in applicationUrl if PORT is set
+if ($Port) {
+    $appUrl = $profile.applicationUrl
+    if ($appUrl) {
+        $profile.applicationUrl = $appUrl -replace ":\d+", ":$Port"
+    }
+}
+
+# Ensure environmentVariables exists
+if (-not $profile.environmentVariables) {
+    $profile | Add-Member -NotePropertyName "environmentVariables" -NotePropertyValue ([PSCustomObject]@{})
+}
+$envVars = $profile.environmentVariables
+
+# Set AzureAd values
+if ($ClientId) {
+    if ($envVars.PSObject.Properties["AzureAd__ClientId"]) {
+        $envVars.AzureAd__ClientId = $ClientId
+    } else {
+        $envVars | Add-Member -NotePropertyName "AzureAd__ClientId" -NotePropertyValue $ClientId
+    }
+}
+if ($TenantId) {
+    if ($envVars.PSObject.Properties["AzureAd__TenantId"]) {
+        $envVars.AzureAd__TenantId = $TenantId
+    } else {
+        $envVars | Add-Member -NotePropertyName "AzureAd__TenantId" -NotePropertyValue $TenantId
+    }
+}
+if ($ClientSecret) {
+    $secretKey = "AzureAd__ClientCredentials__0__ClientSecret"
+    if ($envVars.PSObject.Properties[$secretKey]) {
+        $envVars.$secretKey = $ClientSecret
+    } else {
+        $envVars | Add-Member -NotePropertyName $secretKey -NotePropertyValue $ClientSecret
+    }
+}
+
+# Write back
+$data | ConvertTo-Json -Depth 10 | Set-Content $LaunchSettingsFile -Encoding UTF8
+Write-Host "Updated $LaunchSettingsFile from $EnvFile"

--- a/e2e/run-playwright-tests.ps1
+++ b/e2e/run-playwright-tests.ps1
@@ -1,0 +1,151 @@
+<#
+.SYNOPSIS
+  Run Playwright E2E tests against all 3 language bots.
+  Each bot is started, tested, and stopped in sequence.
+
+.PARAMETER Language
+  Which bot to test: dotnet, node, python, or all (default).
+
+.PARAMETER Headed
+  Run Playwright in headed mode (visible browser).
+
+.EXAMPLE
+  .\run-playwright-tests.ps1
+  .\run-playwright-tests.ps1 -Language node -Headed
+  .\run-playwright-tests.ps1 -Headed
+#>
+param(
+    [ValidateSet("all", "dotnet", "node", "python")]
+    [string]$Language = "all",
+    [switch]$Headed
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path -Parent $ScriptDir
+$EnvFile = Join-Path $RepoRoot ".env"
+$PwDir = Join-Path $ScriptDir "playwright"
+
+if (-not (Test-Path $EnvFile)) {
+    Write-Error ".env not found at $EnvFile"
+    return
+}
+
+if (-not (Test-Path (Join-Path $PwDir "storageState.json"))) {
+    Write-Error "storageState.json not found. Run 'cd e2e/playwright && npm run setup' first."
+    return
+}
+
+# Load .env into current process environment
+Get-Content $EnvFile | ForEach-Object {
+    if ($_ -match '^\s*([^#][^=]+)=(.*)$') {
+        [Environment]::SetEnvironmentVariable($Matches[1].Trim(), $Matches[2].Trim(), "Process")
+    }
+}
+
+$BotProcess = $null
+
+function Stop-Bot {
+    if ($script:BotProcess -and -not $script:BotProcess.HasExited) {
+        Write-Host "Stopping bot (PID $($script:BotProcess.Id))..."
+        Stop-Process -Id $script:BotProcess.Id -Force -ErrorAction SilentlyContinue
+        $script:BotProcess.WaitForExit(5000) | Out-Null
+    }
+    $script:BotProcess = $null
+}
+
+function Wait-ForBot {
+    $port = if ($env:PORT) { $env:PORT } else { "3978" }
+    Write-Host "Waiting for bot on port $port..."
+    for ($i = 1; $i -le 30; $i++) {
+        try {
+            $response = Invoke-WebRequest -Uri "http://localhost:$port/api/messages" `
+                -Method POST -ContentType "application/json" -Body "{}" `
+                -ErrorAction Stop -TimeoutSec 2
+            Write-Host "Bot is ready."
+            return $true
+        } catch {
+            if ($script:BotProcess -and $script:BotProcess.HasExited) {
+                Write-Error "Bot process died before becoming ready."
+                return $false
+            }
+            Start-Sleep -Seconds 1
+        }
+    }
+    Write-Error "Bot failed to start within 30 seconds."
+    return $false
+}
+
+function Start-DotNetBot {
+    Write-Host "Starting .NET test-bot..."
+    & "$ScriptDir\env2azad.ps1" -EnvFile "$EnvFile" -LaunchSettingsFile "$RepoRoot\dotnet\samples\TestBot\Properties\launchSettings.json"
+    $script:BotProcess = Start-Process -FilePath "dotnet" `
+        -ArgumentList "run", "--project", "$RepoRoot\dotnet\samples\TestBot" `
+        -PassThru -NoNewWindow
+}
+
+function Start-NodeBot {
+    Write-Host "Starting Node.js test-bot..."
+    $script:BotProcess = Start-Process -FilePath "npx" `
+        -ArgumentList "tsx", "samples/test-bot/index.ts" `
+        -WorkingDirectory "$RepoRoot\node" `
+        -PassThru -NoNewWindow
+}
+
+function Start-PythonBot {
+    Write-Host "Starting Python test-bot..."
+    $script:BotProcess = Start-Process -FilePath "python" `
+        -ArgumentList "main.py" `
+        -WorkingDirectory "$RepoRoot\python\samples\test-bot" `
+        -PassThru -NoNewWindow
+}
+
+function Invoke-PlaywrightFor {
+    param([string]$Lang)
+
+    Write-Host ""
+    Write-Host "=============================="
+    Write-Host "  Playwright: $Lang"
+    Write-Host "=============================="
+
+    switch ($Lang) {
+        "dotnet" { Start-DotNetBot }
+        "node"   { Start-NodeBot }
+        "python" { Start-PythonBot }
+        default  { Write-Error "Unknown language: $Lang"; return }
+    }
+
+    if (-not (Wait-ForBot)) {
+        Stop-Bot
+        throw "Bot failed to start for $Lang"
+    }
+
+    try {
+        Push-Location $PwDir
+        $pwArgs = @("playwright", "test", "--project=teams-tests")
+        if ($Headed) { $pwArgs += "--headed" }
+        & npx @pwArgs
+        if ($LASTEXITCODE -ne 0) { throw "Playwright tests failed for $Lang" }
+    } finally {
+        Pop-Location
+        Stop-Bot
+    }
+
+    Write-Host "✅ Playwright $Lang passed"
+}
+
+# Main
+try {
+    $languages = if ($Language -eq "all") { @("dotnet", "node", "python") } else { @($Language) }
+
+    foreach ($lang in $languages) {
+        Invoke-PlaywrightFor $lang
+    }
+
+    Write-Host ""
+    Write-Host "======================================="
+    Write-Host "  All Playwright E2E tests passed ✅"
+    Write-Host "======================================="
+} finally {
+    Stop-Bot
+}

--- a/e2e/run-playwright-tests.sh
+++ b/e2e/run-playwright-tests.sh
@@ -2,7 +2,7 @@
 # Run Playwright E2E tests against all 3 language bots.
 # Each bot is started, tested, and stopped in sequence.
 #
-# Usage: ./run-playwright-tests.sh [dotnet|node|python]
+# Usage: ./run-playwright-tests.sh [dotnet|node|python] [--headed]
 #   No argument runs all 3 languages.
 #
 # Prerequisites:
@@ -15,6 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENV_FILE="$REPO_ROOT/.env"
 PW_DIR="$SCRIPT_DIR/playwright"
+HEADED=""
 
 if [ ! -f "$ENV_FILE" ]; then
   echo "Error: $ENV_FILE not found." >&2
@@ -108,7 +109,7 @@ run_playwright_for() {
   wait_for_bot
 
   cd "$PW_DIR"
-  npx playwright test --project=teams-tests
+  npx playwright test --project=teams-tests $HEADED
   cd "$REPO_ROOT"
 
   stop_bot
@@ -116,7 +117,14 @@ run_playwright_for() {
 }
 
 # Parse arguments
-LANGUAGES="${1:-all}"
+LANGUAGES=""
+for arg in "$@"; do
+  case "$arg" in
+    --headed) HEADED="--headed" ;;
+    *) LANGUAGES="$arg" ;;
+  esac
+done
+LANGUAGES="${LANGUAGES:-all}"
 if [ "$LANGUAGES" = "all" ]; then
   LANGUAGES="dotnet node python"
 fi

--- a/node/packages/botas/src/bot-application.ts
+++ b/node/packages/botas/src/bot-application.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { createRequire } from 'node:module'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { CoreActivity, ResourceResponse } from './core-activity.js'
 import type { TurnMiddleware } from './i-turn-middleware.js'
@@ -59,6 +60,12 @@ export class BotHandlerException extends Error {
  * ```
  */
 export class BotApplication {
+  /** The Botas SDK version. */
+  static readonly version: string = (() => {
+    const r = createRequire(import.meta.url)
+    return (r('../package.json') as { version: string }).version
+  })()
+
   /** Resolved options for this application instance. */
   readonly options: BotApplicationOptions
 

--- a/node/samples/test-bot/index.ts
+++ b/node/samples/test-bot/index.ts
@@ -2,6 +2,9 @@
 // Run: npx tsx index.ts
 
 import { BotApp } from 'botas-express'
+import { BotApplication } from 'botas-core'
+
+const platform = `Node.js ${process.version} ${process.platform} ${process.arch}`
 
 const app = new BotApp()
 
@@ -29,7 +32,7 @@ app.on('message', async (ctx) => {
       }]
     })
   } else {
-    await ctx.send(`You said: ${ctx.activity.text}`)
+    await ctx.send(`Echo: ${ctx.activity.text} [botas-node v${BotApplication.version} | ${platform}]`)
   }
 })
 

--- a/python/packages/botas/src/botas/__init__.py
+++ b/python/packages/botas/src/botas/__init__.py
@@ -1,3 +1,4 @@
+from botas._version import __version__
 from botas.bot_application import BotApplication, BotHandlerException, InvokeResponse
 from botas.bot_auth import BotAuthError, validate_bot_token
 from botas.conversation_client import ConversationClient
@@ -59,5 +60,6 @@ __all__ = [
     "TenantInfo",
     "TokenManager",
     "TurnContext",
+    "__version__",
     "validate_bot_token",
 ]

--- a/python/packages/botas/src/botas/bot_application.py
+++ b/python/packages/botas/src/botas/bot_application.py
@@ -63,6 +63,8 @@ class BotHandlerException(Exception):
 
 
 class BotApplication:
+    version: str = __import__("botas._version", fromlist=["__version__"]).__version__
+
     def __init__(self, options: BotApplicationOptions = BotApplicationOptions()) -> None:
         self._token_manager = TokenManager(options)
         token_provider = self._token_manager.get_bot_token

--- a/python/samples/test-bot/main.py
+++ b/python/samples/test-bot/main.py
@@ -2,9 +2,11 @@
 # Run: python main.py
 
 import logging
+import platform
 
-from botas import InvokeResponse
 from botas_fastapi import BotApp
+
+from botas import BotApplication, InvokeResponse
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -42,7 +44,8 @@ async def on_message(ctx):
             }
         )
     else:
-        await ctx.send(f"You said: {ctx.activity.text}")
+        plat = f"Python {platform.python_version()} ({platform.system()})"
+        await ctx.send(f"Echo: {ctx.activity.text} [botas-python v{BotApplication.version} | {plat}]")
 
 
 @app.on_invoke("adaptiveCard/action")


### PR DESCRIPTION
This pull request introduces SDK version reporting and platform information to the test bots for .NET, Node.js, and Python, and adds new PowerShell scripts to streamline end-to-end (E2E) testing and environment configuration. The most important changes are grouped into SDK enhancements and E2E tooling improvements.

**SDK enhancements:**

* All three test bots (`TestBot` in .NET, `test-bot` in Node.js and Python) now echo their SDK version and platform information in responses, using new static version properties added to each SDK (`BotApplication.Version` in .NET, `BotApplication.version` in Node.js, and `BotApplication.version` in Python). [[1]](diffhunk://#diff-f27b9a12d5dfaac1e42ae86b34342bbd7f2ef8be361b238d936221f61bbb486fR1-R8) [[2]](diffhunk://#diff-f27b9a12d5dfaac1e42ae86b34342bbd7f2ef8be361b238d936221f61bbb486fL47-R51) [[3]](diffhunk://#diff-4688462bbf89b837ab2dcfc03dbedfbedf09e3c9059829bc5e91d71ce210f8beR4) [[4]](diffhunk://#diff-4688462bbf89b837ab2dcfc03dbedfbedf09e3c9059829bc5e91d71ce210f8beR63-R68) [[5]](diffhunk://#diff-5ee1e4b4edcd07e796a4bd3ef72a24de14eaf28a5a176262fd13828d55405b61R5-R7) [[6]](diffhunk://#diff-5ee1e4b4edcd07e796a4bd3ef72a24de14eaf28a5a176262fd13828d55405b61L32-R35) [[7]](diffhunk://#diff-d3af0563c66806adcc4f0164af628a931447fa1b055182bbe10a41aa10ccb6c6R1) [[8]](diffhunk://#diff-d3af0563c66806adcc4f0164af628a931447fa1b055182bbe10a41aa10ccb6c6R63) [[9]](diffhunk://#diff-0fcabceffb1554f9a2ccf87fa4edeae6757a42f428653350c4e41357d7ce4b33R66-R67) [[10]](diffhunk://#diff-0bc24e18a8b19ff9404997391c96c9fbdc0b2eac6f08f2fa4fd94bb2f42aa36eR5-R10) [[11]](diffhunk://#diff-0bc24e18a8b19ff9404997391c96c9fbdc0b2eac6f08f2fa4fd94bb2f42aa36eL45-R48)

**E2E tooling improvements:**

* Added `env2azad.ps1`, a PowerShell script that reads Azure AD environment variables from a `.env` file and updates a `.NET` `launchSettings.json` for local development.
* Added `run-playwright-tests.ps1`, a PowerShell script to automate Playwright E2E testing across all three language bots, handling bot startup, environment setup, and test orchestration.
* Updated `run-playwright-tests.sh` to support a `--headed` flag for visible browser testing and improved argument parsing for selecting languages and options. [[1]](diffhunk://#diff-d4d72a8d4914ed29896f5d14021b8dfe2e204af73e63eb18755310b29d678673L5-R5) [[2]](diffhunk://#diff-d4d72a8d4914ed29896f5d14021b8dfe2e204af73e63eb18755310b29d678673R18) [[3]](diffhunk://#diff-d4d72a8d4914ed29896f5d14021b8dfe2e204af73e63eb18755310b29d678673L111-R127)