### PR TITLE
fix: make API doc cross-links clickable and sanitize generated .NET docs

### DIFF
--- a/.squad/agents/kif/history.md
+++ b/.squad/agents/kif/history.md
@@ -7,6 +7,22 @@
 
 ## Learnings
 
+### 2025-05-XX: .NET API docs XML tag sanitization
+
+**Problem**: DefaultDocumentation generates markdown with raw XML doc comment tags (`<example>`, `<code>`) that VitePress interprets as Vue components, breaking the build with "Element is missing end tag" errors.
+
+**Solution**: Added `sanitize_dotnet_docs()` function to `docs-site/generate-api-docs.sh` that post-processes the generated .NET API docs using `awk` to:
+1. Convert `<example><code>...</code></example>` blocks to markdown code fences (```csharp ... ```)
+2. Strip bare XML doc tags (`<see>`, `<param>`, `<returns>`, `<summary>`, `<remarks>`)
+
+**Key files**:
+- `docs-site/generate-api-docs.sh` — API doc generation script
+- `docs-site/api/generated/dotnet/` — .NET API docs output directory
+
+**Portability**: Uses POSIX-compatible `awk` for cross-platform compatibility (Git Bash on Windows, Linux in CI).
+
+**Pattern**: For generated documentation that includes embedded XML or HTML tags incompatible with the target renderer (VitePress), add a post-processing sanitization step immediately after generation rather than trying to configure the generator itself.
+
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 - **2026-04-15**: Added version selector dropdown to VitePress docs site navigation. Implemented: (1) `docs-site/versions.json` with structure `{ "current": "0.3", "versions": [] }` for CD-driven updates; (2) `docs-site/.vitepress/config.mts` reads versions.json at build time and generates nav dropdown items dynamically; (3) Dropdown placed as last nav item after Teams Features, showing `v{current} (latest|dev)` label; (4) "Latest" link points to `/botas/`, previous versions to `/botas/v{version}/`; (5) Uses only Node.js built-ins (fs, path), gracefully degrades if file missing. Design enables CD workflow to update versions.json before build, supporting multi-version doc deployments. See decision: `.squad/decisions/inbox/kif-version-selector.md`.
 - **2026-04-13**: Updated Python run/startup instructions in `docs-site/getting-started.md`, `docs-site/auth-setup.md`, and `docs-site/languages/python.md` to promote `uv` as the recommended runner. All sample run commands now show: (1) `::: code-group` tabs with both bash and PowerShell examples, (2) `uv run --env-file ../../.env main.py` as the primary method (works cross-platform), (3) `::: details` blocks for users without uv showing pip/python fallback. Paths use backslashes for `cd` on PowerShell but forward slashes for `--env-file` (uv handles both). Updated sections in getting-started (lines 142-173), auth-setup (lines 128-161), and python.md (lines 351-372, 417-438, 470-491). Purpose: improve Windows developer experience and modernize Python setup guidance.
@@ -155,3 +171,9 @@
 - **Build scripts**: Updated `docs-site/generate-api-docs.sh` to run `npm run docs` for both packages; added `docs-site/api/generated/` to .gitignore (generated files)
 - **Coexistence**: Hand-written API docs (`nodejs.md`, `python.md`) remain as supplementary guides; generated docs demonstrate automation with cross-linking
 - **Version note**: typedoc-plugin-markdown v4.x has very different config from v3.x — native VitePress support, no need for typedoc-vitepress-theme
+
+### 2026-XX-XX: Markdown cross-links must be outside backticks
+
+Cross-links in markdown tables must NOT be inside backtick code spans. Markdown does NOT render links inside backticks — everything between backticks is literal text. Fixed ~98 affected lines across nodejs.md and python.md by removing outer backticks from Type/Signature cells containing `[TypeName](#anchor)` syntax, and escaping `<>` as HTML entities (`&lt;`/`&gt;`) to prevent VitePress from interpreting generics as HTML tags. Example: `\\sendActivityAsync(...): Promise<[ResourceResponse](#resourceresponse)>\\ ` became `sendActivityAsync(...): Promise&lt;[ResourceResponse](#resourceresponse)&gt;`.
+
+**Pattern:** In table cells with cross-links: (1) remove outer backticks, (2) escape angle brackets, (3) leave method/property name column unchanged, (4) keep pipe escapes as-is. VitePress build passes after fix.

