### PR TITLE
docs: enforce branch workflow in agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,13 @@ Rules enforced: `E` (pycodestyle errors), `F` (pyflakes), `W` (pycodestyle warni
 ## Use links, not duplication
 If you need implementation or architectural details, link to the existing docs instead of re-stating them.
 
+## Branch workflow
+- **Never commit directly to `main`.** Always create a new feature branch before making changes.
+- Branch naming: use descriptive prefixes like `fix/`, `feat/`, `docs/`, `test/` (e.g., `fix/auth-validation`, `docs/custom-domain`).
+- Open a PR for review — do not push to `main`.
+
 ## What not to do
+- Do not commit or push directly to `main` — the branch has protection rules.
 - Do not add new instructions that conflict with `AGENTS.md` or `specs/README.md`.
 - Do not treat this repo as a single-language project.
 - Do not invent new authentication flows or HTTP contracts outside the Bot Service model.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Rules: `E`, `F`, `W`, `I` — line length **120** (see `python/packages/botas/py
 
 ## What Not to Do
 
+- **Do not commit or push directly to `main`** — always create a feature branch and open a PR.
 - Do not duplicate spec content in this file or elsewhere — link to `specs/` instead.
 - Do not invent new authentication flows or HTTP contracts outside the Bot Service model.
 - Do not treat this repo as a single-language project.


### PR DESCRIPTION
Add explicit branch protection rules to coding agent instructions so Copilot always creates a feature branch instead of committing to main.

**Files updated:**
- \.github/copilot-instructions.md\ — added **Branch workflow** section with naming conventions
- \AGENTS.md\ — added branch rule to **What Not to Do**