### PR TITLE
Rename 'Bot Framework' to 'Bot Service'

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Copilot Instructions for `botas`
 
 ## Purpose
-This repository implements a multi-language Bot Framework library with .NET, Node.js, and Python ports. The primary work is library behavior parity, middleware pipeline consistency, and authentication correctness.
+This repository implements a multi-language Bot Service library with .NET, Node.js, and Python ports. The primary work is library behavior parity, middleware pipeline consistency, and authentication correctness.
 
 ## What to read first
 - `AGENTS.md` — porting guide and behavioral invariants for all languages
@@ -61,7 +61,7 @@ If you need implementation or architectural details, link to the existing docs i
 ## What not to do
 - Do not add new instructions that conflict with `AGENTS.md` or `specs/README.md`.
 - Do not treat this repo as a single-language project.
-- Do not invent new authentication flows or HTTP contracts outside the Bot Framework model.
+- Do not invent new authentication flows or HTTP contracts outside the Bot Service model.
 
 ## Good first tasks for agents
 - Update implementation docs when behavior changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`botas` is a multi-language Bot Framework library with implementations in **.NET**, **Node.js**, and **Python**. The goal is behavioral parity across all languages while following each language's idioms.
+`botas` is a multi-language Bot Service library with implementations in **.NET**, **Node.js**, and **Python**. The goal is behavioral parity across all languages while following each language's idioms.
 
 ---
 
