### PR TITLE
Fix GHSA-9mv3-2cwr-p262: upgrade DataProtection to 10.0.7

### DIFF
--- a/dotnet/src/Botas/BotApplicationConfigurationExtensions.cs
+++ b/dotnet/src/Botas/BotApplicationConfigurationExtensions.cs
@@ -81,7 +81,7 @@ public static class BotApplicationConfigurationExtensions
                 sp.GetRequiredService<AgentScopeProvider>().Scope,
                 aadConfigSectionName));
 
-        static ConversationClient ConversationClientFactory(IServiceProvider provider, object serviceKey) => new(
+        static ConversationClient ConversationClientFactory(IServiceProvider provider, object? serviceKey) => new(
             provider.GetRequiredService<IHttpClientFactory>().CreateClient(ConversationHttpClientName),
             provider.GetService<ILogger<ConversationClient>>()!
             );

--- a/dotnet/src/Botas/Botas.csproj
+++ b/dotnet/src/Botas/Botas.csproj
@@ -33,8 +33,10 @@
     <PackageReference Include="Microsoft.Identity.Web.AgentIdentities" Version="4.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
+    <!-- Pin to 10.0.7 to fix GHSA-9mv3-2cwr-p262 (high-severity DataProtection vulnerability) -->
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
     <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.17.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Security Fix — High Severity (CVSS 9.1)

Fixes #240

### Vulnerability
**GHSA-9mv3-2cwr-p262**: Padding-oracle vulnerability in \Microsoft.AspNetCore.DataProtection\ 10.0.0–10.0.6 allows elevation of privilege via forged authentication cookies.

### Changes
- **\Botas.csproj\**: Pin \Microsoft.AspNetCore.DataProtection\ to **10.0.7** (patched version)
- **\Botas.csproj\**: Bump \System.Security.Cryptography.Xml\ from 10.0.6 → **10.0.7** (required by DataProtection 10.0.7)
- **\BotApplicationConfigurationExtensions.cs\**: Fix nullability mismatch (\object\ → \object?\) exposed by the package upgrade

### Verification
- \dotnet restore\ ✅ — no vulnerability warnings
- \dotnet build\ ✅ — 0 errors, 0 warnings
- \dotnet test\ ✅ — 77/77 tests pass