### PR TITLE
fix: return 405 for non-POST on /api/messages in Node

### DIFF
--- a/node/packages/botas-express/src/bot-app.spec.ts
+++ b/node/packages/botas-express/src/bot-app.spec.ts
@@ -88,6 +88,16 @@ describe('BotApp', () => {
     assert.deepEqual(JSON.parse(res.body), { status: 'ok' })
   })
 
+  it('GET /api/messages returns 405 Method Not Allowed', async () => {
+    const app = new BotApp({ port: freePort(), auth: false })
+    server = app.start()
+    const addr = server.address() as { port: number }
+
+    const res = await get(addr.port, '/api/messages')
+    assert.equal(res.status, 405)
+    assert.ok(res.body.includes('Method Not Allowed'))
+  })
+
   it('GET / returns status page', async () => {
     const app = new BotApp({ port: freePort(), auth: false })
     server = app.start()

--- a/node/packages/botas-express/src/bot-app.ts
+++ b/node/packages/botas-express/src/bot-app.ts
@@ -123,6 +123,10 @@ export class BotApp {
       })
     }
 
+    app.all(path, (_req, res) => {
+      res.status(405).set('Allow', 'POST').json({ error: 'Method Not Allowed' })
+    })
+
     app.get('/health', (_req, res) => { res.json({ status: 'ok' }) })
     app.get('/', (_req, res) => {
       res.send(`Bot ${this.bot.options.clientId ?? '(no client ID)'} is running. Send messages to ${path}`)


### PR DESCRIPTION
Fixes #250

Node.js was returning 404 for GET /api/messages. Changed to return 405 Method Not Allowed with Allow: POST header to match Python and .NET behavior.

## Changes
- Added pp.all(path) catch-all after the POST route in otas-express BotApp.start()`n- Returns 405 with Allow: POST header and { error: 'Method Not Allowed' } body
- Added test verifying GET /api/messages returns 405
- All 10 express tests pass