### PR TITLE
docs: add package registry links to language guides

### DIFF
--- a/docs-site/.vitepress/theme/index.ts
+++ b/docs-site/.vitepress/theme/index.ts
@@ -10,7 +10,7 @@ function VersionBadge() {
       class: 'version-badge',
       style: 'margin-left: 8px; padding: 2px 8px; font-size: 12px; border-radius: 6px; background: var(--vp-c-brand-soft); color: var(--vp-c-brand-1); font-weight: 600;',
     },
-    'v0.3'
+    'v0.3.18-alpha'
   )
 }
 

--- a/docs-site/languages/dotnet.md
+++ b/docs-site/languages/dotnet.md
@@ -4,6 +4,8 @@ outline: deep
 
 # .NET (C#)
 
+📦 [Botas 0.3.18-alpha on NuGet](https://www.nuget.org/packages/Botas/0.3.18-alpha)
+
 ## Project setup
 
 The botas library targets **.NET 10**. Add a NuGet package reference to your ASP.NET Core web project:

--- a/docs-site/languages/nodejs.md
+++ b/docs-site/languages/nodejs.md
@@ -4,6 +4,8 @@ outline: deep
 
 # Node.js (TypeScript)
 
+📦 [botas-core 0.3.18-alpha](https://www.npmjs.com/package/botas-core/v/0.3.18-alpha) · [botas-express 0.3.18-alpha](https://www.npmjs.com/package/botas-express/v/0.3.18-alpha)
+
 ## Installation
 
 The Node.js implementation ships as two npm packages, both published as ES modules and requiring **Node.js 20+**:

--- a/docs-site/languages/python.md
+++ b/docs-site/languages/python.md
@@ -4,6 +4,8 @@ outline: deep
 
 # Python
 
+📦 [botas 0.3.18 on PyPI](https://pypi.org/project/botas/0.3.18/)
+
 ## Installation
 
 The Python implementation ships as two pip packages, requiring **Python 3.11+**:

--- a/docs-site/versions.json
+++ b/docs-site/versions.json
@@ -1,4 +1,4 @@
 {
-  "current": "0.3",
+  "current": "0.3.18-alpha",
   "versions": []
 }


### PR DESCRIPTION
Add version-specific package links to each language guide page, with the version matching the version selector.

### Changes
- **versions.json** + **VersionBadge**: Updated from \