### PR TITLE
docs: specs overhaul - accuracy, coverage, readability (#259)

### DIFF
--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -9,6 +9,22 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+### Specs Overhaul: dotnet.md Audit and Fix (2026-04-13)
+- **Task:** Fixed `specs/reference/dotnet.md` to match actual .NET implementation for Issue #259.
+- **Key findings and fixes:**
+  1. **ProcessAsync signature** — Doc incorrectly stated `ProcessAsync(Request, Response)`, changed to `ProcessAsync(HttpContext)` which matches actual implementation.
+  2. **TurnContext return types** — All `SendAsync()` and `SendTypingAsync()` methods return `Task<string>` (activity ID), not `Task` as doc showed.
+  3. **SendTypingAsync** — Confirmed exists with signature `Task<string> SendTypingAsync(CancellationToken)`.
+  4. **OnInvoke handler** — Added missing documentation for `BotApplication.OnInvoke()` and `BotApp.OnInvoke()` methods; returns `InvokeResponse` object.
+  5. **BotApp.Create** — Added `routePath` parameter documentation (optional, default `"api/messages"`).
+  6. **Version and AppId properties** — Both exposed: `BotApplication.Version` (static), `BotApplication.AppId` (instance property).
+  7. **ConversationClient** — Only `SendActivityAsync(CoreActivity)` method exists; no other methods implemented (audit was correct).
+  8. **New InvokeResponse documentation** — Added full section documenting `Status` and `Body` properties with example invoke handler.
+  9. **Language-Specific Differences table** — Expanded and corrected 13 entries to reflect actual API surface including AppId, Version, Route path, and Invoke handler registration.
+- **Files modified:** `specs/reference/dotnet.md` only (no source code changes).
+- **Testing:** Verified all changes against actual source in `dotnet/src/Botas/` — BotApp.cs, BotApplication.cs, TurnContext.cs, ConversationClient.cs.
+- **Key insight:** The .NET implementation is the canonical reference; specs must match the code precisely to enable cross-language porting.
+
 ### Typing Activity Support (2026-04-13)
 - **Implemented typing activity support** following approved API design from `.squad/decisions/inbox/leela-typing-api-resolved.md`.
 - **New API surface:**

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -75,3 +75,18 @@
 - No `botas-hono` package exists — only Express adapter needed changes
 - 405 handling lives on separate branch `fix/node-get-405` (PR #255) — not modified here
 - **PR:** #257 — Fixes #247 (Node.js part)
+
+### Node.js Specs Overhaul (2026-04-25)
+- **Fixed `specs/reference/node.md` for accuracy vs. implementation:**
+  - Corrected import paths: `botas` → `botas-core` (core API) and `botas-express` (Express adapter)
+  - Clarified `botAuthHono` is NOT exported; users must import `validateBotToken` + `BotAuthError` from `botas-core` and write custom middleware
+  - Added `onInvoke()` method to BotApplication class signature (invoke handlers return InvokeResponse)
+  - Updated configuration table: `TENANT_ID` defaults to `"botframework.com"` (not `"common"`), added `ALLOWED_SERVICE_URLS` env var for SSRF protection
+  - Added `MANAGED_IDENTITY_CLIENT_ID` to configuration table
+  - Updated Language-Specific Differences table to reflect `validateBotToken()` as the auth import for custom middleware
+  - Replaced `botAuthHono()` import example with complete custom middleware implementation in Hono sample
+  - Added new `validateBotToken()` section explaining direct use for non-Express frameworks
+- **Auth library confirmed:** `jose` (not `jsonwebtoken` + `jwks-rsa`)
+- **Key audit finding:** `botAuthHono` is sample code only, not an exported library function
+- **Issue:** #259 (docs/specs-overhaul-259)
+

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -49,6 +49,21 @@
 - Async context managers critical for resource cleanup in long-running servers
 - Extra fields on CoreActivity (membersAdded, reactionsAdded, action) use original JSON camelCase keys via Pydantic extra="allow"; access with `getattr(activity, "membersAdded", None)` — they're raw dicts/lists, not typed models
 
+### Specs Overhaul — Python Reference Doc (Issue #259) (2026-04-24)
+- **Fixed specs/reference/python.md to match actual implementation:**
+  - **BotApp import path:** Changed `from botas import BotApp` → `from botas_fastapi import BotApp` (line 13). BotApp lives in botas-fastapi package adapter, not core.
+  - **TurnContext.send signature:** Updated to accept `str | CoreActivity | dict` (was only `str | dict`). CoreActivity is a valid input per actual source.
+  - **on_invoke method:** Added `on_invoke(name, handler)` to BotApplication API signature (was missing). Returns `InvokeResponse(status, body)`.
+  - **InvokeResponse & invoke activities:** Added new "Invoke Activities" section documenting handler pattern and automatic 501 fallback.
+  - **Configuration table:** Added `MANAGED_IDENTITY_CLIENT_ID` and `ALLOWED_SERVICE_URLS` environment variables (both are read by code but were missing from docs).
+  - **HTTP Integration:** Split FastAPI example from manual integration; clarified `invoke_response` handling for both paths.
+  - **Auth Dependency:** Clarified `BotApp` auto-enables auth when `CLIENT_ID` is set; manual path uses `bot_auth_dependency(client_id)`.
+  - **Language-Specific Differences:** Updated `TurnContext.send` signature in table to match actual `str | CoreActivity | dict`.
+  - **Exception class:** Added `cause` and `activity` attributes to BotHandlerException documentation.
+- **Verification:** Audited bot_application.py, turn_context.py, conversation_client.py, core_activity.py, bot_app.py, token_manager.py, __init__.py files.
+- **Branch:** docs/specs-overhaul-259 (PR #259)
+
+
 ### API Documentation — Google-style Docstrings (2026-04-22)
 - **Added Google-style docstrings to all 12 public Python files** in `python/packages/botas/src/botas/` per user directive (Rido, 2026-04-22T21:27).
 - **Files documented:**

--- a/.squad/agents/kif/history.md
+++ b/.squad/agents/kif/history.md
@@ -179,3 +179,32 @@
 Cross-links in markdown tables must NOT be inside backtick code spans. Markdown does NOT render links inside backticks — everything between backticks is literal text. Fixed ~98 affected lines across nodejs.md and python.md by removing outer backticks from Type/Signature cells containing `[TypeName](#anchor)` syntax, and escaping `<>` as HTML entities (`&lt;`/`&gt;`) to prevent VitePress from interpreting generics as HTML tags. Example: `\\sendActivityAsync(...): Promise<[ResourceResponse](#resourceresponse)>\\ ` became `sendActivityAsync(...): Promise&lt;[ResourceResponse](#resourceresponse)&gt;`.
 
 **Pattern:** In table cells with cross-links: (1) remove outer backticks, (2) escape angle brackets, (3) leave method/property name column unchanged, (4) keep pipe escapes as-is. VitePress build passes after fix.
+
+### 2025-01-XX: Specs overhaul readability work (Issue #259)
+
+**What**: Fixed all broken links, added template headers, standardized terminology, and extracted user stories into a new spec file.
+
+**Links fixed** (6 total):
+1. `specs/architecture.md` line 106: `./specs/activity-schema.md` → `./activity-schema.md` (already in specs/)
+2. `specs/README.md` line 32: Simplified link to `../docs-site/middleware.md` (removed redundant Developer Docs link)
+3. `specs/protocol.md` line 268: Updated relative path in middleware reference
+4. `specs/contributing.md` line 147: Changed `./turn-context.md` → `./protocol.md#turncontext` (turn-context.md not created yet; linked to closest spec)
+5. `specs/activity-schema.md` line 6: Updated broken anchor `./README.md#coreactivitybuilder` → `./architecture.md#components`
+
+**Template headers added**:
+- `specs/setup.md`: Added purpose line, Status: Draft, and Overview section
+- `specs/architecture.md`: Added purpose line and Status: Draft at top
+- `specs/reference/dotnet.md`, `specs/reference/node.md`, `specs/reference/python.md`: Added Status: Draft and short Overview line
+
+**Terminology standardized**:
+- Replaced all "BotAS" with "botas" (lowercase) across: `architecture.md`, `configuration.md`, `activity-schema.md`, `samples.md`, `setup.md` (5 replacements total)
+- Maintained consistent capitalization: "botas" in prose, "Botas" at sentence start
+
+**User stories extracted**:
+- Created new `specs/user-stories.md` with all four Gherkin scenarios (US-001 Echo Bot, US-002 Proactive Messaging, US-003 Middleware Pipeline, US-004 Teams Features) plus acceptance criteria
+- Updated `specs/README.md` to remove inline user stories and link to new file: "See [User Stories](./user-stories.md) for detailed behavioral scenarios."
+
+**Files modified**: 10 (architecture.md, README.md, protocol.md, contributing.md, activity-schema.md, setup.md, configuration.md, samples.md, dotnet.md, node.md, python.md) + 1 new (user-stories.md)
+
+**Pattern**: Breaking large content blocks into separate spec files improves discoverability (user stories live in their own file, not buried in README) and keeps reference sections consistent across languages. Template headers (purpose + status) establish consistency and make the spec tree browsable.
+

--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -7,6 +7,39 @@
 
 ## Learnings
 
+### 2025-05-XX: Specs overhaul — accuracy fixes and new component specs
+
+Completed Part 1 (accuracy) and Part 3 (new specs) of GitHub Issue #259 specs overhaul.
+
+**Accuracy fixes applied**:
+- **protocol.md & invoke-activities.md**: Corrected CatchAll + invoke interaction — invoke activities ALWAYS bypass CatchAll and go to invoke-specific dispatch (Decision 1). Removed catch-all invoke handler concept (Decision 4) — no implementation has it.
+- **architecture.md**: Fixed .NET handler registration description (also has `On(type, handler)`, not just `OnActivity`). Fixed SSRF section to say `smba.trafficmanager.net` exact match only (not `*.trafficmanager.net` wildcard).
+- **inbound-auth.md**: Noted Node.js uses `jose` library (not `jsonwebtoken` + `jwks-rsa`). Noted OpenID config URL variation (with/without hyphen). Flagged .NET issuer v2.0 format validation gap.
+- **teams-activity.md**: Added missing fields `localTimestamp`, `localTimezone`, `NotificationInfo`, `TeamsConversation`, and clarified `withAdaptiveCardAttachment` method naming.
+- **configuration.md**: Fixed Python import path (import `BotApp` from `botas_fastapi`, not `botas`). Added `MANAGED_IDENTITY_CLIENT_ID` and `ALLOWED_SERVICE_URLS` env vars to table.
+- **activity-schema.md**: Noted `id` and `channelId` are currently in extension data but will be promoted to typed fields (Decision 6, code change pending).
+
+**New specs written**:
+- **turn-context.md**: TurnContext properties (`activity`, `app`), methods (`send`, `sendTyping`), lifecycle, language-specific notes.
+- **core-activity-builder.md**: Builder methods (all `with*` variants), usage examples, relationship to TurnContext.
+- **conversation-client.md**: All API methods (send, update, delete, members, create conversation, etc.), error handling, conversation ID encoding, service URL validation, language-specific availability notes.
+
+**Key learnings**:
+- All 3 implementations route invoke activities separately from CatchAll — this is a hard invariant because invoke handlers need to return `InvokeResponse`.
+- .NET has both `On(type, handler)` AND `OnActivity` CatchAll (not just CatchAll as previously stated).
+- Node.js migrated from `jsonwebtoken` + `jwks-rsa` to `jose` library for JWT validation.
+- .NET only implements `SendActivityAsync` in ConversationClient — all other methods (update, delete, members) are only in Node.js/Python.
+- Conversation IDs may contain semicolons (Teams agents channel) — must truncate before URL-encoding.
+
+**Spec writing patterns for AI agents**:
+- Start each spec with Purpose (one sentence) and Status (Draft/Implemented).
+- Structure: Overview → Constructor → Properties → Methods → Examples → Language-Specific Notes → References.
+- For methods: show signatures for all 3 languages, note which languages have which features.
+- Link to related specs (don't duplicate content).
+- Use tables for cross-language comparison.
+- Note known gaps and pending changes (e.g., Decision 6 promotion of id/channelId).
+
+
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
 - **2026-04-13: Issue triage — 8 untriaged items routed and prioritized.** All 8 open issues (GitHub #76, #75, #74, #72, #70, #67, #65, #64) labeled with `squad:{member}` and given triage comments. 4 issues marked HIGH: #72 (Python FastAPI shutdown), #70 (Node rate limiting), #67 (Node middleware rejections), #65 (Node debug logging secrets). Medium/low audit collections (#76 Node, #75 .NET, #74 Python) sent to language-specific devs for targeted follow-up creation. No cross-language coordination required. Decision: .squad/decisions/inbox/leela-issue-triage.md
@@ -38,3 +71,5 @@
 - **2026-04-23: Triage — PR #235 merged, Issue #236 reassigned to squad:leela.** PR #235 ("fix: accumulate versions.json across docs deployments") successfully merged. Approach is sound: CD workflow now preserves existing versions.json from gh-pages before deploy, merges old + new version lists (deduplicated, sorted), and syncs VersionBadge UI to read from versions.json dynamically. No follow-up needed. **Issue #236 reassigned from squad:bender → squad:leela.** Title: "Inconsistencies across languages implementing ActivityType". Context: PR #231 introduced ActivityType constructs; issue reports inconsistency across .NET/Node/Python. This is an API design and parity issue (architecture concern), not DevOps. Requires cross-language audit of PR #231 impact to identify concrete inconsistencies. Priority: Medium (depends on research to scope). Decision: `.squad/decisions/inbox/leela-triage-2026-04-23.md`
 
 - **2026-04-23: Issue #236 deep audit — ActivityType parity confirmed.** Full cross-language audit of ActivityType and TeamsActivityType after PR #231. All three languages (.NET, Node.js, Python) define identical sets: Core = {message, typing, invoke}, Teams = Core + {event, conversationUpdate, messageUpdate, messageDelete, messageReaction, installationUpdate}. All match `specs/activity-schema.md` exactly. Differences are purely structural/idiomatic: (1) Node has dedicated `activity-type.ts` while .NET/Python define inline in core activity file; (2) TeamsActivityType composition differs (C# re-declares via `ActivityType.X`, TS uses union inclusion, Python flat-lists all values); (3) Type mechanisms differ by language (const strings, TS union types, Python Literal). None affect behavior. Posted detailed findings comment on issue #236. Recommendation: issue can be closed, no code changes needed. Label updated from squad:bender → squad:leela.
+
+- **2026-04-25: Specs overhaul audit synthesized → Issue #259.** Coordinated 4-agent audit (Amy/.NET, Fry/Node.js, Hermes/Python, Kif/Structure) of all specs/ files against implementations. Synthesized ~94 findings into GitHub issue #259 with actionable checkboxes. Key output: 6 "Decisions Needed" items where spec and ALL THREE implementations disagree (CatchAll+invoke, 200-vs-501 for missing invoke handlers, case-insensitive lookup, catch-all invoke handler, 400-vs-500 input validation, id/channelId typing). Also flagged 3 new specs needed (TurnContext, CoreActivityBuilder, ConversationClient), 6 broken links, 7 template gaps, and terminology inconsistency. Proposed priority: Accuracy → Coverage → Readability. Decision: `.squad/decisions/inbox/leela-specs-audit.md`

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -6,10 +6,20 @@
       "sourceType": "github",
       "computedHash": "81af098a4ce6f0e323c1bd02b8e79df3bbaed57cbf1c4060f58ddc95de5545a1"
     },
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "computedHash": "784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea"
+    },
     "teams-bot-infra": {
       "source": "@microsoft/teams.cli",
       "sourceType": "npm",
       "computedHash": "3b91cb566f52fafc52bfa82c5a70713caa65270f116cc0c1d5466bb05ec80e2f"
+    },
+    "to-prd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "computedHash": "8351452ad372ea4f839d3f7b951927b417851ffa49e7e6af28ea0f0ae111dca8"
     }
   }
 }