@@ -86,7 +86,7 @@ Rules: `E`, `F`, `W`, `I` — line length **120** (see `python/packages/botas/py
 ## What Not to Do
 
 - Do not duplicate spec content in this file or elsewhere — link to `specs/` instead.
-- Do not invent new authentication flows or HTTP contracts outside the Bot Framework model.
+- Do not invent new authentication flows or HTTP contracts outside the Bot Service model.
 - Do not treat this repo as a single-language project.
 
 ---
@@ -108,5 +108,5 @@ Verify with a quick grep: `grep -rn 'oldPattern' docs-site/ specs/` before commi
 - [specs/](specs/README.md) — canonical feature specification (start here)
 - [specs/Architecture.md](specs/architecture.md) — design overview and component diagram
 - [specs/Setup.md](specs/setup.md) — Azure registration and bot credentials
-- [Bot Framework REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference)
-- [Bot Framework authentication](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-authentication)
+- [Bot Service REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference)
+- [Bot Service authentication](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-authentication)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Repo Is
 
-`botas` is a multi-language Bot Framework library with implementations in **.NET**, **Node.js**, and **Python**. The primary work is behavioral parity across languages, middleware pipeline consistency, and authentication correctness.
+`botas` is a multi-language Bot Service library with implementations in **.NET**, **Node.js**, and **Python**. The primary work is behavioral parity across languages, middleware pipeline consistency, and authentication correctness.
 
 Read these first:
 - `specs/README.md` — canonical feature specification and language-specific intentional differences
@@ -76,7 +76,7 @@ POST /api/messages
 
 **Two-auth model**:
 - **Inbound**: JWT bearer token validated before any processing. Fetches JWKS from botframework.com.
-- **Outbound**: `TokenManager` acquires and caches OAuth2 client-credentials tokens for Bot Framework API calls.
+- **Outbound**: `TokenManager` acquires and caches OAuth2 client-credentials tokens for Bot Service API calls.
 
 **Handler registration** (per language):
 - Node.js / Python: `on(type, handler)` / `@bot.on("type")` decorator — one handler per activity type

--- a/Skills.md
+++ b/Skills.md
@@ -1,8 +1,8 @@
 ---
 name: botas
-description: Lightweight multi-language Bot Framework library for building Microsoft Teams bots in .NET, Node.js, and Python with middleware pipelines, JWT authentication, and handler patterns.
+description: Lightweight multi-language Bot Service library for building Microsoft Teams bots in .NET, Node.js, and Python with middleware pipelines, JWT authentication, and handler patterns.
 license: MIT
-compatibility: Requires .NET 10 SDK (C#), Node.js 20+ (TypeScript), or Python 3.12+ (asyncio). All languages support Microsoft Teams and Bot Framework HTTP protocol.
+compatibility: Requires .NET 10 SDK (C#), Node.js 20+ (TypeScript), or Python 3.12+ (asyncio). All languages support Microsoft Teams and Bot Service HTTP protocol.
 metadata:
   languages: ".NET,Node.js,Python"
   frameworks: "ASP.NET Core,Express,Hono,FastAPI,aiohttp"
@@ -11,7 +11,7 @@ metadata:
   docs: "https://rido-min.github.io/botas/"
 ---
 
-# BotAS — Bot Framework Library
+# BotAS — Bot Service Library
 
 Build Microsoft Teams bots in three languages with a unified API. Botas handles HTTP routing, JWT authentication, middleware pipelines, and activity handlers out of the box.
 
@@ -166,7 +166,7 @@ Register one handler per activity type. Unregistered types are silently ignored.
 
 **Common Activity Types:**
 
-Botas accepts *any* activity type string—the handler dispatch is string-based with no fixed enum. Below are the most common types in Bot Framework. You can register handlers for any custom or uncommon types as well.
+Botas accepts *any* activity type string—the handler dispatch is string-based with no fixed enum. Below are the most common types in Bot Service. You can register handlers for any custom or uncommon types as well.
 
 - `message` — User text messages
 - `typing` — Typing indicators
@@ -223,7 +223,7 @@ Botas handles two types of authentication:
 
 ### Inbound Authentication (Receiving Messages)
 
-Bot Framework signs every incoming request with a JWT token. Botas validates it automatically before calling handlers.
+Bot Service signs every incoming request with a JWT token. Botas validates it automatically before calling handlers.
 
 **Setup:**
 ```csharp
@@ -242,7 +242,7 @@ app = BotApp()
 ```
 
 **How it works:**
-1. Bot Framework sends request with `Authorization: Bearer <jwt>`
+1. Bot Service sends request with `Authorization: Bearer <jwt>`
 2. Botas fetches JWKS from Microsoft
 3. JWT is validated
 4. If valid, handler runs; if invalid, request rejected with 401
@@ -277,7 +277,7 @@ await ctx.send("Hello")
 1. Bot acquires OAuth2 token using `CLIENT_ID` + `CLIENT_SECRET`
 2. Token cached locally (refresh when expired)
 3. Every outbound activity includes `Authorization: Bearer <token>`
-4. Bot Framework validates token, processes message
+4. Bot Service validates token, processes message
 
 **Environment:**
 ```env

--- a/docs-site/api/dotnet.md
+++ b/docs-site/api/dotnet.md
@@ -57,7 +57,7 @@ public class BotApplication
 | `OnInvoke` | `BotApplication OnInvoke(string name, Func<TurnContext, CancellationToken, Task<InvokeResponse>> handler)` | Register a named invoke handler. |
 | `ProcessAsync` | `Task<CoreActivity> ProcessAsync(HttpContext httpContext, CancellationToken ct)` | Process an incoming HTTP request through the full pipeline. |
 | `Use` | `ITurnMiddleWare Use(ITurnMiddleWare middleware)` | Add middleware to the pipeline. |
-| `SendActivityAsync` | `Task<string> SendActivityAsync(CoreActivity activity, CancellationToken ct)` | Send an outbound activity via the Bot Framework API. |
+| `SendActivityAsync` | `Task<string> SendActivityAsync(CoreActivity activity, CancellationToken ct)` | Send an outbound activity via the Bot Service API. |
 
 ---
 
@@ -81,7 +81,7 @@ public class TurnContext
 
 ## ConversationClient
 
-Outbound Bot Framework REST API client with SSRF protection.
+Outbound Bot Service REST API client with SSRF protection.
 
 ```csharp
 public class ConversationClient
@@ -95,7 +95,7 @@ public class ConversationClient
 
 ## CoreActivity
 
-Bot Framework activity payload. Supports unknown JSON property round-tripping via `Properties`.
+Bot Service activity payload. Supports unknown JSON property round-tripping via `Properties`.
 
 ```csharp
 public class CoreActivity
@@ -112,7 +112,7 @@ public CoreActivity(string type = "message")
 | Property | Type | Description |
 |----------|------|-------------|
 | `Type` | `string` | Activity type (e.g. `"message"`, `"typing"`). |
-| `ServiceUrl` | `string?` | Bot Framework service URL for replies. |
+| `ServiceUrl` | `string?` | Bot Service service URL for replies. |
 | `Name` | `string?` | Activity name (used by invoke/event). |
 | `Value` | `object?` | Activity value payload. |
 | `Text` | `string?` | Text content of the activity. |
@@ -191,7 +191,7 @@ public class Conversation
 
 ## Entity
 
-Bot Framework entity metadata (mentions, places, etc.).
+Bot Service entity metadata (mentions, places, etc.).
 
 ```csharp
 public class Entity

--- a/docs-site/api/index.md
+++ b/docs-site/api/index.md
@@ -27,7 +27,7 @@ The .NET implementation is distributed as the **Botas** NuGet package. All types
 
 | Type | Description |
 |------|-------------|
-| [CoreActivity](/api/generated/dotnet/api/Botas.CoreActivity.html) | Bot Framework activity (the fundamental unit) |
+| [CoreActivity](/api/generated/dotnet/api/Botas.CoreActivity.html) | Bot Service activity (the fundamental unit) |
 | [CoreActivityBuilder](/api/generated/dotnet/api/Botas.CoreActivityBuilder.html) | Fluent builder for outbound activities |
 | [ActivityType](/api/generated/dotnet/api/Botas.ActivityType.html) | Core activity type string constants |
 | [ChannelAccount](/api/generated/dotnet/api/Botas.ChannelAccount.html) | User/bot/participant identity |
@@ -96,7 +96,7 @@ Core types and functionality for building bots in Node.js.
 
 | Type | Description |
 |------|-------------|
-| [CoreActivity](/api/generated/nodejs/botas-core/README#coreactivity) | Bot Framework activity schema |
+| [CoreActivity](/api/generated/nodejs/botas-core/README#coreactivity) | Bot Service activity schema |
 | [ActivityType](/api/generated/nodejs/botas-core/README#activitytype) | Activity type constants |
 | [TeamsActivity](/api/generated/nodejs/botas-core/README#teamsactivity) | Teams-specific activity with channel data |
 | [TeamsActivityType](/api/generated/nodejs/botas-core/README#teamsactivitytype) | Teams activity type constants |
@@ -131,7 +131,7 @@ Core modules and functionality for building bots in Python.
 | [bot_application](/api/generated/python/botas/#botas.bot_application) | Core bot application with middleware pipeline and handler dispatch |
 | [turn_context](/api/generated/python/botas/#botas.turn_context) | Single turn context (activity + send methods) |
 | [conversation_client](/api/generated/python/botas/#botas.conversation_client) | Outbound HTTP client with SSRF protection |
-| [core_activity](/api/generated/python/botas/#botas.core_activity) | Bot Framework activity schema |
+| [core_activity](/api/generated/python/botas/#botas.core_activity) | Bot Service activity schema |
 | [i_turn_middleware](/api/generated/python/botas/#botas.i_turn_middleware) | Middleware pipeline interface |
 
 #### Teams-Specific

--- a/docs-site/api/nodejs.md
+++ b/docs-site/api/nodejs.md
@@ -86,7 +86,7 @@ interface TurnContext
 
 ## ConversationClient
 
-Typed client for the Bot Framework Conversation REST API.
+Typed client for the Bot Service Conversation REST API.
 
 ```typescript
 class ConversationClient
@@ -118,7 +118,7 @@ new ConversationClient(getToken?: TokenProvider)
 
 ## CoreActivity
 
-Bot Framework activity payload interface.
+Bot Service activity payload interface.
 
 ```typescript
 interface CoreActivity
@@ -127,7 +127,7 @@ interface CoreActivity
 | Property | Type | Description |
 |----------|------|-------------|
 | `type` | `string` | Activity type (e.g. `"message"`, `"typing"`). |
-| `serviceUrl` | `string` | Bot Framework service URL for replies. |
+| `serviceUrl` | `string` | Bot Service service URL for replies. |
 | `from` | [ChannelAccount](#channelaccount) | Sender account. |
 | `recipient` | [ChannelAccount](#channelaccount) | Recipient account. |
 | `conversation` | [Conversation](#conversation) | Conversation reference. |
@@ -237,7 +237,7 @@ interface Conversation
 
 ## Entity
 
-Bot Framework entity metadata.
+Bot Service entity metadata.
 
 ```typescript
 interface Entity
@@ -403,7 +403,7 @@ Returns middleware that strips the bot's own `@mention` text from incoming messa
 function validateBotToken(authHeader: string | undefined, appId?: string): Promise<void>
 ```
 
-Validates the inbound JWT bearer token against Bot Framework issuers and JWKS endpoints. Throws [BotAuthError](#botautherror) on failure.
+Validates the inbound JWT bearer token against Bot Service issuers and JWKS endpoints. Throws [BotAuthError](#botautherror) on failure.
 
 ### validateServiceUrl
 
@@ -411,7 +411,7 @@ Validates the inbound JWT bearer token against Bot Framework issuers and JWKS en
 function validateServiceUrl(serviceUrl: string): void
 ```
 
-Validates the service URL against the Bot Framework allowlist. Throws [BotAuthError](#botautherror) for disallowed URLs.
+Validates the service URL against the Bot Service allowlist. Throws [BotAuthError](#botautherror) for disallowed URLs.
 
 ### BotAuthError
 
@@ -425,7 +425,7 @@ Thrown on authentication or token validation failure. HTTP layer should return 4
 
 ## TokenManager
 
-Acquires and caches OAuth2 client-credentials tokens for outbound Bot Framework API calls.
+Acquires and caches OAuth2 client-credentials tokens for outbound Bot Service API calls.
 
 ```typescript
 class TokenManager
@@ -532,7 +532,7 @@ interface PagedMembersResult<T> {
 
 ### BotHttpClient
 
-Low-level authenticated HTTP client for Bot Framework REST calls.
+Low-level authenticated HTTP client for Bot Service REST calls.
 
 ```typescript
 class BotHttpClient {
@@ -623,7 +623,7 @@ interface BotAppOptions extends BotApplicationOptions
 
 ### botAuthExpress
 
-Express middleware that validates the Bot Framework JWT token.
+Express middleware that validates the Bot Service JWT token.
 
 ```typescript
 function botAuthExpress(appId?: string): (req, res, next) => Promise<void>

--- a/docs-site/api/python.md
+++ b/docs-site/api/python.md
@@ -101,7 +101,7 @@ TurnContext(app: [BotApplication](#botapplication), activity: [CoreActivity](#co
 
 ## ConversationClient
 
-Typed async client for the Bot Framework Conversation REST API.
+Typed async client for the Bot Service Conversation REST API.
 
 ```python
 class ConversationClient
@@ -134,7 +134,7 @@ ConversationClient(get_token: TokenProvider | None = None)
 
 ## CoreActivity
 
-Bot Framework activity payload. Pydantic model with camelCase JSON aliases and `extra="allow"` for unknown property round-tripping.
+Bot Service activity payload. Pydantic model with camelCase JSON aliases and `extra="allow"` for unknown property round-tripping.
 
 ```python
 class CoreActivity(BaseModel)
@@ -143,7 +143,7 @@ class CoreActivity(BaseModel)
 | Field | Type | JSON Alias | Description |
 |-------|------|-----------|-------------|
 | `type` | `str` | `type` | Activity type (e.g. `"message"`, `"typing"`). |
-| `service_url` | `str` | `serviceUrl` | Bot Framework service URL. |
+| `service_url` | `str` | `serviceUrl` | Bot Service service URL. |
 | `from_account` | [ChannelAccount](#channelaccount) \| None | `from` | Sender account. |
 | `recipient` | [ChannelAccount](#channelaccount) \| None | `recipient` | Recipient account. |
 | `conversation` | [Conversation](#conversation) \| None | `conversation` | Conversation reference. |
@@ -233,7 +233,7 @@ class Conversation(BaseModel)
 
 ## Entity
 
-Bot Framework entity metadata.
+Bot Service entity metadata.
 
 ```python
 class Entity(BaseModel)
@@ -423,7 +423,7 @@ Middleware that strips the bot's own `@mention` text from incoming messages.
 async def validate_bot_token(auth_header: str | None, app_id: str | None = None) -> None
 ```
 
-Validates the inbound JWT bearer token against Bot Framework issuers and JWKS endpoints. Raises [BotAuthError](#botautherror) on failure.
+Validates the inbound JWT bearer token against Bot Service issuers and JWKS endpoints. Raises [BotAuthError](#botautherror) on failure.
 
 ### BotAuthError
 
@@ -437,7 +437,7 @@ Raised on inbound JWT validation failure. HTTP layer should return 401.
 
 ## TokenManager
 
-Acquires and caches OAuth2 client-credentials tokens for outbound Bot Framework API calls.
+Acquires and caches OAuth2 client-credentials tokens for outbound Bot Service API calls.
 
 ```python
 class TokenManager
@@ -617,7 +617,7 @@ app.start()
 
 ### bot_auth_dependency
 
-FastAPI dependency that validates the Bot Framework JWT token.
+FastAPI dependency that validates the Bot Service JWT token.
 
 ```python
 def bot_auth_dependency(app_id: str | None = None) -> Callable

--- a/docs-site/authentication.md
+++ b/docs-site/authentication.md
@@ -16,22 +16,22 @@ Every Teams bot needs to authenticate in both directions:
 
 | Direction | What happens | How it works |
 |-----------|-------------|--------------|
-| **Inbound** | Bot Framework sends an activity to your bot | Your bot validates the JWT bearer token on every `POST /api/messages` request. Invalid tokens are rejected with a `401` before any of your code runs. |
-| **Outbound** | Your bot replies to the user | botas acquires an OAuth2 client-credentials token and attaches it to every call to the Bot Framework REST API. Token caching and refresh are handled automatically. |
+| **Inbound** | Bot Service sends an activity to your bot | Your bot validates the JWT bearer token on every `POST /api/messages` request. Invalid tokens are rejected with a `401` before any of your code runs. |
+| **Outbound** | Your bot replies to the user | botas acquires an OAuth2 client-credentials token and attaches it to every call to the Bot Service REST API. Token caching and refresh are handled automatically. |
 
 This two-way security model ensures:
-- Only the Bot Framework can send activities to your bot (inbound JWT validation)
+- Only the Bot Service can send activities to your bot (inbound JWT validation)
 - Only your bot can send messages on behalf of your app (outbound client credentials)
 
 ---
 
 ## How Inbound Auth Works (JWT Validation)
 
-When the Bot Framework sends a message to your bot, it includes a **signed JWT** (JSON Web Token) in the `Authorization` header.
+When the Bot Service sends a message to your bot, it includes a **signed JWT** (JSON Web Token) in the `Authorization` header.
 
 botas automatically:
 
-1. **Fetches signing keys** from the Bot Framework's OpenID metadata endpoint (`https://login.botframework.com/v1/.well-known/openidconfiguration`)
+1. **Fetches signing keys** from the Bot Service's OpenID metadata endpoint (`https://login.botframework.com/v1/.well-known/openidconfiguration`)
 2. **Verifies the JWT signature** using those keys
 3. **Checks the token claims**:
    - `aud` (audience) must match your `CLIENT_ID`
@@ -48,7 +48,7 @@ botas middleware runs before your code. If JWT validation fails, your handlers a
 
 ## How Outbound Auth Works (Client Credentials)
 
-When your bot sends a reply, botas needs to prove to the Bot Framework API that the request is authorized.
+When your bot sends a reply, botas needs to prove to the Bot Service API that the request is authorized.
 
 botas automatically:
 
@@ -134,7 +134,7 @@ The [env-to-launch-settings.mjs](https://github.com/rido-min/botas/blob/main/dot
 
 ### `403 Forbidden` on outbound replies
 
-**Cause**: Token acquisition failed or the token was rejected by the Bot Framework API.
+**Cause**: Token acquisition failed or the token was rejected by the Bot Service API.
 
 **Fix**:
 1. Verify `CLIENT_SECRET` is correct and hasn't expired
@@ -143,7 +143,7 @@ The [env-to-launch-settings.mjs](https://github.com/rido-min/botas/blob/main/dot
 
 ### Bot doesn't respond at all
 
-**Cause**: The Bot Framework can't reach your bot's messaging endpoint.
+**Cause**: The Bot Service can't reach your bot's messaging endpoint.
 
 **Fix**:
 1. Check that your dev tunnel is running

--- a/docs-site/languages/dotnet.md
+++ b/docs-site/languages/dotnet.md
@@ -94,7 +94,7 @@ For advanced scenarios — custom DI lifetimes, multi-bot hosting, or manual mid
 
 ### `AddBotApplication<T>` — register services
 
-Call this on `IServiceCollection` during host construction. It registers your bot as a singleton, sets up JWT authentication, authorization policies, and the authenticated HTTP clients used to call the Bot Framework REST API.
+Call this on `IServiceCollection` during host construction. It registers your bot as a singleton, sets up JWT authentication, authorization policies, and the authenticated HTTP clients used to call the Bot Service REST API.
 
 ```csharp
 WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
@@ -103,7 +103,7 @@ webAppBuilder.Services.AddBotApplication<BotApplication>();
 
 Under the hood, `AddBotApplication<T>` calls:
 
-- **`AddBotAuthorization`** — configures two JWT bearer schemes (`Bot` and `Agent`) that validate tokens from the Bot Framework and your Azure AD tenant, and wires them into a `DefaultPolicy` authorization policy.
+- **`AddBotAuthorization`** — configures two JWT bearer schemes (`Bot` and `Agent`) that validate tokens from the Bot Service and your Azure AD tenant, and wires them into a `DefaultPolicy` authorization policy.
 - **`AddBotApplicationClients`** — registers `ConversationClient` with pre-configured `HttpClient` instances that automatically attach an outbound OAuth2 bearer token (scope `https://api.botframework.com/.default`).
 
 ### `UseBotApplication<T>` — map the endpoint
@@ -310,7 +310,7 @@ For setup details on Azure Bot registration and credentials, see the [Setup Guid
 | Type | Description |
 |------|-------------|
 | `BotApplication` | Main bot class — owns the handler, middleware pipeline, and send methods |
-| `CoreActivity` | Deserialized Bot Framework activity; preserves unknown JSON properties via `[JsonExtensionData]` |
+| `CoreActivity` | Deserialized Bot Service activity; preserves unknown JSON properties via `[JsonExtensionData]` |
 | `ChannelAccount` | Represents a user or bot identity (`Id`, `Name`, `AadObjectId`, `Role`) |
 | `Conversation` | Conversation identifier (`Id`), also preserves extension data |
 | `ConversationClient` | Sends outbound activities over the authenticated HTTP client |

--- a/docs-site/languages/nodejs.md
+++ b/docs-site/languages/nodejs.md
@@ -175,7 +175,7 @@ server.post('/api/messages', botAuthExpress(), (req, res) => {
 })
 ```
 
-`botAuthExpress()` validates the `Authorization: Bearer <token>` header against the Bot Framework JWKS endpoint. If validation fails, it responds with `401` before your handler ever runs.
+`botAuthExpress()` validates the `Authorization: Bearer <token>` header against the Bot Service JWKS endpoint. If validation fails, it responds with `401` before your handler ever runs.
 
 `processAsync(req, res)` reads the request body, runs the middleware pipeline and handler, then writes `200 {}` on success or `500` on error.
 
@@ -361,7 +361,7 @@ For setup details on Azure Bot registration and credentials, see the [Setup Guid
 | Type | Description |
 |------|-------------|
 | `BotApplication` | Main bot class — owns handlers, middleware pipeline, and send methods |
-| `CoreActivity` | Deserialized Bot Framework activity; preserves unknown JSON properties in `properties` |
+| `CoreActivity` | Deserialized Bot Service activity; preserves unknown JSON properties in `properties` |
 | `ChannelAccount` | Represents a user or bot identity (`id`, `name`, `aadObjectId`, `role`) |
 | `Conversation` | Conversation identifier (`id`) |
 | `ConversationClient` | Sends outbound activities over the authenticated HTTP client |

--- a/docs-site/languages/python.md
+++ b/docs-site/languages/python.md
@@ -159,7 +159,7 @@ async def messages(request: Request):
     return {}
 ```
 
-`bot_auth_dependency()` validates the `Authorization: Bearer <token>` header against the Bot Framework JWKS endpoint. If validation fails, it raises `HTTPException(401)`.
+`bot_auth_dependency()` validates the `Authorization: Bearer <token>` header against the Bot Service JWKS endpoint. If validation fails, it raises `HTTPException(401)`.
 
 `process_body(str)` parses the activity JSON, runs the middleware pipeline and handler.
 
@@ -339,7 +339,7 @@ All credentials are read from environment variables by default:
 | Type | Description |
 |------|-------------|
 | `BotApplication` | Main bot class — owns handlers, middleware pipeline, and send methods |
-| `CoreActivity` | Deserialized Bot Framework activity (Pydantic v2); preserves unknown JSON properties in `model_extra` |
+| `CoreActivity` | Deserialized Bot Service activity (Pydantic v2); preserves unknown JSON properties in `model_extra` |
 | `ChannelAccount` | Represents a user or bot identity (`id`, `name`, `aad_object_id`, `role`) |
 | `Conversation` | Conversation identifier (`id`) |
 | `ConversationClient` | Sends outbound activities over the authenticated HTTP client |

--- a/docs-site/middleware.md
+++ b/docs-site/middleware.md
@@ -63,7 +63,7 @@ Here are practical reasons to use middleware:
 | **Logging** | Log all incoming activities and response times for debugging and auditing. |
 | **Activity filtering/modification** | Strip mentions, redact sensitive data, or normalize user input. |
 | **Metrics & telemetry** | Count message types, measure handler latency, send to Application Insights. |
-| **Authentication checks** | Validate user identity or conversation authorization beyond Bot Framework JWT. |
+| **Authentication checks** | Validate user identity or conversation authorization beyond Bot Service JWT. |
 | **Rate limiting** | Throttle requests from a single user or conversation. |
 | **Context enrichment** | Look up user profile, conversation state, and attach to context for handler use. |
 | **Error recovery** | Wrap handlers in try/catch to send fallback messages on failure. |

--- a/docs-site/setup.md
+++ b/docs-site/setup.md
@@ -57,7 +57,7 @@ For Python, we recommend installing [uv](https://docs.astral.sh/uv/) — it simp
 
 ## Step 1: Set Up a Tunnel
 
-The Bot Framework needs to reach your bot over HTTPS. A dev tunnel exposes your localhost (port `3978`) to the internet.
+The Bot Service needs to reach your bot over HTTPS. A dev tunnel exposes your localhost (port `3978`) to the internet.
 
 ```bash
 # Log in and create a tunnel

--- a/docs-site/teams-features.md
+++ b/docs-site/teams-features.md
@@ -8,7 +8,7 @@ Send mentions, adaptive cards, and suggested actions using `TeamsActivity` and `
 
 ## Overview
 
-While `CoreActivity` handles basic Bot Framework messaging, Microsoft Teams adds rich features — mentions, adaptive cards, channel metadata, quick-reply buttons — that bots frequently use.
+While `CoreActivity` handles basic Bot Service messaging, Microsoft Teams adds rich features — mentions, adaptive cards, channel metadata, quick-reply buttons — that bots frequently use.
 
 **`TeamsActivity`** extends `CoreActivity` with strongly-typed Teams-specific properties.
 **`TeamsActivityBuilder`** provides a fluent API for constructing replies with mentions, cards, and suggested actions.
@@ -416,7 +416,7 @@ cd python/samples/teams-sample && python main.py
 
 ## Typing Indicators
 
-Show the user that your bot is working on a reply. Typing activities are part of the core Bot Framework protocol (not Teams-specific), but they are especially useful in Teams where users expect real-time feedback.
+Show the user that your bot is working on a reply. Typing activities are part of the core Bot Service protocol (not Teams-specific), but they are especially useful in Teams where users expect real-time feedback.
 
 ### Sending a typing indicator
 

--- a/dotnet/samples/TypingBot/README.md
+++ b/dotnet/samples/TypingBot/README.md
@@ -1,6 +1,6 @@
 # Typing Activity Sample
 
-This sample demonstrates how to send and receive typing indicators in a Bot Framework bot.
+This sample demonstrates how to send and receive typing indicators in a Bot Service bot.
 
 ## Features
 

--- a/dotnet/src/Botas/Attachment.cs
+++ b/dotnet/src/Botas/Attachment.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 namespace Botas;
 
 /// <summary>
-/// Represents a file or rich card attachment on a Bot Framework activity.
+/// Represents a file or rich card attachment on a Bot Service activity.
 /// </summary>
 public class Attachment
 {

--- a/dotnet/src/Botas/BotApplication.cs
+++ b/dotnet/src/Botas/BotApplication.cs
@@ -138,7 +138,7 @@ public class BotApplication
     }
 
     /// <summary>
-    /// Processes an incoming HTTP request containing a Bot Framework activity.
+    /// Processes an incoming HTTP request containing a Bot Service activity.
     /// Deserializes the activity, runs it through the middleware pipeline and handler dispatch,
     /// and writes the HTTP response (JSON <c>{}</c> on success, or an <see cref="InvokeResponse"/> for invoke activities).
     /// </summary>
@@ -247,11 +247,11 @@ public class BotApplication
     }
 
     /// <summary>
-    /// Sends an outbound activity to the Bot Framework channel via the <see cref="ConversationClient"/>.
+    /// Sends an outbound activity to the Bot Service channel via the <see cref="ConversationClient"/>.
     /// </summary>
     /// <param name="activity">The activity to send. Must have routing fields (<c>ServiceUrl</c>, <c>Conversation</c>) populated.</param>
     /// <param name="cancellationToken">Token to cancel the send operation.</param>
-    /// <returns>The raw JSON response from the Bot Framework service.</returns>
+    /// <returns>The raw JSON response from the Bot Service service.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the <see cref="ConversationClient"/> has not been initialized (no request has been processed yet).</exception>
     public async Task<string> SendActivityAsync(CoreActivity activity, CancellationToken cancellationToken = default)
     {

--- a/dotnet/src/Botas/BotAuthenticationHandler.cs
+++ b/dotnet/src/Botas/BotAuthenticationHandler.cs
@@ -7,7 +7,7 @@ namespace Botas;
 
 /// <summary>
 /// HTTP message handler that automatically acquires and attaches authentication tokens
-/// for Bot Framework API calls using app-only (client credentials) token acquisition.
+/// for Bot Service API calls using app-only (client credentials) token acquisition.
 /// </summary>
 /// <remarks>
 /// Initializes a new instance of the <see cref="BotAuthenticationHandler"/> class.

--- a/dotnet/src/Botas/Botas.csproj
+++ b/dotnet/src/Botas/Botas.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Description>Lightweight library for building Microsoft Bot Framework bots with ASP.NET Core</Description>
+    <Description>Lightweight library for building Microsoft Bot Service bots with ASP.NET Core</Description>
     <Authors>rido-min</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/rido-min/botas</PackageProjectUrl>

--- a/dotnet/src/Botas/ConversationClient.cs
+++ b/dotnet/src/Botas/ConversationClient.cs
@@ -4,14 +4,14 @@ using System.Text;
 namespace Botas;
 
 /// <summary>
-/// HTTP client for sending outbound activities to the Bot Framework channel service.
+/// HTTP client for sending outbound activities to the Bot Service channel service.
 /// Handles SSRF protection by validating service URLs against a known allowlist.
 /// </summary>
 /// <param name="httpClient">The HTTP client (typically configured with an authentication handler for outbound tokens).</param>
 /// <param name="logger">Logger instance for diagnostic output.</param>
 public class ConversationClient(HttpClient httpClient, ILogger<ConversationClient> logger)
 {
-    // #107: Allowlist of known Bot Framework service URL patterns to prevent SSRF
+    // #107: Allowlist of known Bot Service service URL patterns to prevent SSRF
     // Suffix patterns (host must end with these)
     private static readonly string[] AllowedServiceUrlSuffixes =
     [
@@ -27,14 +27,14 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
     ];
 
     /// <summary>
-    /// Sends an activity to the Bot Framework channel service via the REST API.
+    /// Sends an activity to the Bot Service channel service via the REST API.
     /// Trace activities are silently skipped. The service URL is validated against an allowlist before sending.
     /// </summary>
     /// <param name="activity">The activity to send. Must have <c>ServiceUrl</c> and <c>Conversation.Id</c> set.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>The raw JSON response body on success.</returns>
     /// <exception cref="ArgumentException">Thrown when the <c>ServiceUrl</c> is missing or not in the allowed list.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when the Bot Framework service returns a non-success status code.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the Bot Service service returns a non-success status code.</exception>
     public async Task<string> SendActivityAsync(CoreActivity activity, CancellationToken cancellationToken = default)
     {
 
@@ -78,7 +78,7 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
     }
 
     /// <summary>
-    /// Validates that the service URL is an HTTPS URL pointing to a known Bot Framework endpoint.
+    /// Validates that the service URL is an HTTPS URL pointing to a known Bot Service endpoint.
     /// Prevents SSRF by rejecting URLs that could target internal services.
     /// </summary>
     internal static void ValidateServiceUrl(string? serviceUrl)
@@ -147,7 +147,7 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
 
         if (!isAllowed)
         {
-            throw new ArgumentException($"ServiceUrl host is not in the allowed Bot Framework service URL list: {host}", nameof(serviceUrl));
+            throw new ArgumentException($"ServiceUrl host is not in the allowed Bot Service service URL list: {host}", nameof(serviceUrl));
         }
     }
 }

--- a/dotnet/src/Botas/CoreActivity.cs
+++ b/dotnet/src/Botas/CoreActivity.cs
@@ -18,7 +18,7 @@ public static class ActivityType
 }
 
 /// <summary>
-/// Extended activity type string constants for Teams and other Bot Framework channels.
+/// Extended activity type string constants for Teams and other Bot Service channels.
 /// Includes all core types plus channel-specific activity types.
 /// </summary>
 public static class TeamsActivityType
@@ -51,7 +51,7 @@ public static class TeamsActivityType
 public class ExtendedPropertiesDictionary : Dictionary<string, object?> { }
 
 /// <summary>
-/// Represents a Bot Framework activity — the fundamental unit of communication between a bot and a channel.
+/// Represents a Bot Service activity — the fundamental unit of communication between a bot and a channel.
 /// Contains typed fields for common properties and an extension dictionary that preserves unknown JSON properties.
 /// </summary>
 /// <param name="type">The activity type (e.g. <c>"message"</c>, <c>"invoke"</c>, <c>"typing"</c>). Defaults to <c>"message"</c>.</param>

--- a/dotnet/src/Botas/JwtExtensions.cs
+++ b/dotnet/src/Botas/JwtExtensions.cs
@@ -14,14 +14,14 @@ namespace Botas;
 
 
 /// <summary>
-/// Extension methods for configuring JWT-based Bot Framework authentication and authorization.
+/// Extension methods for configuring JWT-based Bot Service authentication and authorization.
 /// Supports both single-tenant and multi-tenant bot registration scenarios.
 /// </summary>
 public static class JwtExtensions
 {
     /// <summary>
     /// Adds JWT bearer authentication for a single-tenant bot registration.
-    /// Configures two authentication schemes: <c>"Bot"</c> (for Bot Framework tokens)
+    /// Configures two authentication schemes: <c>"Bot"</c> (for Bot Service tokens)
     /// and <c>"Agent"</c> (for agent-to-agent tokens from the configured tenant).
     /// </summary>
     /// <param name="services">The service collection to configure.</param>
@@ -117,12 +117,12 @@ public static class JwtExtensions
 
 
     /// <summary>
-    /// Adds a JWT bearer authentication scheme configured for Bot Framework token validation.
+    /// Adds a JWT bearer authentication scheme configured for Bot Service token validation.
     /// Dynamically resolves the OIDC metadata endpoint based on the token's issuer claim.
     /// </summary>
     /// <param name="builder">The authentication builder to extend.</param>
     /// <param name="schemeName">A unique name for this authentication scheme (e.g. <c>"Bot"</c>, <c>"Agent"</c>).</param>
-    /// <param name="tenantId">The Azure AD tenant ID, or <c>"botframework.com"</c> for the Bot Framework issuer.</param>
+    /// <param name="tenantId">The Azure AD tenant ID, or <c>"botframework.com"</c> for the Bot Service issuer.</param>
     /// <param name="audience">The expected audience (typically the bot's Azure AD client ID).</param>
     /// <returns>The <see cref="AuthenticationBuilder"/> for chaining.</returns>
     public static AuthenticationBuilder AddCustomJwtBearer(this AuthenticationBuilder builder, string schemeName, string tenantId, string audience)
@@ -173,7 +173,7 @@ public static class JwtExtensions
                      string issuer = token.Claims.FirstOrDefault(claim => claim.Type == "iss")?.Value!;
                      string tid = token.Claims.FirstOrDefault(claim => claim.Type == "tid")?.Value!;
 
-                     // #99: Validate issuer against known Bot Framework issuers before constructing OIDC authority
+                     // #99: Validate issuer against known Bot Service issuers before constructing OIDC authority
                      if (!IsKnownIssuer(issuer, validIssuers))
                      {
                          context.Fail("Token issuer is not in the allowed issuers list.");
@@ -278,7 +278,7 @@ public static class JwtExtensions
                     string issuer = token.Claims.FirstOrDefault(claim => claim.Type == "iss")?.Value!;
                     string tid = token.Claims.FirstOrDefault(claim => claim.Type == "tid")?.Value!;
 
-                    // #99: Validate issuer against known Bot Framework issuers before constructing OIDC authority
+                    // #99: Validate issuer against known Bot Service issuers before constructing OIDC authority
                     if (!IsKnownIssuer(issuer, validIssuers))
                     {
                         context.Fail("Token issuer is not in the allowed issuers list.");

--- a/dotnet/src/Botas/README.md
+++ b/dotnet/src/Botas/README.md
@@ -1,6 +1,6 @@
 # Botas The Bot App SDK
 
-Lightweight library for building [Microsoft Bot Framework](https://learn.microsoft.com/azure/bot-service/) bots — .NET / ASP.NET Core.
+Lightweight library for building [Microsoft Bot Service](https://learn.microsoft.com/azure/bot-service/) bots — .NET / ASP.NET Core.
 A lightweight library for building [Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/) bots in .NET / ASP.NET Core
 
 ## What it does

--- a/e2e/dotnet/ConversationService.cs
+++ b/e2e/dotnet/ConversationService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Botas.E2ETests;
 
 /// <summary>
-/// A real HTTP listener that acts as a fake Bot Framework channel service.
+/// A real HTTP listener that acts as a fake Bot Service channel service.
 /// Captures outbound SendActivity payloads from ConversationClient via TaskCompletionSource.
 /// </summary>
 public sealed class ConversationService : IAsyncDisposable

--- a/node/packages/botas-core/package.json
+++ b/node/packages/botas-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botas-core",
   "version": "0.1.0",
-  "description": "Lightweight library for building Microsoft Bot Framework bots - Node.js/TypeScript",
+  "description": "Lightweight library for building Microsoft Bot Service bots - Node.js/TypeScript",
   "type": "module",
   "license": "MIT",
   "author": "rido-min",

--- a/node/packages/botas-core/src/activity-type.ts
+++ b/node/packages/botas-core/src/activity-type.ts
@@ -12,7 +12,7 @@
 export type ActivityType = 'message' | 'typing' | 'invoke'
 
 /**
- * Extended activity type strings for Teams and other Bot Framework channels.
+ * Extended activity type strings for Teams and other Bot Service channels.
  *
  * Includes all core types plus channel-specific activity types commonly
  * used in Microsoft Teams bots.

--- a/node/packages/botas-core/src/bot-application.ts
+++ b/node/packages/botas-core/src/bot-application.ts
@@ -54,7 +54,7 @@ export class BotHandlerException extends Error {
 }
 
 /**
- * Core bot application that processes incoming Bot Framework activities.
+ * Core bot application that processes incoming Bot Service activities.
  *
  * Web-server-agnostic — use {@link processAsync} with Express (or any
  * Node.js `http.Server`) and {@link processBody} with frameworks that manage
@@ -79,7 +79,7 @@ export class BotApplication {
   /** Resolved options for this application instance. */
   readonly options: BotApplicationOptions
 
-  /** Client for sending, updating, and deleting activities via the Bot Framework API. */
+  /** Client for sending, updating, and deleting activities via the Bot Service API. */
   readonly conversationClient: ConversationClient
 
   /**
@@ -233,7 +233,7 @@ export class BotApplication {
   /**
    * Proactively send an activity to a conversation.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param conversationId - Target conversation ID.
    * @param activity - CoreActivity payload to send.
    * @returns The {@link ResourceResponse} containing the new activity ID, or `undefined`.

--- a/node/packages/botas-core/src/bot-auth-middleware.ts
+++ b/node/packages/botas-core/src/bot-auth-middleware.ts
@@ -66,7 +66,7 @@ function getAdditionalAllowedUrls (): string[] {
 }
 
 /**
- * Validate that a serviceUrl is a known Bot Framework endpoint.
+ * Validate that a serviceUrl is a known Bot Service endpoint.
  * Prevents SSRF by blocking arbitrary URLs from incoming activities.
  *
  * @throws {BotAuthError} when the URL is not on the allowlist.
@@ -181,10 +181,10 @@ function validIssuers (tid?: string): string[] {
 }
 
 /**
- * Validates a Bot Framework or Entra ID Bearer token.
+ * Validates a Bot Service or Entra ID Bearer token.
  * Throws {@link BotAuthError} if the token is missing, malformed, or fails validation.
  *
- * Supports tokens from both the Bot Framework channel service and Azure AD/Entra ID.
+ * Supports tokens from both the Bot Service channel service and Azure AD/Entra ID.
  * The correct OpenID configuration is selected dynamically by inspecting the token's
  * `iss` claim before full validation (see specs/inbound-auth.md).
  *
@@ -251,7 +251,7 @@ export async function validateBotToken (
 }
 
 /**
- * Error thrown when Bot Framework JWT validation fails.
+ * Error thrown when Bot Service JWT validation fails.
  *
  * Indicates the incoming request did not carry a valid Bearer token.
  * The HTTP layer should return `401 Unauthorized` when this error is caught.

--- a/node/packages/botas-core/src/bot-http-client.ts
+++ b/node/packages/botas-core/src/bot-http-client.ts
@@ -18,7 +18,7 @@ export interface BotRequestOptions {
 export type TokenProvider = () => Promise<string>
 
 /**
- * Authenticated HTTP client for the Bot Framework REST API.
+ * Authenticated HTTP client for the Bot Service REST API.
  *
  * Wraps axios and injects a Bearer token via a request interceptor when a
  * {@link TokenProvider} is supplied.
@@ -102,7 +102,7 @@ export class BotHttpClient {
   }
 
   /**
-   * Send a GET request to a Bot Framework API endpoint.
+   * Send a GET request to a Bot Service API endpoint.
    *
    * @typeParam T - Expected response body type.
    * @param baseUrl - Service URL base (e.g. `activity.serviceUrl`).
@@ -122,7 +122,7 @@ export class BotHttpClient {
   }
 
   /**
-   * Send a POST request to a Bot Framework API endpoint.
+   * Send a POST request to a Bot Service API endpoint.
    *
    * @typeParam T - Expected response body type.
    * @param baseUrl - Service URL base.
@@ -144,7 +144,7 @@ export class BotHttpClient {
   }
 
   /**
-   * Send a PUT request to a Bot Framework API endpoint.
+   * Send a PUT request to a Bot Service API endpoint.
    *
    * @typeParam T - Expected response body type.
    * @param baseUrl - Service URL base.
@@ -166,7 +166,7 @@ export class BotHttpClient {
   }
 
   /**
-   * Send a DELETE request to a Bot Framework API endpoint.
+   * Send a DELETE request to a Bot Service API endpoint.
    *
    * @param baseUrl - Service URL base.
    * @param endpoint - API path.

--- a/node/packages/botas-core/src/conversation-client.ts
+++ b/node/packages/botas-core/src/conversation-client.ts
@@ -16,7 +16,7 @@ import type {
 } from './core-activity.js'
 
 /**
- * Client for the Bot Framework v3 Conversations REST API.
+ * Client for the Bot Service v3 Conversations REST API.
  *
  * Sends activities, manages members, creates conversations, and uploads attachments.
  */
@@ -36,7 +36,7 @@ export class ConversationClient {
   /**
    * Send an activity to a conversation.
    *
-   * @param serviceUrl - Bot Framework service URL (from the incoming activity).
+   * @param serviceUrl - Bot Service service URL (from the incoming activity).
    * @param conversationId - Target conversation ID.
    * @param activity - CoreActivity payload to send.
    * @returns The {@link ResourceResponse} containing the new activity ID, or `undefined`.
@@ -59,7 +59,7 @@ export class ConversationClient {
   /**
    * Update an existing activity in a conversation.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param conversationId - Target conversation ID.
    * @param activityId - ID of the activity to update.
    * @param activity - Updated activity payload (partial merge).
@@ -84,7 +84,7 @@ export class ConversationClient {
   /**
    * Delete an activity from a conversation.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param conversationId - Target conversation ID.
    * @param activityId - ID of the activity to delete.
    */
@@ -106,7 +106,7 @@ export class ConversationClient {
   /**
    * Retrieve all members of a conversation.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param conversationId - Target conversation ID.
    * @returns Array of {@link ChannelAccount} members; empty array if none.
    */
@@ -128,7 +128,7 @@ export class ConversationClient {
   /**
    * Retrieve a single member of a conversation by user ID.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param conversationId - Target conversation ID.
    * @param memberId - ID of the member to retrieve.
    * @returns The {@link ChannelAccount}, or `undefined` if not found.
@@ -153,7 +153,7 @@ export class ConversationClient {
    *
    * Use `continuationToken` from the previous result to fetch subsequent pages.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param conversationId - Target conversation ID.
    * @param pageSize - Maximum number of members per page.
    * @param continuationToken - Opaque token from a previous page result.
@@ -183,7 +183,7 @@ export class ConversationClient {
   /**
    * Remove a member from a conversation.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param conversationId - Target conversation ID.
    * @param memberId - ID of the member to remove.
    */
@@ -205,7 +205,7 @@ export class ConversationClient {
   /**
    * Create a new proactive conversation.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param parameters - Conversation creation parameters (members, topic, initial activity).
    * @returns A {@link ConversationResourceResponse} with the new conversation ID, or `undefined`.
    */
@@ -225,7 +225,7 @@ export class ConversationClient {
   /**
    * List all conversations the bot is a member of.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param continuationToken - Opaque token from a previous page result.
    * @returns A {@link ConversationsResult} with conversations and an optional continuation token.
    */
@@ -246,7 +246,7 @@ export class ConversationClient {
   /**
    * Upload a transcript of past activities to a conversation.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param conversationId - Target conversation ID.
    * @param transcript - Ordered list of activities to upload.
    * @returns The {@link ResourceResponse}, or `undefined`.
@@ -269,7 +269,7 @@ export class ConversationClient {
   /**
    * Retrieve the conversation account details.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @param conversationId - Target conversation ID.
    * @returns The {@link Conversation}, or `undefined` if not found.
    */

--- a/node/packages/botas-core/src/core-activity.ts
+++ b/node/packages/botas-core/src/core-activity.ts
@@ -53,7 +53,7 @@ export interface Attachment {
 }
 
 /**
- * The core activity payload received from or sent to the Bot Framework.
+ * The core activity payload received from or sent to the Bot Service.
  * Only the fields listed here are explicitly typed; all other wire properties
  * are preserved in `properties`.
  */
@@ -180,7 +180,7 @@ export class CoreActivityBuilder {
   /**
    * Set the service URL for the channel.
    *
-   * @param serviceUrl - Bot Framework service URL.
+   * @param serviceUrl - Bot Service service URL.
    * @returns `this` for method chaining.
    */
   withServiceUrl (serviceUrl: string): this {

--- a/node/packages/botas-core/src/remove-mention-middleware.ts
+++ b/node/packages/botas-core/src/remove-mention-middleware.ts
@@ -5,7 +5,7 @@ import type { TurnMiddleware } from './i-turn-middleware.js'
 import type { TurnContext } from './turn-context.js'
 import type { Entity } from './core-activity.js'
 
-/** Shape of a mention entity as sent by Bot Framework channels. */
+/** Shape of a mention entity as sent by Bot Service channels. */
 interface MentionEntity extends Entity {
   type: 'mention'
   mentioned: { id: string; name?: string }

--- a/node/packages/botas-core/src/teams-activity.ts
+++ b/node/packages/botas-core/src/teams-activity.ts
@@ -124,7 +124,7 @@ export class TeamsActivityBuilder {
   /**
    * Set the service URL.
    *
-   * @param serviceUrl - Bot Framework service URL for the channel.
+   * @param serviceUrl - Bot Service service URL for the channel.
    * @returns `this` for method chaining.
    */
   withServiceUrl (serviceUrl: string): this {

--- a/node/packages/botas-core/src/token-manager.ts
+++ b/node/packages/botas-core/src/token-manager.ts
@@ -18,7 +18,7 @@ const AUTHORITY_BASE = 'https://login.microsoftonline.com'
  *
  * Used by both {@link TokenManager} and {@link BotApplicationOptions}.
  * All fields are optional — omitting credentials disables authentication
- * (suitable for local development with the Bot Framework Emulator).
+ * (suitable for local development).
  */
 export type TokenManagerOptions = {
   /** Application (client) ID. */
@@ -44,7 +44,7 @@ type ResolvedOptions = Required<Omit<TokenManagerOptions, 'token'>> & {
 }
 
 /**
- * Manages Bot Framework access token acquisition via MSAL.
+ * Manages Bot Service access token acquisition via MSAL.
  *
  * Supports four authentication flows, selected automatically based on the
  * options provided:
@@ -82,7 +82,7 @@ export class TokenManager {
   }
 
   /**
-   * Acquire a Bot Framework access token for outbound API calls.
+   * Acquire a Bot Service access token for outbound API calls.
    *
    * Returns `null` when no credentials are configured (dev/testing mode).
    * Caches tokens via MSAL and deduplicates concurrent requests.

--- a/node/packages/botas-express/package.json
+++ b/node/packages/botas-express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botas-express",
   "version": "0.1.0",
-  "description": "Express integration for botas – zero-boilerplate Bot Framework bot hosting",
+  "description": "Express integration for botas – zero-boilerplate Bot Service bot hosting",
   "type": "module",
   "license": "MIT",
   "author": "rido-min",

--- a/node/packages/botas-express/src/bot-auth-express.ts
+++ b/node/packages/botas-express/src/bot-auth-express.ts
@@ -8,7 +8,7 @@ type ExpressResponse = { status(code: number): ExpressResponse; end(msg?: string
 type NextFn = (err?: unknown) => void
 
 /**
- * Express middleware that validates the Bot Framework JWT token.
+ * Express middleware that validates the Bot Service JWT token.
  *
  * @param appId - The bot's client ID. Falls back to CLIENT_ID env var.
  *

--- a/python/packages/botas-fastapi/pyproject.toml
+++ b/python/packages/botas-fastapi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "botas-fastapi"
 dynamic = ["version"]
-description = "FastAPI integration for botas – zero-boilerplate Bot Framework bot hosting"
+description = "FastAPI integration for botas – zero-boilerplate Bot Service bot hosting"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.12"

--- a/python/packages/botas-fastapi/src/botas_fastapi/bot_app.py
+++ b/python/packages/botas-fastapi/src/botas_fastapi/bot_app.py
@@ -98,7 +98,7 @@ class BotApp:
             # Startup
             yield
             # Shutdown - close the bot's HTTP client
-            # CORS is not needed: Bot Framework calls this endpoint directly (no browser)
+            # CORS is not needed: Bot Service calls this endpoint directly (no browser)
             await self.bot.aclose()
 
         auth_enabled = self._auth if self._auth is not None else bool(self.bot.appid)

--- a/python/packages/botas-fastapi/src/botas_fastapi/bot_auth.py
+++ b/python/packages/botas-fastapi/src/botas_fastapi/bot_auth.py
@@ -8,7 +8,7 @@ _logger = logging.getLogger(__name__)
 
 
 def bot_auth_dependency(app_id: str | None = None):
-    """Return a FastAPI dependency that validates the Bot Framework JWT token.
+    """Return a FastAPI dependency that validates the Bot Service JWT token.
 
     Usage:
         @app.post("/api/messages", dependencies=[Depends(bot_auth_dependency())])

--- a/python/packages/botas/pyproject.toml
+++ b/python/packages/botas/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "botas"
 dynamic = ["version"]
-description = "Lightweight library for building Microsoft Bot Framework bots - Python"
+description = "Lightweight library for building Microsoft Bot Service bots - Python"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.12"

--- a/python/packages/botas/src/botas/__init__.py
+++ b/python/packages/botas/src/botas/__init__.py
@@ -1,7 +1,7 @@
-"""Botas — a lightweight, multi-language Bot Framework library for Python.
+"""Botas — a lightweight, multi-language Bot Service library for Python.
 
 Provides the core building blocks for receiving, processing, and sending
-Bot Framework activities over HTTP.  Typical usage::
+Bot Service activities over HTTP.  Typical usage::
 
     from botas import BotApplication, TurnContext
 

--- a/python/packages/botas/src/botas/bot_application.py
+++ b/python/packages/botas/src/botas/bot_application.py
@@ -31,7 +31,7 @@ def _get_additional_allowed_urls() -> list[str]:
 
 
 def _validate_service_url(service_url: str) -> None:
-    """Validate serviceUrl against Bot Framework allowlist. Prevents SSRF."""
+    """Validate serviceUrl against Bot Service allowlist. Prevents SSRF."""
     try:
         parsed = urlparse(service_url)
     except Exception:
@@ -93,7 +93,7 @@ class BotHandlerException(Exception):
 
 
 class BotApplication:
-    """Central entry point for building a bot with the Bot Framework.
+    """Central entry point for building a bot with the Bot Service.
 
     Manages the middleware pipeline, activity handler dispatch, outbound
     messaging via :class:`ConversationClient`, and OAuth2 token lifecycle
@@ -225,7 +225,7 @@ class BotApplication:
         Returns ``None`` for all other activity types.
 
         Args:
-            body: Raw JSON string representing a Bot Framework activity.
+            body: Raw JSON string representing a Bot Service activity.
 
         Returns:
             An :class:`InvokeResponse` for invoke activities, or ``None``.

--- a/python/packages/botas/src/botas/bot_auth.py
+++ b/python/packages/botas/src/botas/bot_auth.py
@@ -1,6 +1,6 @@
-"""Bot Framework JWT token validation for inbound requests.
+"""Bot Service JWT token validation for inbound requests.
 
-Validates bearer tokens from both the Bot Framework channel service and
+Validates bearer tokens from both the Bot Service channel service and
 Azure AD / Entra ID.  See ``specs/inbound-auth.md`` for protocol details.
 """
 
@@ -55,7 +55,7 @@ def _peek_claims(token: str) -> dict[str, str | None]:
 def _resolve_metadata_url(iss: str | None, tid: str | None) -> str:
     """Select the OpenID metadata URL based on the token's issuer.
 
-    Bot Framework tokens use the botframework.com metadata.
+    Bot Service tokens use the botframework.com metadata.
     Azure AD/Entra ID tokens use the tenant-specific metadata.
     """
     if iss == _BOT_FRAMEWORK_ISSUER:
@@ -114,9 +114,9 @@ async def _get_jwks(metadata_url: str, force_refresh: bool = False) -> list[dict
 
 
 async def validate_bot_token(auth_header: str | None, app_id: str | None = None) -> None:
-    """Validate a Bot Framework or Entra ID JWT bearer token.
+    """Validate a Bot Service or Entra ID JWT bearer token.
 
-    Supports tokens from both the Bot Framework channel service and Azure
+    Supports tokens from both the Bot Service channel service and Azure
     AD / Entra ID.  The correct OpenID configuration is selected dynamically
     by inspecting the token's issuer claim (see ``specs/inbound-auth.md``).
 

--- a/python/packages/botas/src/botas/bot_http_client.py
+++ b/python/packages/botas/src/botas/bot_http_client.py
@@ -1,4 +1,4 @@
-"""Authenticated HTTP client for Bot Framework REST API calls.
+"""Authenticated HTTP client for Bot Service REST API calls.
 
 Wraps :class:`httpx.AsyncClient` with automatic bearer-token injection,
 URL construction, and error handling.
@@ -36,7 +36,7 @@ class BotRequestOptions:
 
 
 class BotHttpError(Exception):
-    """Raised when a Bot Framework REST API call returns a non-success status.
+    """Raised when a Bot Service REST API call returns a non-success status.
 
     Attributes:
         status_code: The HTTP status code from the response.
@@ -57,7 +57,7 @@ class BotHttpError(Exception):
 
 
 class BotHttpClient:
-    """Low-level async HTTP client with automatic Bot Framework authentication.
+    """Low-level async HTTP client with automatic Bot Service authentication.
 
     Wraps :class:`httpx.AsyncClient` to inject bearer tokens, construct
     URLs, and translate HTTP errors into :class:`BotHttpError`.
@@ -131,7 +131,7 @@ class BotHttpClient:
         params: dict[str, str | None] | None = None,
         options: BotRequestOptions | None = None,
     ) -> Any:
-        """Send a GET request to the Bot Framework REST API.
+        """Send a GET request to the Bot Service REST API.
 
         Args:
             base_url: The channel's service URL.
@@ -156,7 +156,7 @@ class BotHttpClient:
         body: Any,
         options: BotRequestOptions | None = None,
     ) -> Any:
-        """Send a POST request to the Bot Framework REST API.
+        """Send a POST request to the Bot Service REST API.
 
         Args:
             base_url: The channel's service URL.
@@ -181,7 +181,7 @@ class BotHttpClient:
         body: Any,
         options: BotRequestOptions | None = None,
     ) -> Any:
-        """Send a PUT request to the Bot Framework REST API.
+        """Send a PUT request to the Bot Service REST API.
 
         Args:
             base_url: The channel's service URL.
@@ -205,7 +205,7 @@ class BotHttpClient:
         endpoint: str,
         options: BotRequestOptions | None = None,
     ) -> None:
-        """Send a DELETE request to the Bot Framework REST API.
+        """Send a DELETE request to the Bot Service REST API.
 
         Args:
             base_url: The channel's service URL.

--- a/python/packages/botas/src/botas/conversation_client.py
+++ b/python/packages/botas/src/botas/conversation_client.py
@@ -1,4 +1,4 @@
-"""High-level client for the Bot Framework Conversation REST API.
+"""High-level client for the Bot Service Conversation REST API.
 
 Wraps :class:`BotHttpClient` to provide typed methods for sending,
 updating, and deleting activities, managing conversation members, and
@@ -42,7 +42,7 @@ def _serialize(obj: Any) -> Any:
 
 
 class ConversationClient:
-    """Typed client for Bot Framework Conversation REST API operations.
+    """Typed client for Bot Service Conversation REST API operations.
 
     All methods accept a ``service_url`` and ``conversation_id`` to target
     the correct channel endpoint.  Authentication is handled automatically

--- a/python/packages/botas/src/botas/core_activity.py
+++ b/python/packages/botas/src/botas/core_activity.py
@@ -1,4 +1,4 @@
-"""Bot Framework activity schema models.
+"""Bot Service activity schema models.
 
 Defines :class:`CoreActivity` and supporting types (accounts, conversations,
 attachments, entities) as Pydantic models with camelCase JSON aliases.
@@ -26,7 +26,7 @@ TeamsActivityType = Literal[
     "messageReaction",
     "installationUpdate",
 ]
-"""Extended activity type strings for Teams and other Bot Framework channels."""
+"""Extended activity type strings for Teams and other Bot Service channels."""
 
 
 class _CamelModel(BaseModel):
@@ -78,7 +78,7 @@ class Conversation(_CamelModel):
 
 
 class Entity(_CamelModel):
-    """Bot Framework entity metadata (mentions, places, etc.).
+    """Bot Service entity metadata (mentions, places, etc.).
 
     Extra fields are preserved via Pydantic's ``extra="allow"`` config.
     """
@@ -87,7 +87,7 @@ class Entity(_CamelModel):
 
 
 class Attachment(_CamelModel):
-    """Bot Framework attachment (images, cards, files, etc.).
+    """Bot Service attachment (images, cards, files, etc.).
 
     Attributes:
         content_type: MIME type (e.g. ``"application/vnd.microsoft.card.adaptive"``).
@@ -105,7 +105,7 @@ class Attachment(_CamelModel):
 
 
 class CoreActivity(_CamelModel):
-    """Bot Framework activity payload.
+    """Bot Service activity payload.
 
     Represents an incoming or outgoing message, typing indicator, or other event.
     Routing fields (``from``, ``recipient``, ``conversation``, ``serviceUrl``) are

--- a/python/packages/botas/src/botas/i_turn_middleware.py
+++ b/python/packages/botas/src/botas/i_turn_middleware.py
@@ -1,4 +1,4 @@
-"""Middleware protocol for the Bot Framework turn pipeline.
+"""Middleware protocol for the Bot Service turn pipeline.
 
 Middleware intercepts every incoming activity before handler dispatch.
 Implement the :class:`TurnMiddleware` protocol and register with

--- a/python/packages/botas/src/botas/suggested_actions.py
+++ b/python/packages/botas/src/botas/suggested_actions.py
@@ -1,4 +1,4 @@
-"""Bot Framework suggested actions and card action models."""
+"""Bot Service suggested actions and card action models."""
 
 from __future__ import annotations
 

--- a/python/packages/botas/src/botas/token_manager.py
+++ b/python/packages/botas/src/botas/token_manager.py
@@ -1,4 +1,4 @@
-"""OAuth2 token management for outbound Bot Framework API calls.
+"""OAuth2 token management for outbound Bot Service API calls.
 
 Acquires and caches client-credentials tokens via MSAL for authenticating
 outbound REST API requests.  See ``specs/outbound-auth.md`` for details.
@@ -40,7 +40,7 @@ _BOT_FRAMEWORK_SCOPE = "https://api.botframework.com/.default"
 
 
 class TokenManager:
-    """Acquires and caches OAuth2 tokens for outbound Bot Framework API calls.
+    """Acquires and caches OAuth2 tokens for outbound Bot Service API calls.
 
     Uses MSAL's ``ConfidentialClientApplication`` for client-credentials flow,
     or delegates to a custom ``token_factory`` if provided.
@@ -68,7 +68,7 @@ class TokenManager:
         return self._client_id
 
     async def get_bot_token(self) -> str | None:
-        """Acquire a token for the Bot Framework API scope.
+        """Acquire a token for the Bot Service API scope.
 
         Returns:
             A bearer token string, or ``None`` if credentials are not configured.

--- a/python/packages/botas/tests/test_p1_security_fixes.py
+++ b/python/packages/botas/tests/test_p1_security_fixes.py
@@ -12,7 +12,7 @@ class TestServiceUrlValidation:
 
     @pytest.mark.asyncio
     async def test_valid_botframework_urls(self):
-        """Valid Bot Framework URLs should be accepted."""
+        """Valid Bot Service URLs should be accepted."""
         bot = BotApplication()
         valid_urls = [
             "https://api.botframework.com",

--- a/python/packages/botas/tests/test_security_fixes.py
+++ b/python/packages/botas/tests/test_security_fixes.py
@@ -44,7 +44,7 @@ class TestServiceUrlValidation:
 
     @pytest.mark.asyncio
     async def test_valid_botframework_urls(self):
-        """Valid Bot Framework URLs should be accepted."""
+        """Valid Bot Service URLs should be accepted."""
         bot = BotApplication()
         valid_urls = [
             "https://api.botframework.com",

--- a/specs/README.md
+++ b/specs/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-`botas` is a lightweight library for building Microsoft Bot Framework bots. This spec documents behavioral contracts for cross-language parity.
+`botas` is a lightweight library for building Microsoft Bot Service bots. This spec documents behavioral contracts for cross-language parity.
 
 ---
 
@@ -53,7 +53,7 @@ Feature: Bot responds to user messages
 
   Scenario: Authentication
     Given a running bot
-    When Bot Framework sends activity
+    When Bot Service sends activity
     Then JWT token is validated
 ```
 

--- a/specs/activity-schema.md
+++ b/specs/activity-schema.md
@@ -1,6 +1,6 @@
 # Activity Schema Spec
 
-**Purpose**: Define the JSON payload structure for activities exchanged between bots and the Bot Framework Service.
+**Purpose**: Define the JSON payload structure for activities exchanged between bots and the Bot Service Service.
 **Status**: Draft
 
 > **Note**: Outbound activities are typically constructed using the fluent `CoreActivityBuilder`. See the [Bot Spec — CoreActivityBuilder](./README.md#coreactivitybuilder) for the API.
@@ -9,7 +9,7 @@
 
 ## Overview
 
-All communication between a bot and the Bot Framework Service uses **Activity** JSON objects. This document defines the schema and serialization rules.
+All communication between a bot and the Bot Service Service uses **Activity** JSON objects. This document defines the schema and serialization rules.
 
 ---
 
@@ -31,7 +31,7 @@ The core message/event model. Only the fields below are explicitly typed; everyt
 
 ### Inbound Activity Fields
 
-Fields present on activities received from the Bot Framework Service (`POST /api/messages`).
+Fields present on activities received from the Bot Service Service (`POST /api/messages`).
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -171,4 +171,4 @@ All activity types may carry additional properties beyond the typed fields. BotA
 ## References
 
 - [Protocol Spec](./protocol.md) — HTTP contract for sending/receiving activities
-- [Bot Framework Activity Schema](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#activity-object)
+- [Bot Service Activity Schema](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#activity-object)

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-BotAS is a thin adapter between an HTTP framework and the [Microsoft Bot Framework REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference). The same design is implemented in .NET, Node.js, and Python.
+BotAS is a thin adapter between an HTTP framework and the [Microsoft Bot Service REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference). The same design is implemented in .NET, Node.js, and Python.
 
 ---
 

--- a/specs/contributing.md
+++ b/specs/contributing.md
@@ -142,7 +142,7 @@ In order of priority:
 | `CoreActivity` | Activity model with extension data preservation | [Activity Schema](./activity-schema.md) |
 | `CoreActivityBuilder` | Fluent builder with `withConversationReference` | [Activity Schema](./activity-schema.md) |
 | `TokenManager` | OAuth2 client-credentials token acquisition and caching | [Outbound Auth](./outbound-auth.md) |
-| `ConversationClient` | HTTP client for the Bot Framework REST API | [Protocol — Outbound](./protocol.md#outbound-sending-activities) |
+| `ConversationClient` | HTTP client for the Bot Service REST API | [Protocol — Outbound](./protocol.md#outbound-sending-activities) |
 | `BotApplication` | Middleware pipeline + handler dispatch | [Protocol](./protocol.md) |
 | `TurnContext` | Scoped context for handlers and middleware | [Turn Context](./turn-context.md) |
 | Inbound JWT validation | Validate incoming bearer tokens | [Inbound Auth](./inbound-auth.md) |
@@ -176,7 +176,7 @@ Add a job to `.github/workflows/CI.yml` that builds, lints, and tests the new po
 ## What Not to Do
 
 - Do not duplicate spec content — link to `specs/` instead.
-- Do not invent new authentication flows or HTTP contracts outside the Bot Framework model.
+- Do not invent new authentication flows or HTTP contracts outside the Bot Service model.
 - Do not treat this repo as a single-language project.
 - Do not add new dependencies without justification.
 

--- a/specs/future/targeted-messages-reactions.md
+++ b/specs/future/targeted-messages-reactions.md
@@ -12,7 +12,7 @@ Microsoft Teams supports two features for rich bot interactions:
 1. **Targeted Messages (Notification-Only Messages)**: Messages visible only to a specific user in a group conversation, without triggering the bot for other participants.
 2. **Reactions**: Emoji reactions that bots can add to existing messages (e.g., 👍, ❤️, 🎉).
 
-Both features require specialized Bot Framework API calls that the current `botas` ConversationClient does not expose.
+Both features require specialized Bot Service API calls that the current `botas` ConversationClient does not expose.
 
 ---
 
@@ -62,7 +62,7 @@ Add two new capabilities to the `ConversationClient` and `TurnContext`:
 1. **Parity with teams.net PR #338**: Mirrors [ConversationClient changes](https://github.com/microsoft/teams.net/pull/338) that added `IsTargeted` and reaction support.
 2. **Builder pattern**: Use existing `CoreActivityBuilder` for constructing targeted messages.
 3. **Convenience methods**: High-level `TurnContext` methods for common use cases.
-4. **HTTP transparency**: Query parameter `?isTargetedActivity=true` appended to Bot Framework URLs.
+4. **HTTP transparency**: Query parameter `?isTargetedActivity=true` appended to Bot Service URLs.
 
 ---
 
@@ -278,7 +278,7 @@ async def add_reaction(self, reaction_type: str) -> None
 
 ### HTTP Request
 
-When `activity.IsTargeted` / `activity.isTargeted` / `activity.is_targeted` is `true`, the framework appends `?isTargetedActivity=true` to outbound Bot Framework URLs:
+When `activity.IsTargeted` / `activity.isTargeted` / `activity.is_targeted` is `true`, the framework appends `?isTargetedActivity=true` to outbound Bot Service URLs:
 
 **Send activity:**
 ```
@@ -303,7 +303,7 @@ DELETE {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}?is
 
 ### JSON Serialization
 
-The `IsTargeted` property is **NOT serialized** in the JSON payload sent to Bot Framework:
+The `IsTargeted` property is **NOT serialized** in the JSON payload sent to Bot Service:
 
 ```json
 {
@@ -379,7 +379,7 @@ Content-Type: application/json
 | `😢` | `sad` |
 | `😠` | `angry` |
 
-If an emoji is NOT in the mapping, pass it as-is to the Bot Framework API (which may accept or reject it).
+If an emoji is NOT in the mapping, pass it as-is to the Bot Service API (which may accept or reject it).
 
 ### ConversationClient Method
 
@@ -543,10 +543,10 @@ app.on('message', async (ctx) => {
 
 2. **Should reactions support bulk addition?**
    - Proposal: Not in Phase 1. Call `addReaction` multiple times if needed.
-   - Rationale: Bot Framework API accepts one reaction per POST.
+   - Rationale: Bot Service API accepts one reaction per POST.
 
 3. **Should we validate reaction types?**
-   - Proposal: No. Pass through to Bot Framework; let it reject invalid types.
+   - Proposal: No. Pass through to Bot Service; let it reject invalid types.
    - Rationale: Avoids maintenance burden if Teams adds new reaction types.
 
 4. **Should targeted messages work for direct (1:1) conversations?**
@@ -560,5 +560,5 @@ app.on('message', async (ctx) => {
 - [teams.net PR #338](https://github.com/microsoft/teams.net/pull/338) — Reference implementation for targeted messages and reactions
 - [teams.net ConversationClient.cs](https://github.com/microsoft/teams.net/blob/next/core/src/Microsoft.Teams.Bot.Core/ConversationClient.cs) — Targeted message query parameter logic
 - [teams.net CoreActivity.cs](https://github.com/microsoft/teams.net/blob/next/core/src/Microsoft.Teams.Bot.Core/Schema/CoreActivity.cs) — `IsTargeted` property with `[JsonIgnore]`
-- [Bot Framework Reactions API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-add-activity-reaction) — Protocol documentation
+- [Bot Service Reactions API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-add-activity-reaction) — Protocol documentation
 - [Teams Message Reactions](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events#reactions-to-a-bot-message) — Teams-specific documentation

--- a/specs/future/teams-activity.md
+++ b/specs/future/teams-activity.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-While `CoreActivity` provides basic Bot Framework messaging, Microsoft Teams adds rich channel-specific metadata (channel data, tenant IDs, conversation types, adaptive cards, mentions) that applications frequently need. This spec defines:
+While `CoreActivity` provides basic Bot Service messaging, Microsoft Teams adds rich channel-specific metadata (channel data, tenant IDs, conversation types, adaptive cards, mentions) that applications frequently need. This spec defines:
 
 1. **TeamsActivity** — Extends `CoreActivity` with typed Teams-specific properties.
 2. **TeamsActivityBuilder** — Extends the `CoreActivityBuilder` pattern with Teams-specific fluent methods.
@@ -582,7 +582,7 @@ These are useful but not required for the initial TeamsActivity release:
 **Rationale:**
 - Text modification is context-specific (where to insert the mention? prepend? append? replace?).
 - Explicit is better: the developer sets the text with `WithText("Hello <at>User</at>!")` and calls `AddMention(user)` separately.
-- Matches the Bot Framework mental model (mention entity describes a mention; text contains the markup).
+- Matches the Bot Service mental model (mention entity describes a mention; text contains the markup).
 
 **Impact:** Developers must call both `WithText()` and `AddMention()`. More explicit, less magic.
 
@@ -644,4 +644,4 @@ Each language implementation MUST include:
 - [Bot Spec — CoreActivityBuilder](./README.md#coreactivitybuilder) — Builder pattern reference
 - [Microsoft Teams Activity Schema](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/conversations/conversation-messages#teams-channel-data)
 - [Adaptive Cards Schema](https://adaptivecards.io/explorer/)
-- [Bot Framework Activity Reference](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#activity-object)
+- [Bot Service Activity Reference](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#activity-object)

--- a/specs/inbound-auth.md
+++ b/specs/inbound-auth.md
@@ -1,13 +1,13 @@
 # Inbound Authentication Spec
 
-**Purpose**: Define how bots validate incoming requests from the Bot Framework Service.
+**Purpose**: Define how bots validate incoming requests from the Bot Service Service.
 **Status**: Draft
 
 ---
 
 ## Overview
 
-Every `POST /api/messages` request from the Bot Framework Service carries a JWT bearer token in the `Authorization` header. The bot MUST validate this token **before** processing the activity. An invalid or missing token MUST result in a `401 Unauthorized` response.
+Every `POST /api/messages` request from the Bot Service Service carries a JWT bearer token in the `Authorization` header. The bot MUST validate this token **before** processing the activity. An invalid or missing token MUST result in a `401 Unauthorized` response.
 
 ---
 
@@ -31,7 +31,7 @@ The token's `aud` claim MUST match one of the following:
 |-----------------|---------|
 | Bot's Client ID (plain) | `{CLIENT_ID}` |
 | Bot's Client ID with `api://` prefix | `api://{CLIENT_ID}` |
-| Bot Framework global issuer | `https://api.botframework.com` |
+| Bot Service global issuer | `https://api.botframework.com` |
 
 The Client ID is read from the `CLIENT_ID` environment variable.
 
@@ -41,7 +41,7 @@ The following issuers MUST be accepted:
 
 | Issuer | When used |
 |--------|-----------|
-| `https://api.botframework.com` | Tokens from the global Bot Framework channel |
+| `https://api.botframework.com` | Tokens from the global Bot Service channel |
 | `https://sts.windows.net/{tenantId}/` | Tokens from Azure AD v1 endpoints |
 | `https://login.microsoftonline.com/{tenantId}/v2` | Tokens from Azure AD v2 endpoints |
 | `https://login.microsoftonline.com/{tenantId}/v2.0` | Tokens from Azure AD v2 endpoints (alternate format) |
@@ -135,5 +135,5 @@ All language implementations MUST support the same authentication features. This
 ## References
 
 - [Protocol Spec](./protocol.md) — overall HTTP contract
-- [Bot Framework Authentication](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-authentication)
-- [OpenID Configuration (Bot Framework)](https://login.botframework.com/v1/.well-known/openid-configuration)
+- [Bot Service Authentication](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-authentication)
+- [OpenID Configuration (Bot Service)](https://login.botframework.com/v1/.well-known/openid-configuration)

--- a/specs/invoke-activities.md
+++ b/specs/invoke-activities.md
@@ -91,5 +91,5 @@ If an invoke handler does NOT return an `InvokeResponse`, the framework SHOULD r
 ## References
 
 - [teams.net TeamsBotApplication.cs](https://github.com/microsoft/teams.net/blob/next/core/core/src/Microsoft.Teams.Bot.Apps/TeamsBotApplication.cs) — Reference implementation
-- [Bot Framework Invoke Activities](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-activities#invoke-activity) — Protocol documentation
+- [Bot Service Invoke Activities](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-activities#invoke-activity) — Protocol documentation
 - [Teams Adaptive Cards Actions](https://learn.microsoft.com/microsoftteams/platform/task-modules-and-cards/cards/cards-actions) — Common invoke scenarios

--- a/specs/outbound-auth.md
+++ b/specs/outbound-auth.md
@@ -1,13 +1,13 @@
 # Outbound Authentication Spec
 
-**Purpose**: Define how bots authenticate outbound requests to the Bot Framework Service.
+**Purpose**: Define how bots authenticate outbound requests to the Bot Service Service.
 **Status**: Draft
 
 ---
 
 ## Overview
 
-When a bot sends an activity to the Bot Framework (e.g., replying to a user), the HTTP request MUST include a bearer token obtained via the OAuth 2.0 client credentials flow. This token proves the bot's identity to the Bot Framework Service.
+When a bot sends an activity to the Bot Service (e.g., replying to a user), the HTTP request MUST include a bearer token obtained via the OAuth 2.0 client credentials flow. This token proves the bot's identity to the Bot Service Service.
 
 ---
 
@@ -60,7 +60,7 @@ grant_type=client_credentials
 
 ## Token Usage
 
-Every outbound HTTP request to the Bot Framework MUST include the token:
+Every outbound HTTP request to the Bot Service MUST include the token:
 
 ```
 Authorization: Bearer {access_token}
@@ -69,7 +69,7 @@ Authorization: Bearer {access_token}
 This applies to all outbound calls, including:
 
 - Sending activities (`POST {serviceUrl}v3/conversations/{conversationId}/activities`)
-- Any future Bot Framework REST API calls
+- Any future Bot Service REST API calls
 
 ---
 
@@ -130,4 +130,4 @@ See [Configuration](./configuration.md) for the full per-language configuration 
 
 - [Protocol Spec](./protocol.md) — overall HTTP contract
 - [Microsoft Identity Platform Client Credentials Flow](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow)
-- [Bot Framework Authentication](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-authentication)
+- [Bot Service Authentication](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-authentication)

--- a/specs/proactive-messaging.md
+++ b/specs/proactive-messaging.md
@@ -75,7 +75,7 @@ const response = await client.createConversationAsync(serviceUrl, {
 
 ## ConversationClient API
 
-The `ConversationClient` wraps the [Bot Framework v3 Conversations REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#conversations-object).
+The `ConversationClient` wraps the [Bot Service v3 Conversations REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#conversations-object).
 
 | Method | Description |
 |--------|-------------|
@@ -115,4 +115,4 @@ No additional configuration is needed beyond the standard `CLIENT_ID`, `CLIENT_S
 - [Outbound Auth](./outbound-auth.md) — OAuth2 token acquisition
 - [README — TurnContext](./README.md#turncontext) — `ctx.send()` for in-turn replies
 - [Activity Schema](./activity-schema.md) — activity JSON structure
-- [Bot Framework REST API — Create Conversation](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#create-conversation)
+- [Bot Service REST API — Create Conversation](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#create-conversation)

--- a/specs/protocol.md
+++ b/specs/protocol.md
@@ -7,12 +7,12 @@
 
 ## Overview
 
-A `botas` bot communicates with the Microsoft Bot Framework Service over two HTTP channels:
+A `botas` bot communicates with the Microsoft Bot Service Service over two HTTP channels:
 
 | Direction | Endpoint | Who calls whom |
 |-----------|----------|----------------|
-| **Inbound** | `POST /api/messages` | Bot Framework → Bot |
-| **Outbound** | `POST {serviceUrl}v3/conversations/{conversationId}/activities` | Bot → Bot Framework |
+| **Inbound** | `POST /api/messages` | Bot Service → Bot |
+| **Outbound** | `POST {serviceUrl}v3/conversations/{conversationId}/activities` | Bot → Bot Service |
 
 Both channels carry JSON [Activity](./activity-schema.md) payloads authenticated with bearer tokens (see [Inbound Auth](./inbound-auth.md) and [Outbound Auth](./outbound-auth.md)).
 
@@ -69,7 +69,7 @@ After middleware, the activity is dispatched to a registered handler based on `a
 - If a handler IS registered for the type → invoke it.
 - If NO handler is registered for the type → **silently ignore** the activity (no error).
 
-**Case sensitivity**: Handler lookup by `activity.type` SHOULD use **case-insensitive** comparison. Activity type strings from the Bot Framework (e.g., `"message"`, `"invoke"`) are lowercase by convention, but implementations should tolerate case variations for robustness.
+**Case sensitivity**: Handler lookup by `activity.type` SHOULD use **case-insensitive** comparison. Activity type strings from the Bot Service (e.g., `"message"`, `"invoke"`) are lowercase by convention, but implementations should tolerate case variations for robustness.
 
 ##### CatchAll Handler
 
@@ -118,7 +118,7 @@ The `serviceUrl` from inbound activities MUST be validated against an allowlist 
 
 | Host pattern | Description |
 |--------------|-------------|
-| `*.botframework.com` | Global Bot Framework service |
+| `*.botframework.com` | Global Bot Service service |
 | `*.botframework.us` | US government cloud |
 | `*.botframework.cn` | China cloud |
 | `smba.trafficmanager.net` | Azure Traffic Manager (Teams) — exact match only |
@@ -305,7 +305,7 @@ The bearer token MUST be obtained via the OAuth 2.0 client credentials flow. See
 
 ### Response
 
-On success the Bot Framework returns:
+On success the Bot Service returns:
 
 ```json
 { "id": "new-activity-id" }
@@ -313,7 +313,7 @@ On success the Bot Framework returns:
 
 ### ConversationClient API Surface
 
-Beyond sending activities, the `ConversationClient` wraps the [Bot Framework v3 Conversations REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#conversations-object):
+Beyond sending activities, the `ConversationClient` wraps the [Bot Service v3 Conversations REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#conversations-object):
 
 | Method | HTTP | Path | Description |
 |--------|------|------|-------------|
@@ -373,4 +373,4 @@ Implementations SHOULD ensure HTTP connections are closed on shutdown. The exact
 - [Activity Schema](./activity-schema.md)
 - [Inbound Auth](./inbound-auth.md)
 - [Outbound Auth](./outbound-auth.md)
-- [Bot Framework REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference)
+- [Bot Service REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference)

--- a/specs/setup.md
+++ b/specs/setup.md
@@ -2,7 +2,7 @@
 
 This guide walks through registering a bot and obtaining the credentials needed to run BotAS samples. After completing it you will have `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` values ready to use.
 
-> **Scope**: This guide covers bot *infrastructure* only (app registration, Bot Framework channel registration). It does not cover hosting or deploying your bot code.
+> **Scope**: This guide covers bot *infrastructure* only (app registration, Bot Service channel registration). It does not cover hosting or deploying your bot code.
 
 ---
 

--- a/specs/teams-activity.md
+++ b/specs/teams-activity.md
@@ -145,5 +145,5 @@ reply = TeamsActivityBuilder() \
 ## References
 
 - [Activity Schema](./activity-schema.md)
-- [Bot Framework Activity Reference](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#activity-object)
+- [Bot Service Activity Reference](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#activity-object)
 - [Teams Channel Data](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/conversations/conversation-messages#teams-channel-data)


### PR DESCRIPTION
## Summary

Replaces **~196 occurrences** of \Bot Framework\ with \Bot Service\ across **65 files** — docs, specs, source code comments, package descriptions, and config files.

### What changed
- All prose, comments, and descriptions: \Bot Framework\ → \Bot Service\
- Removed Bot Framework Emulator reference from \	oken-manager.ts\
- Link display text updated (URLs unchanged)

### What was NOT changed
- **\.squad/\ folder** — historical records left as-is
- **Real URLs** containing \otframework.com\ — no whitespace in domain, unaffected by replacement
- **Microsoft doc link URLs** — paths unchanged, only display text updated