### PR TITLE
docs: update Teams CLI references to official @microsoft/teams.cli

### DIFF
--- a/.copilot/skills/teams-bot-infra/SKILL.md
+++ b/.copilot/skills/teams-bot-infra/SKILL.md
@@ -26,7 +26,7 @@ teams --version
 Install the Teams CLI using npm:
 
 ```bash
-npm install -g https://github.com/heyitsaamir/teamscli/releases/latest/download/teamscli.tgz
+npm install -g @microsoft/teams.cli@preview
 ```
 
 **After installation:**

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A lightweight, multi-language library for building [Microsoft Teams](https://lea
 
 - **Teams CLI** — creates bot registrations and provides credentials:
   ```bash
-  npm install -g https://github.com/heyitsaamir/teamscli/releases/latest/download/teamscli.tgz
+  npm install -g @microsoft/teams.cli@preview
   teams login
   ```
 - **Dev tunnel** — exposes your local port. Install [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started).

--- a/docs-site/getting-started.md
+++ b/docs-site/getting-started.md
@@ -127,7 +127,7 @@ For a complete setup walkthrough from zero, see the [Setup Guide](setup).
 
 **Teams CLI install**:
 ```bash
-npm install -g https://github.com/heyitsaamir/teamscli/releases/latest/download/teamscli.tgz
+npm install -g @microsoft/teams.cli@preview
 teams login
 ```
 

--- a/docs-site/setup.md
+++ b/docs-site/setup.md
@@ -19,7 +19,7 @@ Before you begin, install these tools:
 The Teams CLI automates bot registration and credential provisioning:
 
 ```bash
-npm install -g https://github.com/heyitsaamir/teamscli/releases/latest/download/teamscli.tgz
+npm install -g @microsoft/teams.cli@preview
 teams login
 ```
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -7,8 +7,8 @@
       "computedHash": "81af098a4ce6f0e323c1bd02b8e79df3bbaed57cbf1c4060f58ddc95de5545a1"
     },
     "teams-bot-infra": {
-      "source": "heyitsaamir/teamscli",
-      "sourceType": "github",
+      "source": "@microsoft/teams.cli",
+      "sourceType": "npm",
       "computedHash": "3b91cb566f52fafc52bfa82c5a70713caa65270f116cc0c1d5466bb05ec80e2f"
     }
   }

--- a/specs/setup.md
+++ b/specs/setup.md
@@ -11,7 +11,7 @@ This guide walks through registering a bot and obtaining the credentials needed 
 ### 1. Install the Teams CLI
 
 ```bash
-npm install -g https://github.com/heyitsaamir/teamscli/releases/latest/download/teamscli.tgz
+npm install -g @microsoft/teams.cli@preview
 ```
 
 Verify:


### PR DESCRIPTION
Fixes #205

Replaces all references to the unofficial heyitsaamir/teamscli with the official @microsoft/teams.cli@preview package.

**Files updated:**
- .copilot/skills/teams-bot-infra/SKILL.md
- README.md
- specs/setup.md
- docs-site/setup.md
- docs-site/getting-started.md
- skills-lock.json