--- a/specs/README.md
+++ b/specs/README.md
@@ -29,98 +29,15 @@
 | [invoke-activities.md](./invoke-activities.md) | Invoke activity dispatch |
 | [teams-activity.md](./teams-activity.md) | Teams-specific features (TeamsActivity, TeamsActivityBuilder) |
 
-For **developer guides** on middleware patterns, use cases, and samples, see the [Middleware Guide](../docs-site/middleware.md) and [Developer Docs](../docs-site/).
+For **developer guides** on middleware patterns, use cases, and samples, see the [Middleware Guide](../docs-site/middleware.md).
 
 **Aspirational/future specs** (not yet implemented) live in [specs/future/](./future/).
 
 ---
 
-## User Stories (Gherkin)
+## User Stories
 
-### US-001: Echo Bot
-
-```
-Feature: Bot responds to user messages
-  Scenario: Simple message response
-    Given a running bot
-    When user sends "hello"
-    Then bot responds with "you said hello"
-
-  Scenario: Empty message handling
-    Given a running bot
-    When user sends empty message
-    Then bot handles gracefully (no crash)
-
-  Scenario: Authentication
-    Given a running bot
-    When Bot Service sends activity
-    Then JWT token is validated
-```
-
-### US-002: Proactive Messaging
-
-```
-Feature: Bot sends messages outside turn
-  Scenario: Send to stored conversation
-    Given a stored conversation reference
-    When bot sends proactive message
-    Then user receives the message
-
-  Scenario: Invalid reference
-    Given an invalid conversation reference
-    When bot sends message
-    Then error is returned
-```
-
-### US-003: Middleware Pipeline
-
-```
-Feature: Custom middleware processes activities
-  Scenario: Middleware executes before handler
-    Given middleware is registered
-    When activity is received
-    Then middleware runs before handler
-
-  Scenario: Multiple middleware order
-    Given multiple middleware registered
-    When activity is received
-    Then execute in registration order
-
-  Scenario: Middleware short-circuit
-    Given middleware does not call next()
-    Then subsequent middleware and handler are skipped
-```
-
-### US-004: Teams Activity Features
-
-```
-Feature: Rich Teams interactions
-  Scenario: Adaptive Card
-    Given a running bot
-    When user sends "cards"
-    Then bot replies with an Adaptive Card
-
-  Scenario: Suggested Actions
-    Given a running bot
-    When user sends "actions"
-    Then bot replies with suggested action buttons
-
-  Scenario: Mention
-    Given a running bot
-    When user sends any other text
-    Then bot echoes back with an @mention of sender
-```
-
----
-
-## Acceptance Criteria
-
-| ID | Criteria |
-|----|----------|
-| AC-001 | Implementation passes all user story acceptance scenarios |
-| AC-002 | Protocol-compliant serialization/deserialization |
-| AC-003 | JWT validation and OAuth client credentials work |
-| AC-004 | Code follows target language idioms |
+See [User Stories](./user-stories.md) for detailed behavioral scenarios.
 
 ---
 

--- a/specs/activity-schema.md
+++ b/specs/activity-schema.md
@@ -3,7 +3,7 @@
 **Purpose**: Define the JSON payload structure for activities exchanged between bots and the Bot Service Service.
 **Status**: Draft
 
