### PR TITLE
docs: fix getting-started .NET creds, middleware imports, Python imports

### DIFF
--- a/docs-site/getting-started.md
+++ b/docs-site/getting-started.md
@@ -39,6 +39,16 @@ app.Run();
 // dotnet run --project dotnet/samples/EchoBot
 ```
 
+::: info .NET uses `launchSettings.json`, not `.env`
+.NET reads credentials from `launchSettings.json` in `AzureAd__` format (e.g., `AzureAd__ClientId`), not from `.env` files. Use the [`env-to-launch-settings.mjs` helper script](https://github.com/rido-min/botas/blob/main/dotnet/env-to-launch-settings.mjs) to convert `.env` to the correct format:
+
+```bash
+node dotnet/env-to-launch-settings.mjs EchoBot
+```
+
+See [Setup Guide → .NET Environment Variables](setup#net-environment-variables) for full details.
+:::
+
 ```typescript [Node.js]
 // Install:
 // npm install botas-core botas-express

--- a/docs-site/middleware.md
+++ b/docs-site/middleware.md
@@ -120,6 +120,10 @@ class LoggingMiddleware(TurnMiddleware):
 :::
 
 ::: info
+**Middleware type sources (Node.js):** Middleware types (`TurnMiddleware`, `removeMentionMiddleware`, etc.) are defined in `botas-core` and re-exported from `botas-express` for convenience. You can import from either, but imports from `botas-express` are simpler when working with `BotApp`.
+:::
+
+::: info
 **Next callback types:** .NET `NextDelegate` takes `CancellationToken` · Node.js `NextTurn` is `() => Promise<void>` · Python `NextTurn` is `Callable[[], Awaitable[None]]`
 :::
 
@@ -127,7 +131,7 @@ class LoggingMiddleware(TurnMiddleware):
 
 ## Registering middleware
 
-Call `Use()` (**.NET**) or `use()` (**Node / Python**) on your `BotApplication` instance. You can chain multiple calls — they run in the order registered.
+Call `Use()` (**.NET**) or `use()` (**Node / Python**) on your `BotApplication` or `BotApp` instance. You can chain multiple calls — they run in the order registered.
 
 ::: code-group
 ```csharp [.NET]
@@ -150,6 +154,23 @@ bot = BotApplication()
 
 bot.use(LoggingMiddleware())
 bot.use(ErrorHandlingMiddleware())
+```
+:::
+
+::: tip Node.js: Using BotApp
+If you're following the [Getting Started](getting-started) guide with `BotApp`, the API is identical:
+
+```typescript
+import { BotApp } from 'botas-express'
+
+const app = new BotApp()
+
+app
+  .use(loggingMiddleware)
+  .use(errorHandlingMiddleware)
+  .on('message', handler)
+
+app.start()
 ```
 :::
 

--- a/docs-site/teams-features.md
+++ b/docs-site/teams-features.md
@@ -133,6 +133,7 @@ await ctx.send(reply)
 ```
 
 ```python [Python]
+from botas import TeamsActivityBuilder
 from fluent_cards import AdaptiveCardBuilder, TextSize, TextWeight, to_dict
 
 card = (
@@ -240,11 +241,12 @@ app.onInvoke('adaptiveCard/action', async (ctx) => {
 ```
 
 ```python [Python]
+from botas import InvokeResponse
 from fluent_cards import AdaptiveCardBuilder, TextSize, TextWeight, TextColor, to_dict
 
 @app.on_invoke("adaptiveCard/action")
 async def on_card_action(ctx):
-    value = ctx.activity.value or {}
+     value = ctx.activity.value or {}
     action_info = value.get("action", {})
     verb = action_info.get("verb", "unknown")
 
@@ -320,6 +322,7 @@ await ctx.send(reply)
 ```
 
 ```python [Python]
+from botas import TeamsActivityBuilder
 from botas.suggested_actions import SuggestedActions, CardAction
 
 reply = (


### PR DESCRIPTION
Batch fix for three documentation issues:

- **#249**: Added .NET launchSettings.json callout to Getting Started page with reference to the env-to-launch-settings.mjs helper script
- **#248**: Clarified middleware import sources (types defined in botas-core, re-exported from botas-express) and added BotApp usage example
- **#246**: Added missing Python import statements (InvokeResponse, TeamsActivityBuilder) to code examples in teams-features.md

Fixes #249, #248, #246