--- a/docs-site/api/nodejs.md
+++ b/docs-site/api/nodejs.md
@@ -30,8 +30,8 @@ Options are resolved from environment variables (`CLIENT_ID`, `CLIENT_SECRET`, `
 | Property | Type | Description |
 |----------|------|-------------|
 | `version` | `static readonly string` | SDK version string. |
-| `options` | `readonly [BotApplicationOptions](#botapplicationoptions)` | Resolved configuration. |
-| `conversationClient` | `readonly [ConversationClient](#conversationclient)` | Client for outbound API calls. |
+| `options` | readonly [BotApplicationOptions](#botapplicationoptions) | Resolved configuration. |
+| `conversationClient` | readonly [ConversationClient](#conversationclient) | Client for outbound API calls. |
 | `onActivity` | `CoreActivityHandler \| undefined` | Catch-all handler (legacy API). |
 
 ### Methods
@@ -39,11 +39,11 @@ Options are resolved from environment variables (`CLIENT_ID`, `CLIENT_SECRET`, `
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `on` | `on(type: string, handler: CoreActivityHandler): this` | Register a handler for a specific activity type. |
-| `use` | `use(middleware: [TurnMiddleware](#turnmiddleware)): this` | Add middleware to the pipeline. |
+| `use` | use(middleware: [TurnMiddleware](#turnmiddleware)): this | Add middleware to the pipeline. |
 | `onInvoke` | `onInvoke(name: string, handler: InvokeActivityHandler): this` | Register a named invoke handler. |
 | `processAsync` | `processAsync(req: IncomingMessage, res: ServerResponse): Promise<void>` | HTTP request entry point — reads body, validates auth, processes activity. |
-| `processBody` | `processBody(body: string): Promise<[InvokeResponse](#invokeresponse) \| undefined>` | Process a raw JSON body without HTTP response handling. |
-| `sendActivityAsync` | `sendActivityAsync(serviceUrl: string, conversationId: string, activity: Partial<[CoreActivity](#coreactivity)>): Promise<[ResourceResponse](#resourceresponse) \| undefined>` | Send a proactive activity to a conversation. |
+| `processBody` | processBody(body: string): Promise&lt;[InvokeResponse](#invokeresponse) \| undefined&gt; | Process a raw JSON body without HTTP response handling. |
+| `sendActivityAsync` | sendActivityAsync(serviceUrl: string, conversationId: string, activity: Partial&lt;[CoreActivity](#coreactivity)&gt;): Promise&lt;[ResourceResponse](#resourceresponse) \| undefined&gt; | Send a proactive activity to a conversation. |
 
 ---
 
@@ -77,9 +77,9 @@ interface TurnContext
 
 | Member | Type | Description |
 |--------|------|-------------|
-| `activity` | `[CoreActivity](#coreactivity)` | The incoming activity for this turn. |
-| `app` | `[BotApplication](#botapplication)` | The bot application processing this turn. |
-| `send` | `(activityOrText: string \| Partial<[CoreActivity](#coreactivity)>) => Promise<[ResourceResponse](#resourceresponse) \| undefined>` | Reply with text or a full activity. |
+| `activity` | [CoreActivity](#coreactivity) | The incoming activity for this turn. |
+| `app` | [BotApplication](#botapplication) | The bot application processing this turn. |
+| `send` | (activityOrText: string \| Partial&lt;[CoreActivity](#coreactivity)&gt;) =&gt; Promise&lt;[ResourceResponse](#resourceresponse) \| undefined&gt; | Reply with text or a full activity. |
 | `sendTyping` | `() => Promise<void>` | Send a typing indicator. |
 
 ---
@@ -102,17 +102,17 @@ new ConversationClient(getToken?: TokenProvider)
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `sendCoreActivityAsync` | `(serviceUrl, conversationId, activity) => Promise<[ResourceResponse](#resourceresponse) \| undefined>` | Send an activity to a conversation. |
-| `updateCoreActivityAsync` | `(serviceUrl, conversationId, activityId, activity) => Promise<[ResourceResponse](#resourceresponse) \| undefined>` | Update an existing activity. |
+| `sendCoreActivityAsync` | (serviceUrl, conversationId, activity) =&gt; Promise&lt;[ResourceResponse](#resourceresponse) \| undefined&gt; | Send an activity to a conversation. |
+| `updateCoreActivityAsync` | (serviceUrl, conversationId, activityId, activity) =&gt; Promise&lt;[ResourceResponse](#resourceresponse) \| undefined&gt; | Update an existing activity. |
 | `deleteCoreActivityAsync` | `(serviceUrl, conversationId, activityId) => Promise<void>` | Delete an activity. |
-| `getConversationMembersAsync` | `(serviceUrl, conversationId) => Promise<[ChannelAccount](#channelaccount)[]>` | List conversation members. |
-| `getConversationMemberAsync` | `(serviceUrl, conversationId, memberId) => Promise<[ChannelAccount](#channelaccount) \| undefined>` | Get a single member. |
-| `getConversationPagedMembersAsync` | `(serviceUrl, conversationId, pageSize?, continuationToken?) => Promise<[PagedMembersResult](#pagedmembersresult)<[ChannelAccount](#channelaccount)>>` | Get members with pagination. |
+| `getConversationMembersAsync` | (serviceUrl, conversationId) =&gt; Promise&lt;[ChannelAccount](#channelaccount)[]&gt; | List conversation members. |
+| `getConversationMemberAsync` | (serviceUrl, conversationId, memberId) =&gt; Promise&lt;[ChannelAccount](#channelaccount) \| undefined&gt; | Get a single member. |
+| `getConversationPagedMembersAsync` | (serviceUrl, conversationId, pageSize?, continuationToken?) =&gt; Promise&lt;[PagedMembersResult](#pagedmembersresult)&lt;[ChannelAccount](#channelaccount)&gt;&gt; | Get members with pagination. |
 | `deleteConversationMemberAsync` | `(serviceUrl, conversationId, memberId) => Promise<void>` | Remove a member. |
-| `createConversationAsync` | `(serviceUrl, parameters) => Promise<[ConversationResourceResponse](#conversationresourceresponse) \| undefined>` | Create a proactive conversation. |
+| `createConversationAsync` | (serviceUrl, parameters) =&gt; Promise&lt;[ConversationResourceResponse](#conversationresourceresponse) \| undefined&gt; | Create a proactive conversation. |
 | `getConversationsAsync` | `(serviceUrl, continuationToken?) => Promise<ConversationsResult>` | List conversations. |
-| `sendConversationHistoryAsync` | `(serviceUrl, conversationId, transcript) => Promise<[ResourceResponse](#resourceresponse) \| undefined>` | Upload a conversation transcript. |
-| `getConversationAsync` | `(serviceUrl, conversationId) => Promise<[Conversation](#conversation) \| undefined>` | Get conversation details. |
+| `sendConversationHistoryAsync` | (serviceUrl, conversationId, transcript) =&gt; Promise&lt;[ResourceResponse](#resourceresponse) \| undefined&gt; | Upload a conversation transcript. |
+| `getConversationAsync` | (serviceUrl, conversationId) =&gt; Promise&lt;[Conversation](#conversation) \| undefined&gt; | Get conversation details. |
 
 ---
 
@@ -128,14 +128,14 @@ interface CoreActivity
 |----------|------|-------------|
 | `type` | `string` | Activity type (e.g. `"message"`, `"typing"`). |
 | `serviceUrl` | `string` | Bot Framework service URL for replies. |
-| `from` | `[ChannelAccount](#channelaccount)` | Sender account. |
-| `recipient` | `[ChannelAccount](#channelaccount)` | Recipient account. |
-| `conversation` | `[Conversation](#conversation)` | Conversation reference. |
+| `from` | [ChannelAccount](#channelaccount) | Sender account. |
+| `recipient` | [ChannelAccount](#channelaccount) | Recipient account. |
+| `conversation` | [Conversation](#conversation) | Conversation reference. |
 | `text` | `string?` | Text content. |
 | `name` | `string?` | Activity name (for invoke/event). |
 | `value` | `unknown?` | Activity value payload. |
-| `entities` | `[Entity](#entity)[]?` | Entity metadata (mentions, etc.). |
-| `attachments` | `[Attachment](#attachment)[]?` | File/card attachments. |
+| `entities` | [Entity](#entity)[]? | Entity metadata (mentions, etc.). |
+| `attachments` | [Attachment](#attachment)[]? | File/card attachments. |
 | `properties` | `Record<string, unknown>?` | Additional properties (round-trip safe). |
 
 ---
@@ -159,7 +159,7 @@ class CoreActivityBuilder
 | `withText(text)` | `this` | Set the text content. |
 | `withEntities(entities)` | `this` | Set entities. |
 | `withAttachments(attachments)` | `this` | Set attachments. |
-| `build()` | `Partial<[CoreActivity](#coreactivity)>` | Build the activity. |
+| `build()` | Partial&lt;[CoreActivity](#coreactivity)&gt; | Build the activity. |
 
 ---
 
@@ -212,7 +212,7 @@ interface ChannelAccount
 Teams-specific channel account with email and UPN.
 
 ```typescript
-interface TeamsChannelAccount extends [ChannelAccount](#channelaccount)
+interface TeamsChannelAccount extends ChannelAccount
 ```
 
 | Property | Type | Description |
@@ -296,7 +296,7 @@ interface SuggestedActions
 | Property | Type | Description |
 |----------|------|-------------|
 | `to` | `string[]?` | Recipient IDs. |
-| `actions` | `[CardAction](#cardaction)[]` | Action buttons. |
+| `actions` | [CardAction](#cardaction)[] | Action buttons. |
 
 ---
 
@@ -305,25 +305,25 @@ interface SuggestedActions
 Teams-specific activity with channel data and helpers.
 
 ```typescript
-interface TeamsActivity extends [CoreActivity](#coreactivity)
+interface TeamsActivity extends CoreActivity
 ```
 
 ### Additional Properties
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `channelData` | `[TeamsChannelData](#teamschanneldata)?` | Teams-specific channel data. |
+| `channelData` | [TeamsChannelData](#teamschanneldata)? | Teams-specific channel data. |
 | `timestamp` | `string?` | Activity timestamp. |
 | `localTimestamp` | `string?` | Local timestamp. |
 | `locale` | `string?` | User locale. |
 | `localTimezone` | `string?` | User timezone. |
-| `suggestedActions` | `[SuggestedActions](#suggestedactions)?` | Suggested actions. |
+| `suggestedActions` | [SuggestedActions](#suggestedactions)? | Suggested actions. |
 
 ### Static Methods
 
 | Method | Description |
 |--------|-------------|
-| `TeamsActivity.fromActivity(activity: [CoreActivity](#coreactivity))` | Shallow copy cast to `TeamsActivity`. |
+| `TeamsActivity.fromActivity(activity: CoreActivity)` | Shallow copy cast to `TeamsActivity`. |
 
 ---
 
@@ -353,7 +353,7 @@ class TeamsActivityBuilder
 | `addMention(account, mentionText?)` | `this` | Add @mention entity. |
 | `addAdaptiveCardAttachment(card)` | `this` | Append Adaptive Card. |
 | `withAdaptiveCardAttachment(card)` | `this` | Replace attachments with Adaptive Card. |
-| `build()` | `Partial<[TeamsActivity](#teamsactivity)>` | Build the activity. |
+| `build()` | Partial&lt;[TeamsActivity](#teamsactivity)&gt; | Build the activity. |
 
 ---
 
@@ -380,7 +380,7 @@ interface TeamsChannelData
 ### TurnMiddleware
 
 ```typescript
-type TurnMiddleware = (context: [TurnContext](#turncontext), next: NextTurn) => Promise<void>
+type TurnMiddleware = (context: TurnContext, next: NextTurn) => Promise<void>
 type NextTurn = () => Promise<void>
 ```
 
@@ -389,7 +389,7 @@ A function that participates in the turn pipeline. Call `next()` to continue, or
 ### removeMentionMiddleware
 
 ```typescript
-function removeMentionMiddleware(): [TurnMiddleware](#turnmiddleware)
+function removeMentionMiddleware(): TurnMiddleware
 ```
 
 Returns middleware that strips the bot's own `@mention` text from incoming messages.
@@ -404,7 +404,7 @@ Returns middleware that strips the bot's own `@mention` text from incoming messa
 function validateBotToken(authHeader: string | undefined, appId?: string): Promise<void>
 ```
 
-Validates the inbound JWT bearer token against Bot Framework issuers and JWKS endpoints. Throws `[BotAuthError](#botautherror)` on failure.
+Validates the inbound JWT bearer token against Bot Framework issuers and JWKS endpoints. Throws [BotAuthError](#botautherror) on failure.
 
 ### validateServiceUrl
 
@@ -412,7 +412,7 @@ Validates the inbound JWT bearer token against Bot Framework issuers and JWKS en
 function validateServiceUrl(serviceUrl: string): void
 ```
 
-Validates the service URL against the Bot Framework allowlist. Throws `[BotAuthError](#botautherror)` for disallowed URLs.
+Validates the service URL against the Bot Framework allowlist. Throws [BotAuthError](#botautherror) for disallowed URLs.
 
 ### BotAuthError
 
@@ -459,7 +459,7 @@ Wraps exceptions thrown inside activity handlers with the originating activity.
 | Property | Type | Description |
 |----------|------|-------------|
 | `cause` | `unknown` | Original exception. |
-| `activity` | `[CoreActivity](#coreactivity)` | Activity being processed. |
+| `activity` | [CoreActivity](#coreactivity) | Activity being processed. |
 
 ### RequestBodyTooLargeError
 
@@ -516,7 +516,7 @@ interface ResourceResponse {
 ### ConversationResourceResponse
 
 ```typescript
-interface ConversationResourceResponse extends [ResourceResponse](#resourceresponse) {
+interface ConversationResourceResponse extends ResourceResponse {
   serviceUrl: string
   activityId: string
 }
@@ -580,7 +580,7 @@ new BotApp(options?: [BotAppOptions](#botappoptions))
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `bot` | `readonly [BotApplication](#botapplication)` | The underlying `BotApplication` instance. |
+| `bot` | readonly [BotApplication](#botapplication) | The underlying `BotApplication` instance. |
 
 #### Methods
 
@@ -588,8 +588,8 @@ new BotApp(options?: [BotAppOptions](#botappoptions))
 |--------|-----------|-------------|
 | `on` | `on(type: string, handler: CoreActivityHandler): this` | Register an activity handler. Delegates to `BotApplication.on`. |
 | `onInvoke` | `onInvoke(name: string, handler: InvokeActivityHandler): this` | Register a named invoke handler. Delegates to `BotApplication.onInvoke`. |
-| `use` | `use(middleware: [TurnMiddleware](#turnmiddleware)): this` | Add middleware to the pipeline. Delegates to `BotApplication.use`. |
-| `sendActivityAsync` | `sendActivityAsync(serviceUrl: string, conversationId: string, activity: Partial<[CoreActivity](#coreactivity)>): Promise<[ResourceResponse](#resourceresponse) \| undefined>` | Send a proactive activity. Delegates to `BotApplication.sendActivityAsync`. |
+| `use` | use(middleware: [TurnMiddleware](#turnmiddleware)): this | Add middleware to the pipeline. Delegates to `BotApplication.use`. |
+| `sendActivityAsync` | sendActivityAsync(serviceUrl: string, conversationId: string, activity: Partial&lt;[CoreActivity](#coreactivity)&gt;): Promise&lt;[ResourceResponse](#resourceresponse) \| undefined&gt; | Send a proactive activity. Delegates to `BotApplication.sendActivityAsync`. |
 | `start` | `start(): Server` | Start the Express server. Returns the `http.Server` instance. |
 
 #### Example
@@ -611,7 +611,7 @@ app.start()
 Configuration options for `BotApp`. Extends [`BotApplicationOptions`](#botapplicationoptions) with Express-specific settings.
 
 ```typescript
-interface BotAppOptions extends [BotApplicationOptions](#botapplicationoptions)
+interface BotAppOptions extends BotApplicationOptions
 ```
 
 | Field | Type | Default | Description |

--- a/docs-site/api/python.md
+++ b/docs-site/api/python.md
@@ -40,10 +40,10 @@ Options default from environment variables (`CLIENT_ID`, `CLIENT_SECRET`, `TENAN
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `on` | `on(type: str, handler: ActivityHandler \| None = None) -> Any` | Register an activity handler by type. Can be used as a decorator: `@bot.on("message")`. |
-| `use` | `use(middleware: [TurnMiddleware](#turnmiddleware)) -> [BotApplication](#botapplication)` | Add middleware to the pipeline. |
+| `use` | use(middleware: [TurnMiddleware](#turnmiddleware)) -&gt; [BotApplication](#botapplication) | Add middleware to the pipeline. |
 | `on_invoke` | `on_invoke(name: str, handler: InvokeActivityHandler \| None = None) -> Any` | Register a named invoke handler. Can be used as a decorator. |
-| `process_body` | `async process_body(body: str) -> [InvokeResponse](#invokeresponse) \| None` | Parse and process a raw JSON activity body. |
-| `send_activity_async` | `async send_activity_async(service_url: str, conversation_id: str, activity: [CoreActivity](#coreactivity) \| dict) -> [ResourceResponse](#resourceresponse) \| None` | Send a proactive activity to a conversation. |
+| `process_body` | async process_body(body: str) -&gt; [InvokeResponse](#invokeresponse) \| None | Parse and process a raw JSON activity body. |
+| `send_activity_async` | async send_activity_async(service_url: str, conversation_id: str, activity: [CoreActivity](#coreactivity) \| dict) -&gt; [ResourceResponse](#resourceresponse) \| None | Send a proactive activity to a conversation. |
 | `aclose` | `async aclose() -> None` | Clean up resources (HTTP clients, token manager). |
 
 Supports `async with` context manager.
@@ -87,14 +87,14 @@ TurnContext(app: [BotApplication](#botapplication), activity: [CoreActivity](#co
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `activity` | `[CoreActivity](#coreactivity)` | The incoming activity for this turn. |
-| `app` | `[BotApplication](#botapplication)` | The bot application processing this turn. |
+| `activity` | [CoreActivity](#coreactivity) | The incoming activity for this turn. |
+| `app` | [BotApplication](#botapplication) | The bot application processing this turn. |
 
 ### Methods
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `send` | `async send(activity_or_text: str \| [CoreActivity](#coreactivity) \| dict) -> [ResourceResponse](#resourceresponse) \| None` | Reply with text, a full activity, or a dict. |
+| `send` | async send(activity_or_text: str \| [CoreActivity](#coreactivity) \| dict) -&gt; [ResourceResponse](#resourceresponse) \| None | Reply with text, a full activity, or a dict. |
 | `send_typing` | `async send_typing() -> None` | Send a typing indicator. |
 
 ---
@@ -117,17 +117,17 @@ ConversationClient(get_token: TokenProvider | None = None)
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `send_activity_async` | `async (service_url, conversation_id, activity) -> [ResourceResponse](#resourceresponse) \| None` | Send an activity. |
-| `update_activity_async` | `async (service_url, conversation_id, activity_id, activity) -> [ResourceResponse](#resourceresponse) \| None` | Update an activity. |
+| `send_activity_async` | async (service_url, conversation_id, activity) -&gt; [ResourceResponse](#resourceresponse) \| None | Send an activity. |
+| `update_activity_async` | async (service_url, conversation_id, activity_id, activity) -&gt; [ResourceResponse](#resourceresponse) \| None | Update an activity. |
 | `delete_activity_async` | `async (service_url, conversation_id, activity_id) -> None` | Delete an activity. |
-| `get_conversation_members_async` | `async (service_url, conversation_id) -> list[[ChannelAccount](#channelaccount)]` | List members. |
-| `get_conversation_member_async` | `async (service_url, conversation_id, member_id) -> [ChannelAccount](#channelaccount) \| None` | Get one member. |
-| `get_conversation_paged_members_async` | `async (service_url, conversation_id, page_size?, continuation_token?) -> [PagedMembersResult](#pagedmembersresult)` | Get members with pagination. |
+| `get_conversation_members_async` | async (service_url, conversation_id) -&gt; list[[ChannelAccount](#channelaccount)] | List members. |
+| `get_conversation_member_async` | async (service_url, conversation_id, member_id) -&gt; [ChannelAccount](#channelaccount) \| None | Get one member. |
+| `get_conversation_paged_members_async` | async (service_url, conversation_id, page_size?, continuation_token?) -&gt; [PagedMembersResult](#pagedmembersresult) | Get members with pagination. |
 | `delete_conversation_member_async` | `async (service_url, conversation_id, member_id) -> None` | Remove a member. |
-| `create_conversation_async` | `async (service_url, parameters) -> [ConversationResourceResponse](#conversationresourceresponse) \| None` | Create a proactive conversation. |
+| `create_conversation_async` | async (service_url, parameters) -&gt; [ConversationResourceResponse](#conversationresourceresponse) \| None | Create a proactive conversation. |
 | `get_conversations_async` | `async (service_url, continuation_token?) -> ConversationsResult` | List conversations. |
-| `send_conversation_history_async` | `async (service_url, conversation_id, transcript) -> [ResourceResponse](#resourceresponse) \| None` | Upload transcript. |
-| `get_conversation_account_async` | `async (service_url, conversation_id) -> [Conversation](#conversation) \| None` | Get conversation details. |
+| `send_conversation_history_async` | async (service_url, conversation_id, transcript) -&gt; [ResourceResponse](#resourceresponse) \| None | Upload transcript. |
+| `get_conversation_account_async` | async (service_url, conversation_id) -&gt; [Conversation](#conversation) \| None | Get conversation details. |
 | `aclose` | `async aclose() -> None` | Close the HTTP session. |
 
 ---
@@ -144,14 +144,14 @@ class CoreActivity(BaseModel)
 |-------|------|-----------|-------------|
 | `type` | `str` | `type` | Activity type (e.g. `"message"`, `"typing"`). |
 | `service_url` | `str` | `serviceUrl` | Bot Framework service URL. |
-| `from_account` | `[ChannelAccount](#channelaccount) \| None` | `from` | Sender account. |
-| `recipient` | `[ChannelAccount](#channelaccount) \| None` | `recipient` | Recipient account. |
-| `conversation` | `[Conversation](#conversation) \| None` | `conversation` | Conversation reference. |
+| `from_account` | [ChannelAccount](#channelaccount) \| None | `from` | Sender account. |
+| `recipient` | [ChannelAccount](#channelaccount) \| None | `recipient` | Recipient account. |
+| `conversation` | [Conversation](#conversation) \| None | `conversation` | Conversation reference. |
 | `text` | `str \| None` | `text` | Text content. |
 | `name` | `str \| None` | `name` | Activity name (invoke/event). |
 | `value` | `Any` | `value` | Activity value payload. |
-| `entities` | `list[[Entity](#entity)] \| None` | `entities` | Entity metadata. |
-| `attachments` | `list[[Attachment](#attachment)] \| None` | `attachments` | Attachments. |
+| `entities` | list[[Entity](#entity)] \| None | `entities` | Entity metadata. |
+| `attachments` | list[[Attachment](#attachment)] \| None | `attachments` | Attachments. |
 
 ### Methods
 
@@ -172,16 +172,16 @@ class CoreActivityBuilder
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `with_conversation_reference(source)` | `[CoreActivityBuilder](#coreactivitybuilder)` | Copy conversation reference. |
-| `with_type(activity_type)` | `[CoreActivityBuilder](#coreactivitybuilder)` | Set activity type. |
-| `with_service_url(service_url)` | `[CoreActivityBuilder](#coreactivitybuilder)` | Set service URL. |
-| `with_conversation(conversation)` | `[CoreActivityBuilder](#coreactivitybuilder)` | Set conversation. |
-| `with_from(from_account)` | `[CoreActivityBuilder](#coreactivitybuilder)` | Set sender. |
-| `with_recipient(recipient)` | `[CoreActivityBuilder](#coreactivitybuilder)` | Set recipient. |
-| `with_text(text)` | `[CoreActivityBuilder](#coreactivitybuilder)` | Set text. |
-| `with_entities(entities)` | `[CoreActivityBuilder](#coreactivitybuilder)` | Set entities. |
-| `with_attachments(attachments)` | `[CoreActivityBuilder](#coreactivitybuilder)` | Set attachments. |
-| `build()` | `[CoreActivity](#coreactivity)` | Build the activity. |
+| `with_conversation_reference(source)` | [CoreActivityBuilder](#coreactivitybuilder) | Copy conversation reference. |
+| `with_type(activity_type)` | [CoreActivityBuilder](#coreactivitybuilder) | Set activity type. |
+| `with_service_url(service_url)` | [CoreActivityBuilder](#coreactivitybuilder) | Set service URL. |
+| `with_conversation(conversation)` | [CoreActivityBuilder](#coreactivitybuilder) | Set conversation. |
+| `with_from(from_account)` | [CoreActivityBuilder](#coreactivitybuilder) | Set sender. |
+| `with_recipient(recipient)` | [CoreActivityBuilder](#coreactivitybuilder) | Set recipient. |
+| `with_text(text)` | [CoreActivityBuilder](#coreactivitybuilder) | Set text. |
+| `with_entities(entities)` | [CoreActivityBuilder](#coreactivitybuilder) | Set entities. |
+| `with_attachments(attachments)` | [CoreActivityBuilder](#coreactivitybuilder) | Set attachments. |
+| `build()` | [CoreActivity](#coreactivity) | Build the activity. |
 
 ---
 
@@ -207,7 +207,7 @@ class ChannelAccount(BaseModel)
 Teams-specific channel account with email and UPN.
 
 ```python
-class TeamsChannelAccount([ChannelAccount](#channelaccount))
+class TeamsChannelAccount(ChannelAccount)
 ```
 
 | Field | Type | JSON Alias | Description |
@@ -289,7 +289,7 @@ class SuggestedActions(BaseModel)
 | Field | Type | Description |
 |-------|------|-------------|
 | `to` | `list[str] \| None` | Recipient IDs. |
-| `actions` | `list[[CardAction](#cardaction)]` | Action buttons (default `[]`). |
+| `actions` | list[[CardAction](#cardaction)] | Action buttons (default `[]`). |
 
 ---
 
@@ -298,27 +298,27 @@ class SuggestedActions(BaseModel)
 Teams-specific activity with channel data and helpers. Extends `[CoreActivity](#coreactivity)`.
 
 ```python
-class TeamsActivity([CoreActivity](#coreactivity))
+class TeamsActivity(CoreActivity)
 ```
 
 ### Additional Fields
 
 | Field | Type | JSON Alias | Description |
 |-------|------|-----------|-------------|
-| `channel_data` | `[TeamsChannelData](#teamschanneldata) \| None` | `channelData` | Teams channel data. |
+| `channel_data` | [TeamsChannelData](#teamschanneldata) \| None | `channelData` | Teams channel data. |
 | `timestamp` | `str \| None` | `timestamp` | Activity timestamp. |
 | `local_timestamp` | `str \| None` | `localTimestamp` | Local timestamp. |
 | `locale` | `str \| None` | `locale` | User locale. |
 | `local_timezone` | `str \| None` | `localTimezone` | User timezone. |
-| `suggested_actions` | `[SuggestedActions](#suggestedactions) \| None` | `suggestedActions` | Suggested actions. |
+| `suggested_actions` | [SuggestedActions](#suggestedactions) \| None | `suggestedActions` | Suggested actions. |
 
 ### Methods
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `from_activity` | `classmethod (activity: [CoreActivity](#coreactivity)) -> [TeamsActivity](#teamsactivity)` | Convert from CoreActivity. |
-| `add_entity` | `(entity: [Entity](#entity)) -> None` | Add an entity. |
-| `create_builder` | `classmethod () -> [TeamsActivityBuilder](#teamsactivitybuilder)` | Create a fluent builder. |
+| `from_activity` | classmethod (activity: [CoreActivity](#coreactivity)) -&gt; [TeamsActivity](#teamsactivity) | Convert from CoreActivity. |
+| `add_entity` | (entity: [Entity](#entity)) -&gt; None | Add an entity. |
+| `create_builder` | classmethod () -&gt; [TeamsActivityBuilder](#teamsactivitybuilder) | Create a fluent builder. |
 
 ---
 
@@ -332,24 +332,24 @@ class TeamsActivityBuilder
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `with_conversation_reference(source)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Copy conversation reference. |
-| `with_type(activity_type)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set activity type. |
-| `with_service_url(service_url)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set service URL. |
-| `with_conversation(conversation)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set conversation. |
-| `with_from(from_account)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set sender. |
-| `with_recipient(recipient)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set recipient. |
-| `with_text(text)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set text. |
-| `with_channel_data(channel_data)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set channel data. |
-| `with_suggested_actions(actions)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set suggested actions. |
-| `with_entities(entities)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set entities. |
-| `with_attachments(attachments)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set attachments. |
-| `with_attachment(attachment)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Set single attachment. |
-| `add_entity(entity)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Append entity. |
-| `add_attachment(attachment)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Append attachment. |
-| `add_mention(account, mention_text?)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Add @mention entity. |
-| `add_adaptive_card_attachment(card)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Append Adaptive Card (JSON string or dict). |
-| `with_adaptive_card_attachment(card)` | `[TeamsActivityBuilder](#teamsactivitybuilder)` | Replace attachments with Adaptive Card. |
-| `build()` | `[TeamsActivity](#teamsactivity)` | Build the activity. |
+| `with_conversation_reference(source)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Copy conversation reference. |
+| `with_type(activity_type)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set activity type. |
+| `with_service_url(service_url)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set service URL. |
+| `with_conversation(conversation)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set conversation. |
+| `with_from(from_account)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set sender. |
+| `with_recipient(recipient)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set recipient. |
+| `with_text(text)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set text. |
+| `with_channel_data(channel_data)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set channel data. |
+| `with_suggested_actions(actions)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set suggested actions. |
+| `with_entities(entities)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set entities. |
+| `with_attachments(attachments)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set attachments. |
+| `with_attachment(attachment)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Set single attachment. |
+| `add_entity(entity)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Append entity. |
+| `add_attachment(attachment)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Append attachment. |
+| `add_mention(account, mention_text?)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Add @mention entity. |
+| `add_adaptive_card_attachment(card)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Append Adaptive Card (JSON string or dict). |
+| `with_adaptive_card_attachment(card)` | [TeamsActivityBuilder](#teamsactivitybuilder) | Replace attachments with Adaptive Card. |
+| `build()` | [TeamsActivity](#teamsactivity) | Build the activity. |
 
 ---
 
@@ -376,7 +376,7 @@ class TeamsChannelData(BaseModel)
 Teams-specific conversation metadata.
 
 ```python
-class TeamsConversation([Conversation](#conversation))
+class TeamsConversation(Conversation)
 ```
 
 | Field | Type | JSON Alias | Description |
@@ -394,7 +394,7 @@ class TeamsConversation([Conversation](#conversation))
 
 ```python
 class TurnMiddleware(Protocol):
-    async def on_turn(self, context: [TurnContext](#turncontext), next: NextTurn) -> None: ...
+    async def on_turn(self, context: TurnContext, next: NextTurn) -> None: ...
 ```
 
 Protocol for turn middleware. Call `await next()` to continue the pipeline, or skip it to short-circuit.
@@ -411,7 +411,7 @@ Middleware that strips the bot's own `@mention` text from incoming messages.
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `on_turn` | `async on_turn(context: [TurnContext](#turncontext), next: NextTurn) -> None` | Remove self-mentions, then call next. |
+| `on_turn` | async on_turn(context: [TurnContext](#turncontext), next: NextTurn) -&gt; None | Remove self-mentions, then call next. |
 
 ---
 
@@ -423,7 +423,7 @@ Middleware that strips the bot's own `@mention` text from incoming messages.
 async def validate_bot_token(auth_header: str | None, app_id: str | None = None) -> None
 ```
 
-Validates the inbound JWT bearer token against Bot Framework issuers and JWKS endpoints. Raises `[BotAuthError](#botautherror)` on failure.
+Validates the inbound JWT bearer token against Bot Framework issuers and JWKS endpoints. Raises [BotAuthError](#botautherror) on failure.
 
 ### BotAuthError
 
@@ -476,8 +476,8 @@ Wraps exceptions thrown inside activity handlers.
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `cause` | `BaseException` | Original exception. |
-| `activity` | `[CoreActivity](#coreactivity)` | Activity being processed. |
+| `cause` | BaseException | Original exception. |
+| `activity` | [CoreActivity](#coreactivity) | Activity being processed. |
 
 ### InvokeResponse
 
@@ -504,7 +504,7 @@ class ResourceResponse(BaseModel):
 ### ConversationResourceResponse
 
 ```python
-class ConversationResourceResponse([ResourceResponse](#resourceresponse)):
+class ConversationResourceResponse(ResourceResponse):
     service_url: str
     activity_id: str
 ```
@@ -578,7 +578,7 @@ BotApp(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `options` | `[BotApplicationOptions](#botapplicationoptions)` | `BotApplicationOptions()` | Core bot options (auth, tokens). |
+| `options` | [BotApplicationOptions](#botapplicationoptions) | `BotApplicationOptions()` | Core bot options (auth, tokens). |
 | `port` | `int \| None` | `PORT` env or `3978` | Port to listen on. |
 | `path` | `str` | `"/api/messages"` | Path for the messages endpoint. |
 | `auth` | `bool \| None` | `True` when `client_id` set | Whether to enable inbound JWT auth. |
@@ -587,7 +587,7 @@ BotApp(
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `bot` | `[BotApplication](#botapplication)` | The underlying `BotApplication` instance. |
+| `bot` | [BotApplication](#botapplication) | The underlying `BotApplication` instance. |
 
 #### Methods
 
@@ -595,8 +595,8 @@ BotApp(
 |--------|-----------|-------------|
 | `on` | `on(type: str, handler=None) -> Any` | Register an activity handler. Works as a decorator. Delegates to `BotApplication.on`. |
 | `on_invoke` | `on_invoke(name: str, handler=None) -> Any` | Register a named invoke handler. Works as a decorator. Delegates to `BotApplication.on_invoke`. |
-| `use` | `use(middleware: [TurnMiddleware](#turnmiddleware)) -> [BotApp](#botapp)` | Add middleware to the turn pipeline. |
-| `send_activity_async` | `async send_activity_async(service_url, conversation_id, activity) -> [ResourceResponse](#resourceresponse) \| None` | Proactively send an activity. |
+| `use` | use(middleware: [TurnMiddleware](#turnmiddleware)) -&gt; [BotApp](#botapp) | Add middleware to the turn pipeline. |
+| `send_activity_async` | async send_activity_async(service_url, conversation_id, activity) -&gt; [ResourceResponse](#resourceresponse) \| None | Proactively send an activity. |
 | `start` | `start() -> None` | Build the FastAPI app and start Uvicorn. Blocks until shutdown. |
 
 #### Example

--- a/docs-site/generate-api-docs.sh
+++ b/docs-site/generate-api-docs.sh
@@ -6,6 +6,74 @@ set -e
 
 echo "🔧 Generating API documentation for Botas..."
 
+# Function to sanitize .NET docs by converting XML tags to markdown
+sanitize_dotnet_docs() {
+    echo "   Sanitizing .NET API docs (removing XML tags)..."
+    local docs_dir="../docs-site/api/generated/dotnet"
+    
+    if [ ! -d "$docs_dir" ]; then
+        echo "   ⚠️  No .NET docs directory found at $docs_dir"
+        return
+    fi
+    
+    # Process each markdown file
+    find "$docs_dir" -name "*.md" -type f | while read -r file; do
+        # Create a temporary file
+        local temp_file="${file}.tmp"
+        
+        # Use awk to handle multi-line <example><code>...</code></example> blocks
+        awk '
+        /<example>/ {
+            in_example = 1
+            example_block = ""
+            next
+        }
+        in_example {
+            if (/<\/example>/) {
+                # Extract code content between <code> and </code>
+                gsub(/<\/?code>/, "", example_block)
+                # Remove leading/trailing whitespace
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", example_block)
+                # Print as code fence
+                print "```csharp"
+                print example_block
+                print "```"
+                in_example = 0
+                example_block = ""
+                next
+            }
+            # Accumulate lines in example block, skip <code> tags
+            if (/<\/?code>/) {
+                next
+            }
+            if (example_block != "") {
+                example_block = example_block "\n" $0
+            } else {
+                example_block = $0
+            }
+            next
+        }
+        # Strip other XML doc tags outside of code blocks
+        {
+            # Remove <see cref="..."/> and <see cref="...">...</see>
+            gsub(/<see cref="[^"]*"[^>]*>([^<]*)<\/see>/, "\\1")
+            gsub(/<see cref="[^"]*"[^>]*\/>/, "")
+            # Remove <param>, <returns>, <summary>, <remarks> tags
+            gsub(/<\/?param[^>]*>/, "")
+            gsub(/<\/?returns[^>]*>/, "")
+            gsub(/<\/?summary[^>]*>/, "")
+            gsub(/<\/?remarks[^>]*>/, "")
+            print
+        }
+        ' "$file" > "$temp_file"
+        
+        # Replace original with sanitized version
+        mv "$temp_file" "$file"
+    done
+    
+    echo "   ✅ .NET API docs sanitized"
+}
+
 # .NET API docs with DefaultDocumentation
 echo "📘 Generating .NET API docs..."
 cd ../dotnet
@@ -23,6 +91,8 @@ if [ -f "$ASSEMBLY_PATH" ]; then
     mkdir -p ../docs-site/api/generated/dotnet
     defaultdocumentation --AssemblyFilePath "$ASSEMBLY_PATH" --OutputDirectoryPath ../docs-site/api/generated/dotnet --GeneratedPages "Namespaces, Types, Members"
     echo "   ✅ .NET API docs generated to docs-site/api/generated/dotnet/"
+    # Sanitize the generated docs to remove XML tags
+    sanitize_dotnet_docs
 else
     echo "   ⚠️  Assembly not found at $ASSEMBLY_PATH"
 fi


### PR DESCRIPTION
## What

- **Cross-links fixed**: Removed backticks from ~98 table cells in \
odejs.md\ and \python.md\ that contained \[TypeName](#anchor)\ links. Markdown doesn't render links inside code spans, so they appeared as raw text.
- **Angle brackets escaped**: Generics like \Promise<T>\ now use \&lt;\/\&gt;\ HTML entities so VitePress doesn't interpret them as HTML tags.
- **Generated .NET docs sanitized**: Added \sanitize_dotnet_docs()\ post-processing in \generate-api-docs.sh\ that converts XML doc tags (\<example>\, \<code>\) to markdown code fences, preventing VitePress build failures.

## Verified

- VitePress build passes ✅
- Cross-links render as clickable \<a href>\ tags in both Node.js and Python API docs ✅
- Angle brackets display correctly for generics ✅