### PR TITLE
fix: update VitePress base path for custom domain

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -3,14 +3,14 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: 'BotAS',
   description: 'Multi-language Microsoft Teams bot library documentation',
-  base: '/botas/',
+  base: '/',
   appearance: 'dark',
 
   // Ignore dead links from auto-generated API docs (pdoc cross-references)
   ignoreDeadLinks: true,
 
   head: [
-    ['link', { rel: 'icon', href: '/botas/logo.svg' }],
+    ['link', { rel: 'icon', href: '/logo.svg' }],
   ],
 
   themeConfig: {

--- a/docs-site/public/_redirects
+++ b/docs-site/public/_redirects
@@ -1,1 +1,1 @@
-/botas/* /:splat 200
+


### PR DESCRIPTION
Update docs-site VitePress config for custom domain deployment:

- Change \ase\ from \/botas/\ to \/\
- Update favicon href to remove \/botas/\ prefix
- Remove \_redirects\ rewrite rule (no longer needed with \/\ base)