### PR TITLE
fix: standardize Node.js error responses to JSON format

### DIFF
--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -67,3 +67,11 @@
 - CoreActivity only types common fields; Bot Framework fields like `membersAdded`, `reactionsAdded`, `action` arrive at runtime via JSON parse but need `as Record<string, unknown>` cast to access
 - Teams-sample now demonstrates 6 activity types: conversationUpdate, messageReaction, typing, installationUpdate, message, invoke (PR #220, issue #218)
 - JSDoc coverage added to all 11 non-spec source files in `node/packages/botas/src/` for issue #224; build + 112 tests pass clean
+
+### Error Response JSON Format (2026-04-25)
+- **Standardized 401 auth error responses** to return JSON `{ error: 'Unauthorized', message: '<specific error>' }` instead of plain text
+- Updated `ExpressResponse` type to include `json()` method for proper Content-Type headers
+- Added 2 tests verifying JSON error format on missing header and invalid token scenarios
+- No `botas-hono` package exists — only Express adapter needed changes
+- 405 handling lives on separate branch `fix/node-get-405` (PR #255) — not modified here
+- **PR:** #257 — Fixes #247 (Node.js part)

--- a/node/packages/botas-express/src/bot-app.spec.ts
+++ b/node/packages/botas-express/src/bot-app.spec.ts
@@ -173,3 +173,53 @@ describe('botAuthExpress startup validation (#95)', () => {
     assert.doesNotThrow(() => botAuthExpress('explicit-app-id'))
   })
 })
+
+// ── #247: Auth 401 returns JSON error format ─────────────────────────────────
+
+describe('botAuthExpress 401 JSON response (#247)', () => {
+  it('returns JSON { error, message } on missing auth header', async () => {
+    const middleware = botAuthExpress('test-app-id')
+
+    const req = { headers: {} }
+    let statusCode = 0
+    let jsonBody: unknown
+    const res = {
+      status (code: number) { statusCode = code; return this },
+      end () { /* noop */ },
+      json (body: unknown) { jsonBody = body },
+    }
+    const next = () => { /* noop */ }
+
+    await middleware(req, res, next)
+
+    assert.equal(statusCode, 401)
+    assert.ok(jsonBody, 'Should have called res.json()')
+    const body = jsonBody as { error: string; message: string }
+    assert.equal(body.error, 'Unauthorized')
+    assert.ok(body.message.length > 0, 'Should include an error message')
+  })
+
+  it('returns JSON { error, message } on invalid token', async () => {
+    const middleware = botAuthExpress('test-app-id')
+
+    const req = { headers: { authorization: 'Bearer invalid-token' } }
+    let statusCode = 0
+    let jsonBody: unknown
+    const res = {
+      status (code: number) { statusCode = code; return this },
+      end () { /* noop */ },
+      json (body: unknown) { jsonBody = body },
+    }
+    let nextCalled = false
+    const next = (err?: unknown) => { nextCalled = true; void err }
+
+    await middleware(req, res, next)
+
+    assert.equal(statusCode, 401)
+    assert.equal(nextCalled, false)
+    assert.ok(jsonBody, 'Should have called res.json()')
+    const body = jsonBody as { error: string; message: string }
+    assert.equal(body.error, 'Unauthorized')
+    assert.ok(body.message.length > 0, 'Should include an error message')
+  })
+})

--- a/node/packages/botas-express/src/bot-auth-express.ts
+++ b/node/packages/botas-express/src/bot-auth-express.ts
@@ -4,7 +4,7 @@
 import { validateBotToken, BotAuthError } from 'botas-core'
 
 type ExpressRequest = { headers: Record<string, string | string[] | undefined> }
-type ExpressResponse = { status(code: number): ExpressResponse; end(msg?: string): void }
+type ExpressResponse = { status(code: number): ExpressResponse; end(msg?: string): void; json(body: unknown): void }
 type NextFn = (err?: unknown) => void
 
 /**
@@ -30,7 +30,7 @@ export function botAuthExpress (
       next()
     } catch (err: unknown) {
       if (err instanceof BotAuthError) {
-        res.status(401).end(err.message)
+        res.status(401).json({ error: 'Unauthorized', message: err.message })
       } else {
         next(err)
       }


### PR DESCRIPTION
Fixes #247 (Node.js part)

Standardizes HTTP error responses to return JSON:

```json
{"error": "ErrorCode", "message": "human-readable description"}
```

Changes:
- 401 responses now return JSON via res.json() with Content-Type: application/json
- Updated ExpressResponse type to include json() method
- Added 2 new tests verifying JSON error format (missing header + invalid token)

Part of cross-language error format standardization (see #247).

Note: The 405 handler lives on branch fix/node-get-405 (PR #255) and should be updated separately to also return JSON format.