-> **Note**: Outbound activities are typically constructed using the fluent `CoreActivityBuilder`. See the [Bot Spec — CoreActivityBuilder](./README.md#coreactivitybuilder) for the API.
+> **Note**: Outbound activities are typically constructed using the fluent `CoreActivityBuilder`. See [Architecture — Components](./architecture.md#components) for the API.
 
 ---
 
@@ -42,9 +42,9 @@ Fields present on activities received from the Bot Service Service (`POST /api/m
 > - **Teams** (`TeamsActivityType`): All core types plus `"event"` · `"conversationUpdate"` · `"messageUpdate"` · `"messageDelete"` · `"messageReaction"` · `"installationUpdate"`.
 >
 > Unrecognized type values are preserved and silently ignored by handler dispatch.
-| `id` | `string` | No | Unique activity identifier (assigned by the channel) |
+| `id` | `string` | No | Unique activity identifier (assigned by the channel). **Note**: Currently stored in extension data; will be promoted to typed field (Decision 6, code change pending). |
 | `serviceUrl` | `string` | **Yes** | Callback URL for this conversation's channel |
-| `channelId` | `string` | No | Channel identifier (e.g., `"msteams"`, `"webchat"`) |
+| `channelId` | `string` | No | Channel identifier (e.g., `"msteams"`, `"webchat"`). **Note**: Currently stored in extension data; will be promoted to typed field (Decision 6, code change pending). |
 | `text` | `string` | No | Message text content |
 | `name` | `string` | No | Invoke action name (e.g., `"adaptiveCard/action"`). Used for [invoke dispatch](./invoke-activities.md). |
 | `value` | `any` | No | Action-specific payload for invoke activities |
@@ -155,7 +155,7 @@ The type string is open-ended — implementations MUST support registering handl
 
 ## Extension Data Round-Trip
 
-All activity types may carry additional properties beyond the typed fields. BotAS preserves these as extension data, so custom channel data round-trips safely. Both `customField` and `channelData` in the example below are preserved in the extension dictionary. See [Serialization Rules](#serialization-rules).
+All activity types may carry additional properties beyond the typed fields. botas preserves these as extension data, so custom channel data round-trips safely. Both `customField` and `channelData` in the example below are preserved in the extension dictionary. See [Serialization Rules](#serialization-rules).
 
 ```json
 {

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -1,6 +1,10 @@
 # Architecture
 
-BotAS is a thin adapter between an HTTP framework and the [Microsoft Bot Service REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference). The same design is implemented in .NET, Node.js, and Python.
+> botas is a thin adapter between an HTTP framework and the [Microsoft Bot Service REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference).
+
+**Status:** Draft
+
+botas is implemented consistently across .NET, Node.js, and Python.
 
 ---
 
@@ -103,7 +107,7 @@ The library uses separate authentication for each direction:
 
 The core `CoreActivity` type carries the minimum typed fields for a single turn. All other properties from the wire payload are preserved in an extension dictionary.
 
-See [Activity Schema spec](./specs/activity-schema.md) for the full field listing, serialization rules, and examples.
+See [Activity Schema spec](./activity-schema.md) for the full field listing, serialization rules, and examples.
 
 ---
 
@@ -112,7 +116,7 @@ See [Activity Schema spec](./specs/activity-schema.md) for the full field listin
 Handlers are registered by activity type. When an activity arrives, the matching handler is called; unregistered types are silently ignored. See [Protocol spec — Handler Dispatch](./protocol.md#handler-dispatch) for the full contract.
 
 - **Node.js / Python**: per-type map via `on(type, handler)`
-- **.NET**: single `OnActivity` callback; dispatch logic lives in application code
+- **.NET**: per-type map via `On(type, handler)` + optional single `OnActivity` CatchAll callback
 
 ### Invoke activity dispatch
 
@@ -137,7 +141,7 @@ Any exception thrown inside a handler is caught and re-thrown wrapped as `BotHan
 
 The library implements multiple layers of defense against common attack vectors:
 
-- **SSRF protection**: Service URLs are validated against an allowlist before outbound requests. Allowed patterns: `*.botframework.com`, `*.botframework.us`, `*.botframework.cn`, `*.trafficmanager.net`, and `localhost` (development only). See [Inbound Auth spec](./inbound-auth.md) for details.
+- **SSRF protection**: Service URLs are validated against an allowlist before outbound requests. Allowed patterns: `*.botframework.com`, `*.botframework.us`, `*.botframework.cn`, `smba.trafficmanager.net` (exact match), and `localhost` (development only). See [Inbound Auth spec](./inbound-auth.md) for details.
 - **JWKS cache with fallback**: JWT signing keys are cached in memory and refreshed on cache miss. Prevents DoS via repeated JWKS endpoint requests while ensuring key rotation support.
 - **Request body size limits**: Implementations enforce a 1 MB request body limit to prevent memory exhaustion attacks.
 - **JSON parsing hardening**: Node.js implementation blocks prototype-pollution keys (`__proto__`, `constructor`, `prototype`) during JSON parsing. Python strips these for defense-in-depth. .NET's strongly-typed deserialization naturally rejects unknown keys.
@@ -156,7 +160,7 @@ Key invariants: JWT validation before processing, `CoreActivityBuilder.withConve
 
 | Area | .NET | Node.js | Python |
 |---|---|---|---|
-| Handler registration | Single `OnActivity` callback + `OnInvoke` | `on(type, fn)` + `onInvoke(name, fn)` | `@bot.on("type")` decorator + `@bot.on_invoke(name)` |
+| Handler registration | `On(type, fn)` + optional `OnActivity` CatchAll + `OnInvoke` | `on(type, fn)` + `onInvoke(name, fn)` | `@bot.on("type")` decorator + `@bot.on_invoke(name)` |
 | Framework integration | ASP.NET Core middleware (`UseBotApplication`) | Framework-agnostic (`botAuthExpress`, `botAuthHono`) + `botas-express` package | FastAPI `Depends` or aiohttp middleware |
 | DI support | Full DI via `AddBotApplication<T>` | Not applicable | Not applicable |
 | Async model | `async/await` + `CancellationToken` | `async/await` (Promise) | `async/await` (asyncio) |

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-**Purpose**: Per-language configuration reference for BotAS bots.
+**Purpose**: Per-language configuration reference for botas bots.
 **Status**: Draft
 
 ---
@@ -15,6 +15,7 @@ All three languages read the same environment variables.
 | `CLIENT_SECRET` | Conditional | — | Azure AD client secret (required for client-credentials flow) |
 | `TENANT_ID` | Conditional | — | Azure AD tenant ID (required with `CLIENT_SECRET`) |
 | `MANAGED_IDENTITY_CLIENT_ID` | No | — | User-assigned managed identity client ID (for federated auth in Azure) |
+| `ALLOWED_SERVICE_URLS` | No | — | Comma-separated list of additional allowed service URL prefixes for SSRF protection |
 | `PORT` | No | `3978` | HTTP listen port |
 
 \* If `CLIENT_ID` is not set, the bot runs without authentication (useful for local development and testing).
@@ -27,7 +28,7 @@ For instructions on obtaining these values, see [Infrastructure Setup](./setup.m
 
 ## Authentication Flows
 
-BotAS selects the authentication flow automatically based on which credentials are provided:
+botas selects the authentication flow automatically based on which credentials are provided:
 
 | `CLIENT_ID` | `CLIENT_SECRET` | `MANAGED_IDENTITY_CLIENT_ID` | Flow |
 |-------------|-----------------|------------------------------|------|
@@ -64,6 +65,8 @@ See [Outbound Auth](./outbound-auth.md) for token endpoint details and [Inbound 
 **Simple API** — `BotApp()` auto-detects credentials from environment variables.
 
 **Advanced API** — `BotApplication(options=BotApplicationOptions(...))` accepts `client_id`, `client_secret`, `tenant_id`, `managed_identity_client_id`, and an optional `token_factory` callback. All properties fall back to environment variables.
+
+**Import note**: Import `BotApp` from `botas_fastapi` (not `botas`). The `BotApp` helper is framework-specific. For advanced usage, import `BotApplication` from `botas`.
 
 ---
 

--- a/specs/contributing.md
+++ b/specs/contributing.md
@@ -144,7 +144,7 @@ In order of priority:
 | `TokenManager` | OAuth2 client-credentials token acquisition and caching | [Outbound Auth](./outbound-auth.md) |
 | `ConversationClient` | HTTP client for the Bot Service REST API | [Protocol — Outbound](./protocol.md#outbound-sending-activities) |
 | `BotApplication` | Middleware pipeline + handler dispatch | [Protocol](./protocol.md) |
-| `TurnContext` | Scoped context for handlers and middleware | [Turn Context](./turn-context.md) |
+| `TurnContext` | Scoped context for handlers and middleware | [Protocol — TurnContext](./protocol.md#turncontext) |
 | Inbound JWT validation | Validate incoming bearer tokens | [Inbound Auth](./inbound-auth.md) |
 | `BotApp` (optional) | Zero-boilerplate wrapper | Language-specific convenience |
 

--- a/specs/conversation-client.md
+++ b/specs/conversation-client.md
@@ -1,0 +1,468 @@
+# ConversationClient Spec
+
+**Purpose**: Define the `ConversationClient` API for outbound Bot Service REST API calls.  
+**Status**: Draft
+
+---
+
+## Overview
+
+`ConversationClient` wraps the [Bot Service v3 Conversations REST API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#conversations-object). It provides typed methods for:
+- Sending, updating, and deleting activities
+- Managing conversation members
+- Creating proactive conversations
+- Uploading transcripts
+
+All methods require:
+1. **Outbound authentication** — OAuth2 client-credentials tokens (see [Outbound Auth](./outbound-auth.md))
+2. **Service URL validation** — SSRF protection via allowlist (see [Protocol — Service URL Validation](./protocol.md#service-url-validation))
+
+---
+
+## Constructor
+
+**Signature** (language-specific):
+
+**.NET:**
+
+```csharp
+ConversationClient(HttpClient httpClient, ILogger<ConversationClient> logger)
+```
+
+Registered via DI in ASP.NET Core. Application code typically does not call this constructor directly.
+
+**Node.js:**
+
+```typescript
+constructor(getToken?: TokenProvider)
+```
+
+`TokenProvider` is an optional async function `() => Promise<string | undefined>` that returns a bearer token. Omit for unauthenticated local development.
+
+**Python:**
+
+```python
+def __init__(self, get_token: TokenProvider | None = None) -> None
+```
+
+`TokenProvider` is an optional async callable `Callable[[], Awaitable[str | None]]` that returns a bearer token. Omit for unauthenticated local development.
+
+---
+
+## Methods
+
+All methods are async and return typed responses (or `undefined` / `None` when the API returns no body).
+
+### Send Activity
+
+Send an activity to a conversation.
+
+**.NET:**
+
+```csharp
+Task<string> SendActivityAsync(CoreActivity activity, CancellationToken cancellationToken = default)
+```
+
+**Returns**: Raw JSON response body (contains activity ID).
+
+**Node.js / Python:**
+
+```typescript
+// Node.js
+async sendCoreActivityAsync(
+  serviceUrl: string,
+  conversationId: string,
+  activity: Partial<CoreActivity>
+): Promise<ResourceResponse | undefined>
+```
+
+```python
+# Python
+async def send_activity_async(
+    self,
+    service_url: str,
+    conversation_id: str,
+    activity: CoreActivity | dict[str, Any],
+) -> ResourceResponse | None
+```
+
+**Returns**: `ResourceResponse { id: string }` with the new activity ID.
+
+**Note**: .NET embeds `serviceUrl` and `conversationId` in the `CoreActivity` object. Node.js and Python pass them as separate parameters.
+
+---
+
+### Update Activity
+
+Update an existing activity in a conversation.
+
+**Node.js:**
+
+```typescript
+async updateCoreActivityAsync(
+  serviceUrl: string,
+  conversationId: string,
+  activityId: string,
+  activity: Partial<CoreActivity>
+): Promise<ResourceResponse | undefined>
+```
+
+**Python:**
+
+```python
+async def update_activity_async(
+    self,
+    service_url: str,
+    conversation_id: str,
+    activity_id: str,
+    activity: CoreActivity | dict[str, Any],
+) -> ResourceResponse | None
+```
+
+**Returns**: `ResourceResponse` with the activity ID.
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+### Delete Activity
+
+Delete an activity from a conversation.
+
+**Node.js:**
+
+```typescript
+async deleteCoreActivityAsync(
+  serviceUrl: string,
+  conversationId: string,
+  activityId: string
+): Promise<void>
+```
+
+**Python:**
+
+```python
+async def delete_activity_async(
+    self,
+    service_url: str,
+    conversation_id: str,
+    activity_id: str,
+) -> None
+```
+
+**Returns**: `void` / `None`
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+### Get Conversation Members
+
+Retrieve all members of a conversation.
+
+**Node.js:**
+
+```typescript
+async getConversationMembersAsync(
+  serviceUrl: string,
+  conversationId: string
+): Promise<ChannelAccount[]>
+```
+
+**Python:**
+
+```python
+async def get_conversation_members_async(
+    self,
+    service_url: str,
+    conversation_id: str,
+) -> list[ChannelAccount]
+```
+
+**Returns**: Array/list of `ChannelAccount` objects. Empty array if no members.
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+### Get Conversation Member (by ID)
+
+Retrieve a single conversation member by user ID.
+
+**Node.js:**
+
+```typescript
+async getConversationMemberAsync(
+  serviceUrl: string,
+  conversationId: string,
+  memberId: string
+): Promise<ChannelAccount | undefined>
+```
+
+**Python:**
+
+```python
+async def get_conversation_member_async(
+    self,
+    service_url: str,
+    conversation_id: str,
+    member_id: str,
+) -> ChannelAccount | None
+```
+
+**Returns**: `ChannelAccount` or `undefined` / `None` if not found.
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+### Get Conversation Paged Members
+
+Retrieve conversation members with server-side pagination.
+
+**Node.js:**
+
+```typescript
+async getConversationPagedMembersAsync(
+  serviceUrl: string,
+  conversationId: string,
+  pageSize?: number,
+  continuationToken?: string
+): Promise<PagedMembersResult<ChannelAccount>>
+```
+
+**Python:**
+
+```python
+async def get_conversation_paged_members_async(
+    self,
+    service_url: str,
+    conversation_id: str,
+    page_size: int | None = None,
+    continuation_token: str | None = None,
+) -> PagedMembersResult
+```
+
+**Returns**: `PagedMembersResult { members: ChannelAccount[], continuationToken?: string }`
+
+Use `continuationToken` from the result to fetch subsequent pages.
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+### Delete Conversation Member
+
+Remove a member from a conversation.
+
+**Node.js:**
+
+```typescript
+async deleteConversationMemberAsync(
+  serviceUrl: string,
+  conversationId: string,
+  memberId: string
+): Promise<void>
+```
+
+**Python:**
+
+```python
+async def delete_conversation_member_async(
+    self,
+    service_url: str,
+    conversation_id: str,
+    member_id: str,
+) -> None
+```
+
+**Returns**: `void` / `None`
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+### Create Conversation
+
+Create a new proactive conversation (e.g., 1:1 chat with a user).
+
+**Node.js:**
+
+```typescript
+async createConversationAsync(
+  serviceUrl: string,
+  parameters: ConversationParameters
+): Promise<ConversationResourceResponse | undefined>
+```
+
+**Python:**
+
+```python
+async def create_conversation_async(
+    self,
+    service_url: str,
+    parameters: ConversationParameters,
+) -> ConversationResourceResponse | None
+```
+
+**Returns**: `ConversationResourceResponse { id: string, serviceUrl: string, activityId: string }`
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+### Get Conversations
+
+List all conversations the bot is a member of.
+
+**Node.js:**
+
+```typescript
+async getConversationsAsync(
+  serviceUrl: string,
+  continuationToken?: string
+): Promise<ConversationsResult>
+```
+
+**Python:**
+
+```python
+async def get_conversations_async(
+    self,
+    service_url: str,
+    continuation_token: str | None = None,
+) -> ConversationsResult
+```
+
+**Returns**: `ConversationsResult { conversations: Conversation[], continuationToken?: string }`
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+### Send Conversation History (Upload Transcript)
+
+Upload a transcript of past activities to a conversation.
+
+**Node.js:**
+
+```typescript
+async sendConversationHistoryAsync(
+  serviceUrl: string,
+  conversationId: string,
+  transcript: Transcript
+): Promise<ResourceResponse | undefined>
+```
+
+**Python:**
+
+```python
+async def send_conversation_history_async(
+    self,
+    service_url: str,
+    conversation_id: str,
+    transcript: Transcript,
+) -> ResourceResponse | None
+```
+
+**Returns**: `ResourceResponse` or `undefined` / `None`.
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+### Get Conversation
+
+Retrieve conversation account details.
+
+**Node.js:**
+
+```typescript
+async getConversationAsync(
+  serviceUrl: string,
+  conversationId: string
+): Promise<Conversation | undefined>
+```
+
+**Python:**
+
+```python
+async def get_conversation_async(
+    self,
+    service_url: str,
+    conversation_id: str,
+) -> Conversation | None
+```
+
+**Returns**: `Conversation` or `undefined` / `None` if not found.
+
+**Available in**: Node.js, Python  
+**.NET status**: Not yet implemented (tracked in backlog).
+
+---
+
+## Error Handling
+
+All methods throw/reject on error:
+
+- **Authentication errors** — If the token provider returns `undefined` / `None` or an invalid token, the HTTP client returns 401.
+- **Service URL validation errors** — If the `serviceUrl` is not on the allowlist, throws `ArgumentException` (.NET) / `BotAuthError` (Node.js/Python) before making the request.
+- **HTTP errors** — If the Bot Service returns a non-2xx status, throws an exception with the status code and error message (implementation-defined format).
+
+---
+
+## Conversation ID Encoding
+
+When constructing the URL path, the `conversationId` is:
+1. **Truncated at the first `;` character** (for Teams agents channel compatibility)
+2. **URL-encoded** via `encodeURIComponent` / `quote`
+
+Example: `a]concat-123;messageid=9876` becomes `a%5Dconcat-123` in the URL.
+
+The full conversation ID is still used in the activity body.
+
+---
+
+## Service URL Validation
+
+All methods validate the `serviceUrl` parameter against the allowlist before making the request. See [Protocol — Service URL Validation](./protocol.md#service-url-validation) for the full ruleset.
+
+**Allowed patterns**:
+- `*.botframework.com`
+- `*.botframework.us`
+- `*.botframework.cn`
+- `smba.trafficmanager.net` (exact match)
+- `localhost` / `127.0.0.1` (development only)
+- Any prefix in the `ALLOWED_SERVICE_URLS` environment variable
+
+---
+
+## Language-Specific Notes
+
+| Aspect | .NET | Node.js | Python |
+|--------|------|---------|--------|
+| Constructor | DI-injected `HttpClient` + `ILogger` | Optional `TokenProvider` callback | Optional `TokenProvider` callback |
+| Send returns | `Task<string>` (raw JSON) | `Promise<ResourceResponse \| undefined>` | `ResourceResponse \| None` |
+| Method availability | Send only | All methods | All methods |
+| HTTP client | `IHttpClientFactory` with auth handler | `BotHttpClient` (wraps `fetch`) | `BotHttpClient` (wraps `httpx.AsyncClient`) |
+| Resource cleanup | Automatic (DI manages `HttpClient`) | Automatic (`fetch` manages connections) | Must call `aclose()` or use `async with` |
+
+**.NET roadmap**: Update, delete, and member management methods are planned but not yet implemented. Use the Node.js or Python implementations as reference when porting.
+
+---
+
+## References
+
+- [Outbound Auth](./outbound-auth.md) — OAuth2 client-credentials token acquisition
+- [Protocol — Service URL Validation](./protocol.md#service-url-validation) — SSRF protection
+- [Activity Schema](./activity-schema.md) — `CoreActivity` type definition
+- [Bot Service Conversations API](https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#conversations-object) — Official API reference

--- a/specs/core-activity-builder.md
+++ b/specs/core-activity-builder.md
@@ -1,0 +1,393 @@
+# CoreActivityBuilder Spec
+
+**Purpose**: Define the fluent builder API for constructing `CoreActivity` objects.  
+**Status**: Draft
+
+---
+
+## Overview
+
+`CoreActivityBuilder` is a fluent builder for constructing outbound activities. It simplifies the creation of reply activities by:
+- Providing a chainable method interface
+- Automatically copying routing fields from incoming activities (via `withConversationReference`)
+- Swapping `from` and `recipient` when replying
+
+Use this builder when constructing activities manually (outside of `ctx.send()` helpers).
+
+---
+
+## Constructor
+
+**Signature** (language-specific):
+
+**.NET:**
+
+```csharp
+new CoreActivityBuilder()
+```
+
+**Node.js:**
+
+```typescript
+new CoreActivityBuilder()
+```
+
+**Python:**
+
+```python
+CoreActivityBuilder()
+```
+
+All languages initialize the builder with default values:
+- `type`: `"message"`
+- `text`: `""` (empty string)
+
+---
+
+## Methods
+
+All methods return `this` for method chaining (except `build()`).
+
+### withConversationReference / WithConversationReference / with_conversation_reference
+
+Copy routing fields from an incoming activity and swap `from` ↔ `recipient`.
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivityBuilder WithConversationReference(CoreActivity source)
+```
+
+```typescript
+// Node.js
+withConversationReference(source: CoreActivity): this
+```
+
+```python
+# Python
+def with_conversation_reference(self, source: CoreActivity) -> "CoreActivityBuilder"
+```
+
+**Behavior**: Sets the following fields on the outbound activity:
+- `serviceUrl` ← `source.serviceUrl`
+- `conversation` ← `source.conversation`
+- `from` ← `source.recipient` (swap)
+- `recipient` ← `source.from` (swap)
+
+This is the most commonly used method for constructing replies.
+
+---
+
+### withType / WithType / with_type
+
+Set the activity type.
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivityBuilder WithType(string type)
+```
+
+```typescript
+// Node.js
+withType(type: string): this
+```
+
+```python
+# Python
+def with_type(self, type: str) -> "CoreActivityBuilder"
+```
+
+**Default**: `"message"`
+
+---
+
+### withText / WithText / with_text
+
+Set the text content of the activity.
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivityBuilder WithText(string text)
+```
+
+```typescript
+// Node.js
+withText(text: string): this
+```
+
+```python
+# Python
+def with_text(self, text: str) -> "CoreActivityBuilder"
+```
+
+---
+
+### withServiceUrl / WithServiceUrl / with_service_url
+
+Set the service URL for the channel.
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivityBuilder WithServiceUrl(string serviceUrl)
+```
+
+```typescript
+// Node.js
+withServiceUrl(serviceUrl: string): this
+```
+
+```python
+# Python
+def with_service_url(self, service_url: str) -> "CoreActivityBuilder"
+```
+
+---
+
+### withConversation / WithConversation / with_conversation
+
+Set the conversation reference.
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivityBuilder WithConversation(Conversation conversation)
+```
+
+```typescript
+// Node.js
+withConversation(conversation: Conversation): this
+```
+
+```python
+# Python
+def with_conversation(self, conversation: Conversation) -> "CoreActivityBuilder"
+```
+
+---
+
+### withFrom / WithFrom / with_from
+
+Set the sender account.
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivityBuilder WithFrom(ChannelAccount from)
+```
+
+```typescript
+// Node.js
+withFrom(from: ChannelAccount): this
+```
+
+```python
+# Python
+def with_from(self, from_account: ChannelAccount) -> "CoreActivityBuilder"
+```
+
+**Note**: Python uses `from_account` parameter name (reserved keyword workaround).
+
+---
+
+### withRecipient / WithRecipient / with_recipient
+
+Set the recipient account.
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivityBuilder WithRecipient(ChannelAccount recipient)
+```
+
+```typescript
+// Node.js
+withRecipient(recipient: ChannelAccount): this
+```
+
+```python
+# Python
+def with_recipient(self, recipient: ChannelAccount) -> "CoreActivityBuilder"
+```
+
+---
+
+### withEntities / WithEntities / with_entities
+
+Set the entities array (replaces existing entities).
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivityBuilder WithEntities(JsonArray entities)
+```
+
+```typescript
+// Node.js
+withEntities(entities: Entity[]): this
+```
+
+```python
+# Python
+def with_entities(self, entities: list[Entity]) -> "CoreActivityBuilder"
+```
+
+---
+
+### withAttachments / WithAttachments / with_attachments
+
+Set the attachments array (replaces existing attachments).
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivityBuilder WithAttachments(JsonArray attachments)
+```
+
+```typescript
+// Node.js
+withAttachments(attachments: Attachment[]): this
+```
+
+```python
+# Python
+def with_attachments(self, attachments: list[Attachment]) -> "CoreActivityBuilder"
+```
+
+---
+
+### build / Build
+
+Construct the final `CoreActivity` from the builder state.
+
+**Signature**:
+
+```csharp
+// .NET
+CoreActivity Build()
+```
+
+```typescript
+// Node.js
+build(): CoreActivity
+```
+
+```python
+# Python
+def build(self) -> CoreActivity
+```
+
+**Returns**: A new `CoreActivity` instance. Calling `build()` multiple times produces independent copies.
+
+---
+
+## Usage Examples
+
+### .NET
+
+```csharp
+var reply = new CoreActivityBuilder()
+    .WithConversationReference(incomingActivity)
+    .WithText("Hello, user!")
+    .Build();
+
+await app.SendActivityAsync(reply, cancellationToken);
+```
+
+### Node.js
+
+```typescript
+const reply = new CoreActivityBuilder()
+  .withConversationReference(incomingActivity)
+  .withText('Hello, user!')
+  .build()
+
+await app.sendActivityAsync(
+  incomingActivity.serviceUrl,
+  incomingActivity.conversation.id,
+  reply
+)
+```
+
+### Python
+
+```python
+reply = (
+    CoreActivityBuilder()
+    .with_conversation_reference(incoming_activity)
+    .with_text("Hello, user!")
+    .build()
+)
+
+await app.send_activity_async(
+    incoming_activity.service_url,
+    incoming_activity.conversation.id,
+    reply,
+)
+```
+
+---
+
+## Relationship to TurnContext
+
+`TurnContext.send()` uses `CoreActivityBuilder` internally. When you call:
+
+```typescript
+await ctx.send("Hello!")
+```
+
+The framework does:
+
+```typescript
+const reply = new CoreActivityBuilder()
+  .withConversationReference(ctx.activity)
+  .withText("Hello!")
+  .build()
+// ... then sends it
+```
+
+**When to use the builder directly**:
+- Constructing proactive messages (outside the normal turn pipeline)
+- Building activities with complex attachments or entities
+- When you need explicit control over routing fields
+
+**When to use `ctx.send()`**:
+- Inside handlers or middleware (simpler and automatic routing)
+
+---
+
+## Language-Specific Notes
+
+| Aspect | .NET | Node.js | Python |
+|--------|------|---------|--------|
+| Method naming | PascalCase (`WithText`) | camelCase (`withText`) | snake_case (`with_text`) |
+| Type field default | `"message"` | `"message"` | `"message"` |
+| Text field default | `""` | `""` | `""` |
+| Immutability | Each `build()` creates a new `CoreActivity` | Each `build()` creates a new object | Each `build()` creates a new `CoreActivity` |
+
+---
+
+## Design Notes
+
+- **Fluent API**: All setter methods return `this` for chaining.
+- **Immutability**: The builder is mutable (you can call methods in any order), but `build()` produces an independent copy — modifying the result does not affect the builder.
+- **Reusability**: You can call `build()` multiple times on the same builder. Each call produces a new activity with the current builder state.
+
+---
+
+## References
+
+- [Activity Schema](./activity-schema.md) — full `CoreActivity` type definition
+- [TurnContext Spec](./turn-context.md) — high-level send helpers
+- [Protocol Spec](./protocol.md) — HTTP contract for sending activities

--- a/specs/inbound-auth.md
+++ b/specs/inbound-auth.md
@@ -119,16 +119,20 @@ All language implementations MUST support the same authentication features. This
 
 | Feature | Required | .NET | Node.js | Python |
 |---------|----------|------|---------|--------|
-| JWT signature verification (JWKS) | ✅ | MSAL + middleware | `jsonwebtoken` + `jwks-rsa` | `PyJWT` + `httpx` |
+| JWT signature verification (JWKS) | ✅ | MSAL + middleware | `jose` library | `PyJWT` + `httpx` |
 | Audience validation (3 formats) | ✅ | ✅ | ✅ | ✅ |
-| Issuer validation (`sts.windows.net` + `login.microsoftonline.com`) | ✅ | ✅ | ✅ | ✅ |
+| Issuer validation (`sts.windows.net` + `login.microsoftonline.com`) | ✅ | ⚠️ .NET may be missing v2.0 issuer validation | ✅ | ✅ |
 | Dynamic metadata URL selection by `iss` | ✅ | ✅ | ✅ | ✅ |
 | Metadata URL prefix validation (SSRF defense) | ✅ | ✅ | ✅ | ✅ |
-| JWKS key caching | ✅ | Via MSAL | Via `jwks-rsa` | Manual (in-memory) |
+| JWKS key caching | ✅ | Via MSAL | Via `jose` | Manual (in-memory) |
 | Token expiration (`exp` / `nbf`) | ✅ | ✅ | ✅ | ✅ |
 | Auth bypass when `CLIENT_ID` not configured | ✅ | ✅ | ✅ | ✅ |
 
-> **Note**: .NET uses MSAL's built-in JWT validation which handles many of these features natively. Node.js and Python implement validation manually. When adding a new language port, ensure all features in this table are covered.
+> **Note**: .NET uses MSAL's built-in JWT validation which handles many of these features natively. Node.js uses the `jose` library for modern, standards-compliant JWT validation. Python implements validation manually using `PyJWT` and `httpx` for JWKS fetching. When adding a new language port, ensure all features in this table are covered.
+
+> **Known gap**: The .NET implementation may not validate the `v2.0` suffix in issuer URLs (`https://login.microsoftonline.com/{tenantId}/v2.0`). This does not pose a security risk as MSAL validates the signature and audience, but should be fixed for full spec compliance.
+
+> **OpenID config URL variation**: Some implementations may fetch from `https://login.microsoftonline.com/{tid}/v2.0/.well-known/openidconfiguration` (without hyphen) instead of the hyphenated form. Both URLs return equivalent metadata.
 
 ---
 

--- a/specs/invoke-activities.md
+++ b/specs/invoke-activities.md
@@ -19,22 +19,9 @@ When `activity.type === "invoke"`:
 
 1. **Specific handler match** — If `activity.name` matches a registered handler, dispatch to it. The handler returns an `InvokeResponse { status, body? }` which the framework translates to the HTTP response.
 
-2. **Catch-all invoke handler** — If no specific handler matches and a catch-all invoke handler is registered, dispatch to it.
+2. **No handler match** — If `activity.name` doesn't match any registered handler (or no handlers are registered at all), return HTTP 501 (Not Implemented).
 
-3. **No invoke handlers at all** — If no invoke handlers (specific or catch-all) are registered, return HTTP 200 `{}` (the bot simply doesn't handle invokes).
-
-4. **Specific handlers exist but no match** — If specific handlers ARE registered but `activity.name` doesn't match any (and no catch-all is set), return HTTP 501 (Not Implemented).
-
-> **Rationale**: When a bot has registered specific invoke handlers, an unrecognized invoke name likely indicates a misconfiguration — returning 501 signals this clearly.
-
-### Conflict Prevention
-
-A bot MUST NOT register both specific invoke handlers AND a catch-all invoke handler.
-
-| Registration Order | Result |
-|-------------------|--------|
-| Specific handler first → Catch-all handler | Error: "Cannot register catch-all when specific handlers exist" |
-| Catch-all handler first → Specific handler | Error: "Cannot register specific handler when catch-all exists" |
+> **Rationale**: Invoke activities require a synchronous response. Returning 501 when no handler is registered signals to the channel that the bot doesn't implement the requested invoke operation.
 
 ---
 
@@ -58,21 +45,20 @@ Invoke activities flow through the middleware pipeline like all other activities
 
 ### CatchAll Handler Interaction
 
-When a CatchAll handler (`OnActivity` / `onActivity` / `on_activity`) is set, **invoke activities bypass invoke-specific dispatch** and are routed to the CatchAll handler like all other activity types. The CatchAll handler replaces ALL dispatch — including invoke dispatch by `activity.name`. If the CatchAll handler needs to return an `InvokeResponse`, it must do so via the framework's invoke response mechanism (e.g., returning from `processBody` or setting the response on the HTTP context).
+**Invoke activities ALWAYS bypass the CatchAll handler** (`OnActivity` / `onActivity` / `on_activity`) and go directly to invoke-specific dispatch by `activity.name`. This ensures that invoke handlers can return an `InvokeResponse` object, which is required for the synchronous HTTP response contract.
 
-> **Why CatchAll overrides invoke dispatch**: The CatchAll handler is an escape hatch for bots that want full control over all activity routing. CatchAll means "catch ALL".
+> **Why invoke bypasses CatchAll**: Invoke activities have a different return contract than fire-and-forget activities. Invoke handlers must return an `InvokeResponse` with an HTTP status code and optional body. The CatchAll handler signature doesn't support this return type, so invoke activities are routed separately.
 
 ### Quick Reference: Dispatch Decision Table
 
 | Invoke handlers registered? | CatchAll set? | `activity.name` matches? | Result |
 |-----------------------------|---------------|--------------------------|--------|
-| None | No | — | **200 `{}`** (bot doesn't handle invokes) |
-| None | Yes | — | **CatchAll handler** receives the activity |
+| None | No | — | **501** (Not Implemented) |
+| None | Yes | — | **501** (invoke bypasses CatchAll) |
 | Specific only | No | Yes | **Matched handler** runs |
 | Specific only | No | No | **501** (Not Implemented) |
-| Catch-all invoke | No | — | **Catch-all invoke handler** runs |
-| Any | Yes | — | **CatchAll handler** (invoke dispatch bypassed) |
-| Specific + Catch-all invoke | — | — | **Error at registration** (conflict) |
+| Specific only | Yes | Yes | **Matched handler** (invoke bypasses CatchAll) |
+| Specific only | Yes | No | **501** (invoke bypasses CatchAll) |
 
 ---
 

--- a/specs/protocol.md
+++ b/specs/protocol.md
@@ -73,11 +73,12 @@ After middleware, the activity is dispatched to a registered handler based on `a
 
 ##### CatchAll Handler
 
-A CatchAll handler is an optional, application-level callback that, when set, **replaces per-type handler dispatch entirely**:
+A CatchAll handler is an optional, application-level callback that, when set, **replaces per-type handler dispatch for all non-invoke activities**:
 
-- When a CatchAll handler IS set, all incoming activities bypass per-type dispatch and are delivered directly to the CatchAll handler.
+- When a CatchAll handler IS set, all incoming **non-invoke** activities bypass per-type dispatch and are delivered directly to the CatchAll handler.
+- **Invoke activities ALWAYS bypass the CatchAll handler** and go to invoke-specific dispatch (see [Invoke Activities spec](./invoke-activities.md)).
 - When a CatchAll handler IS NOT set, the per-type dispatch behavior (above) applies unchanged.
-- Per-type handlers registered via `On()` / `on()` / `on_activity()` are **NOT invoked** if a CatchAll handler is set.
+- Per-type handlers registered via `On()` / `on()` / `on_activity()` are **NOT invoked** if a CatchAll handler is set (except for invoke activities).
 - Unregistered activity types with no CatchAll handler are still silently ignored.
 - Exceptions thrown inside a CatchAll handler MUST be wrapped in `BotHandlerException` (same as per-type handlers; see [Error Wrapping](#error-wrapping)).
 
@@ -265,7 +266,7 @@ C and the handler are never reached.
 
 ### Patterns
 
-For middleware implementation patterns (logging, error handling, short-circuiting, activity modification, remove-mention), see the [Middleware Guide](../docs-site/middleware.md) and language-specific reference docs in `specs/reference/`.
+For middleware implementation patterns (logging, error handling, short-circuiting, activity modification, remove-mention), see the [Middleware Guide](../docs-site/middleware.md) and [language-specific reference docs](./reference/).
 
 ### Interaction with CatchAll Handler
 

--- a/specs/reference/dotnet.md
+++ b/specs/reference/dotnet.md
@@ -1,6 +1,9 @@
 # .NET API Reference
 
-**Purpose**: Full .NET API signatures and implementation patterns.
+> Full .NET API signatures and implementation patterns.
+
+**Status:** Draft
+
 **See also**: [Core Specs](../README.md)
 
 ---
@@ -24,8 +27,9 @@ app.Run();
 
 | Method | Description |
 |--------|-------------|
-| `BotApp.Create(args)` | Create app with CLI args |
-| `app.On(activityType, handler)` | Register handler |
+| `BotApp.Create(args, routePath?)` | Create app with CLI args and optional custom route path (default: `"api/messages"`) |
+| `app.On(activityType, handler)` | Register handler for activity type |
+| `app.OnInvoke(name, handler)` | Register handler for invoke activity by name |
 | `app.Run()` | Start HTTP server |
 
 ---
@@ -37,9 +41,15 @@ Framework-agnostic bot class for manual HTTP integration.
 ```csharp
 public class BotApplication
 {
-    public BotApplication On(string activityType, Func<TurnContext, CancellationToken, Task> handler)
+    public string? AppId { get; }
+    
+    public static string Version { get; }
     
     public Func<TurnContext, CancellationToken, Task>? OnActivity { get; set; }
+    
+    public BotApplication On(string activityType, Func<TurnContext, CancellationToken, Task> handler)
+    
+    public BotApplication OnInvoke(string name, Func<TurnContext, CancellationToken, Task<InvokeResponse>> handler)
     
     public Task<CoreActivity> ProcessAsync(HttpContext httpContext, CancellationToken ct = default)
     
@@ -60,6 +70,35 @@ bot.Use(new MyMiddleware());
 
 ---
 
+## InvokeResponse
+
+Response object returned by invoke activity handlers.
+
+```csharp
+public class InvokeResponse
+{
+    public int Status { get; set; }
+    public object? Body { get; set; }
+}
+```
+
+The `Status` is written as the HTTP status code; `Body` is serialized as JSON.
+
+Example invoke handler:
+
+```csharp
+app.OnInvoke("composeExtension/query", async (ctx, ct) =>
+{
+    return new InvokeResponse 
+    { 
+        Status = 200, 
+        Body = new { results = new[] { /* ... */ } } 
+    };
+});
+```
+
+---
+
 ## TurnContext
 
 Scoped context for the current turn.
@@ -70,9 +109,9 @@ public class TurnContext
     public CoreActivity Activity { get; }
     public BotApplication App { get; }
     
-    public Task SendAsync(string text, CancellationToken ct)
-    public Task SendAsync(CoreActivity activity, CancellationToken ct)
-    public Task SendTypingAsync(CancellationToken ct)
+    public Task<string> SendAsync(string text, CancellationToken ct)
+    public Task<string> SendAsync(CoreActivity activity, CancellationToken ct)
+    public Task<string> SendTypingAsync(CancellationToken ct)
 }
 ```
 
@@ -251,17 +290,21 @@ class BotHandlerException : Exception
 
 | Concern | .NET Behavior |
 |---------|---------------|
-| Simple bot API | `BotApp.Create()` + `app.On()` |
+| Simple bot API | `BotApp.Create()` + `app.On()` + `app.OnInvoke()` |
 | Web framework | ASP.NET Core (built-in) |
 | Handler registration | `app.On(type, handler)` receiving `TurnContext` |
+| Invoke handler registration | `app.OnInvoke(name, handler)` returns `InvokeResponse` |
 | CatchAll handler | `OnActivity` property |
 | HTTP integration | `ProcessAsync(HttpContext)` |
 | SendActivityAsync args | Single `CoreActivity` (carries serviceUrl/conversationId) |
-| TurnContext.send | `SendAsync(string)` / `SendAsync(CoreActivity)` |
-| TurnContext.sendTyping | `SendTypingAsync()` returns `Task<string>` |
+| TurnContext.send | `SendAsync(string)` / `SendAsync(CoreActivity)` returning `Task<string>` |
+| TurnContext.sendTyping | `SendTypingAsync()` returning `Task<string>` (activity ID) |
 | DI registration | `AddBotApplication<TApp>()` |
 | Activity model | `CoreActivity` class with `[JsonExtensionData]` |
 | `from` field | `From` (C# allows it) |
+| Version property | `BotApplication.Version` (static) |
+| AppId property | `BotApplication.AppId` (instance property) |
+| Route path | `BotApp.Create(args, routePath)` parameter (default: `"api/messages"`) |
 
 ---
 
@@ -280,9 +323,9 @@ public class BotController : ControllerBase
     }
     
     [HttpPost("/api/messages")]
-    public async Task ProcessAsync()
+    public async Task ProcessAsync(CancellationToken ct = default)
     {
-        await _bot.ProcessAsync(Request, Response);
+        await _bot.ProcessAsync(HttpContext, ct);
     }
 }
 ```
@@ -292,9 +335,9 @@ public class BotController : ControllerBase
 ```csharp
 [HttpPost("/api/messages")]
 [Authorize(AuthenticationSchemes = "Bearer")]
-public async Task ProcessAsync()
+public async Task ProcessAsync(CancellationToken ct = default)
 {
-    await _bot.ProcessAsync(Request, Response);
+    await _bot.ProcessAsync(HttpContext, ct);
 }
 ```
 

--- a/specs/reference/node.md
+++ b/specs/reference/node.md
@@ -1,6 +1,9 @@
 # Node.js API Reference
 
-**Purpose**: Full Node.js API signatures and implementation patterns.
+> Full Node.js API signatures and implementation patterns.
+
+**Status:** Draft
+
 **See also**: [Core Specs](../README.md)
 
 ---
@@ -40,6 +43,8 @@ class BotApplication {
     readonly conversationClient: ConversationClient
     
     on(type: string, handler: (ctx: TurnContext) => Promise<void>): this
+    
+    onInvoke(name: string, handler: (ctx: TurnContext) => Promise<InvokeResponse>): this
     
     onActivity?: (ctx: TurnContext) => Promise<void>
     
@@ -188,7 +193,7 @@ const messagesOnly: TurnMiddleware = async (context, next) => {
 #### Remove Bot Mention (Teams)
 
 ```typescript
-import { removeMentionMiddleware } from 'botas'
+import { removeMentionMiddleware } from 'botas-core'
 bot.use(removeMentionMiddleware())
 ```
 
@@ -228,7 +233,7 @@ class BotHandlerException extends Error {
 
 ```typescript
 import express from 'express'
-import { BotApplication, botAuthExpress } from 'botas'
+import { BotApplication, botAuthExpress } from 'botas-express'
 
 const bot = new BotApplication()
 
@@ -248,12 +253,33 @@ server.listen(Number(process.env['PORT'] ?? 3978))
 ```typescript
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
-import { BotApplication, botAuthHono } from 'botas'
+import { BotApplication, validateBotToken, BotAuthError } from 'botas-core'
+import type { Context, Next } from 'hono'
 
 const bot = new BotApplication()
 bot.on('message', async (ctx) => {
   await ctx.send(`You said: ${ctx.activity.text}`)
 })
+
+// Auth middleware for Hono (BotApplication handles JWT validation)
+function botAuthHono (appId?: string) {
+  const audience = appId ?? process.env['CLIENT_ID']
+  if (!audience) {
+    throw new Error('CLIENT_ID environment variable or appId parameter is required')
+  }
+  return async (c: Context, next: Next) => {
+    const header = c.req.header('authorization')
+    try {
+      await validateBotToken(header, appId)
+      return next()
+    } catch (err) {
+      if (err instanceof BotAuthError) {
+        return c.text(err.message, 401)
+      }
+      throw err
+    }
+  }
+}
 
 const app = new Hono()
 app.post('/api/messages', botAuthHono(), async (c) => {
@@ -277,7 +303,7 @@ serve({ fetch: app.fetch, port: Number(process.env['PORT'] ?? 3978) })
 | SendActivityAsync args | `(serviceUrl, conversationId, activity)` |
 | TurnContext.send | `send(string \| Partial<CoreActivity>)` |
 | TurnContext.sendTyping | `sendTyping()` returns `Promise<void>` |
-| Authentication | `botAuthExpress()` / `botAuthHono()` factory |
+| Authentication | `botAuthExpress()` from `botas-express`, or `validateBotToken()` for custom middleware |
 | Activity model | `CoreActivity` interface with `properties?` dict |
 | `from` field | `from` (JS allows it) |
 | Prototype pollution | Must strip `__proto__`, `constructor`, `prototype` |
@@ -289,22 +315,31 @@ serve({ fetch: app.fetch, port: Number(process.env['PORT'] ?? 3978) })
 ### botAuthExpress()
 
 ```typescript
-import { botAuthExpress } from 'botas'
+import { botAuthExpress } from 'botas-express'
 
 server.post('/api/messages', botAuthExpress(), (req, res) => {
   bot.processAsync(req, res)
 })
 ```
 
-### botAuthHono()
+### validateBotToken() — Custom Auth Middleware
+
+For frameworks other than Express, use `validateBotToken()` directly:
 
 ```typescript
-import { botAuthHono } from 'botas'
+import { validateBotToken, BotAuthError } from 'botas-core'
 
-app.post('/api/messages', botAuthHono(), async (c) => {
-  await bot.processBody(await c.req.text())
-  return c.json({})
-})
+// Hono, Fastify, Koa, etc. — call validateBotToken in your middleware
+try {
+  await validateBotToken(authHeader, appId)
+  // Token is valid, proceed
+} catch (err) {
+  if (err instanceof BotAuthError) {
+    // Return 401 Unauthorized
+  } else {
+    throw err
+  }
+}
 ```
 
 ---
@@ -321,7 +356,9 @@ The built-in `fetch` API manages connections automatically. No explicit cleanup 
 |----------|-------------|
 | `CLIENT_ID` | Azure AD application (bot) ID |
 | `CLIENT_SECRET` | Azure AD client secret |
-| `TENANT_ID` | Azure AD tenant ID (or `"common"`) |
+| `TENANT_ID` | Azure AD tenant ID (default: `"botframework.com"`) |
+| `MANAGED_IDENTITY_CLIENT_ID` | Managed identity client ID (optional; use `"system"` for system-assigned) |
+| `ALLOWED_SERVICE_URLS` | Comma-separated list of additional allowed Bot Service URLs for SSRF protection (see [specs/inbound-auth.md](../inbound-auth.md)) |
 | `PORT` | HTTP listen port (default: `3978`) |
 
 ---

--- a/specs/reference/python.md
+++ b/specs/reference/python.md
@@ -1,6 +1,9 @@
 # Python API Reference
 
-**Purpose**: Full Python API signatures and implementation patterns.
+> Full Python API signatures and implementation patterns.
+
+**Status:** Draft
+
 **See also**: [Core Specs](../README.md)
 
 ---
@@ -10,7 +13,7 @@
 Zero-boilerplate bot setup with FastAPI.
 
 ```python
-from botas import BotApp
+from botas_fastapi import BotApp
 
 app = BotApp()
 
@@ -39,6 +42,8 @@ Framework-agnostic bot class.
 ```python
 class BotApplication:
     def on(self, activity_type: str, handler: Callable[[TurnContext], Awaitable[None]]) -> "BotApplication"
+    
+    def on_invoke(self, name: str, handler: Callable[[TurnContext], Awaitable[InvokeResponse]]) -> "BotApplication"
     
     on_activity: Optional[Callable[[TurnContext], Awaitable[None]]]
     
@@ -71,7 +76,7 @@ class TurnContext:
     activity: CoreActivity
     app: BotApplication
     
-    async def send(self, text_or_activity: str | dict) -> ResourceResponse | None:
+    async def send(self, activity_or_text: str | CoreActivity | dict) -> ResourceResponse | None:
     
     async def send_typing(self) -> None:
 ```
@@ -82,8 +87,11 @@ class TurnContext:
 # String - auto-creates message activity
 await ctx.send("Hello!")
 
-# Activity - full control
+# CoreActivity - full control
 await ctx.send(my_activity)
+
+# Dict - raw activity
+await ctx.send({"type": "message", "text": "Hello!"})
 ```
 
 ### Sending Typing Indicator
@@ -221,11 +229,29 @@ reply = TeamsActivityBuilder() \
 
 ---
 
+## Invoke Activities
+
+Invoke activities require a specific handler that returns an `InvokeResponse`.
+
+```python
+from botas import InvokeResponse
+
+@bot.on_invoke("adaptiveCard/action")
+async def handle_card_action(ctx):
+    return InvokeResponse(status=200, body={"status": "ok"})
+```
+
+For unhandled invoke activities, `BotApplication` automatically returns a 501 (Not Implemented) response.
+
+---
+
 ## Exception Handling
 
 ```python
 class BotHandlerException(Exception):
-    pass
+    """Wraps exceptions raised in handlers or invoke handlers."""
+    cause: BaseException
+    activity: CoreActivity
 ```
 
 ---
@@ -235,7 +261,6 @@ class BotHandlerException(Exception):
 ### FastAPI (botas-fastapi)
 
 ```python
-from botas import BotApplication
 from botas_fastapi import BotApp
 
 app = BotApp()
@@ -247,10 +272,9 @@ async def on_message(ctx):
 app.start()
 ```
 
-### Manual (aiohttp)
+### Manual Integration (any framework)
 
 ```python
-from aiohttp import web
 from botas import BotApplication
 
 bot = BotApplication()
@@ -259,14 +283,16 @@ bot = BotApplication()
 async def on_message(ctx):
     await ctx.send(f"You said: {ctx.activity.text}")
 
+# In your framework's HTTP handler:
 async def messages_handler(request):
     body = await request.text()
-    await bot.process_body(body)
-    return web.Response(status=200, text="{}")
-
-app = web.Application()
-app.router.add_post('/api/messages', messages_handler)
-web.run_app(app, port=3978)
+    invoke_response = await bot.process_body(body)
+    if invoke_response is not None:
+        return JSONResponse(
+            status_code=invoke_response.status,
+            content=invoke_response.body if invoke_response.body is not None else {}
+        )
+    return JSONResponse(content={})
 ```
 
 ---
@@ -281,7 +307,7 @@ web.run_app(app, port=3978)
 | CatchAll handler | `on_activity` property |
 | HTTP integration | `process_body(body)` |
 | SendActivityAsync args | `(service_url, conversation_id, activity)` |
-| TurnContext.send | `send(str \| dict)` |
+| TurnContext.send | `send(str \| CoreActivity \| dict)` |
 | TurnContext.sendTyping | `send_typing()` returns `None` |
 | Authentication | `bot_auth_dependency()` / `validate_bot_token()` |
 | Activity model | `CoreActivity` Pydantic model with `model_extra` |
@@ -292,24 +318,30 @@ web.run_app(app, port=3978)
 
 ## Auth Dependency (FastAPI)
 
+`BotApp` handles authentication automatically when a `CLIENT_ID` is set. For manual setup:
+
 ```python
-from fastapi import FastAPI, Depends
-from botas_fastapi import BotApp, bot_auth_dependency
+from fastapi import FastAPI, Depends, Request
+from botas_fastapi import bot_auth_dependency
+from botas import BotApplication
 
-app = FastAPI()
-bot = BotApp()
+bot = BotApplication()
 
-app = BotApp()
-
-@app.on("message")
+@bot.on("message")
 async def on_message(ctx):
     await ctx.send(f"You said: {ctx.activity.text}")
 
 @app.post("/api/messages")
-async def messages(auth: None = Depends(bot_auth_dependency)):
-    await bot.process_body(await request.body())
+async def messages(
+    request: Request,
+    auth: None = Depends(bot_auth_dependency)
+):
+    body = await request.body()
+    await bot.process_body(body.decode())
     return {}
 ```
+
+Token validation happens before the handler runs. If validation fails, a 401 response is returned automatically.
 
 ---
 
@@ -339,7 +371,9 @@ finally:
 |----------|-------------|
 | `CLIENT_ID` | Azure AD application (bot) ID |
 | `CLIENT_SECRET` | Azure AD client secret |
-| `TENANT_ID` | Azure AD tenant ID (or `"common"`) |
+| `TENANT_ID` | Azure AD tenant ID (defaults to `"common"`) |
+| `MANAGED_IDENTITY_CLIENT_ID` | Client ID for managed identity authentication (alternative to `CLIENT_SECRET`) |
+| `ALLOWED_SERVICE_URLS` | Comma-separated list of additional allowed service URL prefixes (security allowlist) |
 | `PORT` | HTTP listen port (default: `3978`) |
 
 ---

--- a/specs/samples.md
+++ b/specs/samples.md
@@ -1,6 +1,6 @@
 # Samples
 
-**Purpose**: Guide to running each BotAS sample.
+**Purpose**: Guide to running each botas sample.
 **Status**: Draft
 
 ---

--- a/specs/setup.md
+++ b/specs/setup.md
@@ -1,8 +1,12 @@
 # Bot Registration Setup
 
-This guide walks through registering a bot and obtaining the credentials needed to run BotAS samples. After completing it you will have `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` values ready to use.
+> Walk through registering a bot and obtaining Azure credentials.
 
-> **Scope**: This guide covers bot *infrastructure* only (app registration, Bot Service channel registration). It does not cover hosting or deploying your bot code.
+**Status:** Draft
+
+## Overview
+
+This guide covers bot infrastructure setup (app registration, Bot Service channel registration) to obtain `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` credentials.
 
 ---
 
@@ -34,7 +38,7 @@ Your bot must be reachable from the internet before you register it. For local d
 
 - **Microsoft devtunnels:** [Get started with devtunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/get-started?tabs=windows)
 
-BotAS samples listen on port `3978` by default, so your endpoint will look like:
+botas samples listen on port `3978` by default, so your endpoint will look like:
 
 ```
 https://<your-tunnel>/api/messages

--- a/specs/teams-activity.md
+++ b/specs/teams-activity.md
@@ -22,6 +22,8 @@ Extends CoreActivity with these properties:
 | `channelData` | `TeamsChannelData?` | Teams-specific metadata |
 | `timestamp` | `Date?` | UTC timestamp |
 | `locale` | `string?` | Sender locale (e.g., `"en-us"`) |
+| `localTimestamp` | `DateTimeOffset?` | Sender's local time |
+| `localTimezone` | `string?` | Sender's timezone (e.g., `"America/New_York"`) |
 | `suggestedActions` | `SuggestedActions?` | Quick reply buttons |
 
 ### Static Methods
@@ -54,14 +56,18 @@ Teams-specific channel metadata:
 | `channel` | `ChannelInfo?` | Channel info |
 | `team` | `TeamInfo?` | Team info |
 | `meeting` | `MeetingInfo?` | Meeting info |
+| `notification` | `NotificationInfo?` | Teams notification settings |
+| `teamsConversation` | `TeamsConversation?` | Extended conversation metadata |
 
 ### Sub-types
 
 ```
-TenantInfo:  { id: string? }
-ChannelInfo: { id: string?, name: string? }
-TeamInfo:    { id: string?, name: string?, aadGroupId: string? }
-MeetingInfo: { id: string? }
+TenantInfo:         { id: string? }
+ChannelInfo:        { id: string?, name: string? }
+TeamInfo:           { id: string?, name: string?, aadGroupId: string? }
+MeetingInfo:        { id: string? }
+NotificationInfo:   { alert: boolean? }
+TeamsConversation:  { id: string?, conversationType: string? }
 ```
 
 ---
@@ -81,10 +87,10 @@ Fluent builder for Teams activities.
 | `withChannelData(TeamsChannelData)` | `Builder` | Set channel data |
 | `withSuggestedActions(SuggestedActions)` | `Builder` | Set quick replies |
 | `withAttachment(Attachment)` | `Builder` | Set single attachment |
+| `withAdaptiveCardAttachment(cardJson)` | `Builder` | Add Adaptive Card (Node/Python: `addAdaptiveCardAttachment`, .NET: `WithAdaptiveCardAttachment`) |
 | `addEntity(Entity)` | `Builder` | Append entity |
 | `addAttachment(Attachment)` | `Builder` | Append attachment |
 | `addMention(ChannelAccount, string?)` | `Builder` | Add mention entity |
-| `addAdaptiveCardAttachment(string)` | `Builder` | Add Adaptive Card |
 
 **Note:** `addMention(account)` creates entity but does NOT modify text. Include `<at>Name</at>` in `withText()`.
 

--- a/specs/turn-context.md
+++ b/specs/turn-context.md
@@ -1,0 +1,174 @@
+# TurnContext Spec
+
+**Purpose**: Define the `TurnContext` object passed to activity handlers and middleware.  
+**Status**: Draft
+
+---
+
+## Overview
+
+`TurnContext` is the context object for a single activity turn. It provides:
+- The incoming activity being processed
+- A reference to the bot application
+- Helper methods to send replies without manually constructing routing fields
+
+Every handler and middleware function receives a `TurnContext` instance. The same instance flows through the entire middleware pipeline and into the final handler.
+
+---
+
+## Constructor
+
+**Signature** (conceptual — language-specific details below):
+
+```
+TurnContext(app: BotApplication, activity: CoreActivity)
+```
+
+Implementations construct `TurnContext` internally when processing an activity. Application code does not call this constructor directly.
+
+---
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `activity` / `Activity` | `CoreActivity` | The incoming activity being processed (immutable). |
+| `app` / `App` | `BotApplication` | The bot application instance handling this turn. |
+
+**Naming conventions**:
+- .NET: PascalCase (`Activity`, `App`)
+- Node.js / Python: camelCase / snake_case (`activity`, `app`)
+
+---
+
+## Methods
+
+### Send Reply
+
+Sends a reply to the conversation that originated the current turn. Routing fields are automatically populated.
+
+**.NET:**
+
+```csharp
+Task<string> SendAsync(string text, CancellationToken cancellationToken = default)
+Task<string> SendAsync(CoreActivity activity, CancellationToken cancellationToken = default)
+```
+
+**Node.js:**
+
+```typescript
+send(activityOrText: string | Partial<CoreActivity>): Promise<ResourceResponse | undefined>
+```
+
+**Python:**
+
+```python
+async def send(
+    self,
+    activity_or_text: str | CoreActivity | dict[str, Any],
+) -> ResourceResponse | None
+```
+
+**Behavior**:
+1. If passed a string, constructs a `message` activity with that text.
+2. If passed an activity/dict, merges it with auto-populated routing fields (`from`, `recipient`, `conversation`, `serviceUrl`).
+3. Calls the underlying `BotApplication.sendActivityAsync` / `SendActivityAsync` / `send_activity_async`.
+4. Returns the `ResourceResponse` (with the new activity ID).
+
+### Send Typing Indicator
+
+Sends a typing indicator to the conversation. Ephemeral — does not return an activity ID.
+
+**.NET:**
+
+```csharp
+Task<string> SendTypingAsync(CancellationToken cancellationToken = default)
+```
+
+**Node.js:**
+
+```typescript
+sendTyping(): Promise<void>
+```
+
+**Python:**
+
+```python
+async def send_typing(self) -> None
+```
+
+**Behavior**: Constructs a `typing` activity with routing fields from `context.activity`, then sends it.
+
+---
+
+## Usage Examples
+
+### .NET
+
+```csharp
+app.On("message", async (context, ct) =>
+{
+    await context.SendTypingAsync(ct);
+    // ... do work ...
+    await context.SendAsync("Processing complete!", ct);
+});
+```
+
+### Node.js
+
+```typescript
+bot.on('message', async (ctx) => {
+  await ctx.sendTyping()
+  // ... do work ...
+  await ctx.send('Processing complete!')
+})
+```
+
+### Python
+
+```python
+@bot.on("message")
+async def on_message(ctx: TurnContext):
+    await ctx.send_typing()
+    # ... do work ...
+    await ctx.send("Processing complete!")
+```
+
+---
+
+## Lifecycle
+
+1. `BotApplication` receives an activity via `POST /api/messages`.
+2. `BotApplication` constructs a `TurnContext` from the activity.
+3. The same `TurnContext` instance flows through:
+   - Middleware pipeline (in registration order)
+   - Handler dispatch (invoke or per-type)
+4. Handlers and middleware can call `ctx.send()` / `ctx.sendTyping()` at any point.
+5. After the turn completes, the `TurnContext` is discarded.
+
+**State sharing**: All middleware and the final handler share the same `TurnContext` instance. Middleware can attach data to the context (via extension properties or dictionaries) for downstream handlers to read.
+
+---
+
+## Immutability Note
+
+The `activity` property itself is immutable (do not replace the reference). However, in weakly-typed languages (Node.js, Python), middleware CAN mutate fields on the activity object (e.g., `context.activity.text = "modified"`). Changes persist through the pipeline. See [Protocol — Middleware](./protocol.md#middleware) for details.
+
+---
+
+## Language-Specific Notes
+
+| Aspect | .NET | Node.js | Python |
+|--------|------|---------|--------|
+| Constructor | `new TurnContext(app, activity)` (internal) | Factory function `createTurnContext(app, activity)` | `TurnContext(app, activity)` |
+| Send returns | `Task<string>` (activity ID) | `Promise<ResourceResponse \| undefined>` | `ResourceResponse \| None` |
+| Typing indicator returns | `Task<string>` (activity ID) | `Promise<void>` | `None` |
+| Async model | `async/await` + `CancellationToken` | `async/await` (Promise) | `async/await` (asyncio) |
+
+---
+
+## References
+
+- [Protocol Spec](./protocol.md) — middleware and handler dispatch
+- [CoreActivityBuilder Spec](./core-activity-builder.md) — activity construction
+- [ConversationClient Spec](./conversation-client.md) — low-level API for sending activities

--- a/specs/user-stories.md
+++ b/specs/user-stories.md
@@ -1,0 +1,98 @@
+# User Stories
+
+> Gherkin-style behavioral scenarios for botas implementations.
+
+**Status:** Draft
+
+---
+
+## US-001: Echo Bot
+
+```
+Feature: Bot responds to user messages
+  Scenario: Simple message response
+    Given a running bot
+    When user sends "hello"
+    Then bot responds with "you said hello"
+
+  Scenario: Empty message handling
+    Given a running bot
+    When user sends empty message
+    Then bot handles gracefully (no crash)
+
+  Scenario: Authentication
+    Given a running bot
+    When Bot Service sends activity
+    Then JWT token is validated
+```
+
+---
+
+## US-002: Proactive Messaging
+
+```
+Feature: Bot sends messages outside turn
+  Scenario: Send to stored conversation
+    Given a stored conversation reference
+    When bot sends proactive message
+    Then user receives the message
+
+  Scenario: Invalid reference
+    Given an invalid conversation reference
+    When bot sends message
+    Then error is returned
+```
+
+---
+
+## US-003: Middleware Pipeline
+
+```
+Feature: Custom middleware processes activities
+  Scenario: Middleware executes before handler
+    Given middleware is registered
+    When activity is received
+    Then middleware runs before handler
+
+  Scenario: Multiple middleware order
+    Given multiple middleware registered
+    When activity is received
+    Then execute in registration order
+
+  Scenario: Middleware short-circuit
+    Given middleware does not call next()
+    Then subsequent middleware and handler are skipped
+```
+
+---
+
+## US-004: Teams Activity Features
+
+```
+Feature: Rich Teams interactions
+  Scenario: Adaptive Card
+    Given a running bot
+    When user sends "cards"
+    Then bot replies with an Adaptive Card
+
+  Scenario: Suggested Actions
+    Given a running bot
+    When user sends "actions"
+    Then bot replies with suggested action buttons
+
+  Scenario: Mention
+    Given a running bot
+    When user sends any other text
+    Then bot echoes back with an @mention of sender
+```
+
+---
+
+## Acceptance Criteria
+
+| ID | Criteria |
+|----|----------|
+| AC-001 | Implementation passes all user story acceptance scenarios |
+| AC-002 | Protocol-compliant serialization/deserialization |
+| AC-003 | JWT validation and OAuth client credentials work |
+| AC-004 | Code follows target language idioms |


### PR DESCRIPTION
## Specs Overhaul

Closes #259

### What changed

**Accuracy fixes (spec → match code):**
- Invoke activities always bypass CatchAll (Decision 1)
- Removed catch-all invoke handler concept (Decision 4)
- Fixed .NET handler registration description in architecture.md
- Corrected SSRF trafficmanager pattern
- Updated Node.js JWT library reference (jose)
- Added missing Teams fields documentation
- Fixed Python BotApp import paths
- Added missing env vars to configuration

**3 new specs:**
- \specs/turn-context.md\ — TurnContext API contract
- \specs/core-activity-builder.md\ — fluent builder API
- \specs/conversation-client.md\ — full ConversationClient API surface

**Reference docs fixed:**
- \specs/reference/dotnet.md\ — ProcessAsync signature, return types, OnInvoke, BotApp.Create, AppId/Version
- \specs/reference/node.md\ — import paths, removed phantom botAuthHono, TENANT_ID default, onInvoke
- \specs/reference/python.md\ — BotApp import, TurnContext.send signature, on_invoke, missing config vars

**Readability:**
- Fixed 6 broken links
- Added template headers to 5 files
- Standardized BotAS → botas terminology
- Extracted user stories to \specs/user-stories.md\

### Code changes (separate issues)

4 decisions require code changes, filed as separate issues:
- #260 — Invoke 200 vs 501 (no handlers → 200, no match → 501)
- #261 — Promote id/channelId to typed fields
- #262 — Input validation → 400 for missing fields
- #263 — Case-insensitive handler lookup