### PR TITLE
docs: Add API Reference links at top of language guides and overview

### DIFF
--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -89,3 +89,9 @@ app.start()
 - [Teams Features](teams-features) — Mentions, Adaptive Cards, Suggested Actions, and Typing Indicators
 - [Middleware](middleware) — Extend the turn pipeline with custom middleware
 - [Authentication](authentication) — How the two-auth model works under the hood
+
+## API Reference
+
+- 📘 [.NET API Reference](/api/generated/dotnet/api/Botas.html) — Generated with DocFX
+- 📗 [Node.js API Reference](/api/generated/nodejs/botas-core/index.html) — Generated with TypeDoc
+- 📙 [Python API Reference](/api/generated/python/botas/index.html) — Generated with pdoc

--- a/docs-site/languages/dotnet.md
+++ b/docs-site/languages/dotnet.md
@@ -4,7 +4,7 @@ outline: deep
 
 # .NET (C#)
 
-📦 [Botas on NuGet](https://www.nuget.org/packages/Botas)
+📦 [Botas on NuGet](https://www.nuget.org/packages/Botas) · 📘 [API Reference](/api/generated/dotnet/api/Botas.html)
 
 ## Project setup
 

--- a/docs-site/languages/nodejs.md
+++ b/docs-site/languages/nodejs.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Node.js (TypeScript)
 
-📦 [botas-core](https://www.npmjs.com/package/botas-core) · [botas-express](https://www.npmjs.com/package/botas-express)
+📦 [botas-core](https://www.npmjs.com/package/botas-core) · [botas-express](https://www.npmjs.com/package/botas-express) · 📗 [API Reference](/api/generated/nodejs/botas-core/index.html)
 
 ## Installation
 

--- a/docs-site/languages/python.md
+++ b/docs-site/languages/python.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Python
 
-📦 [botas on PyPI](https://pypi.org/project/botas/)
+📦 [botas on PyPI](https://pypi.org/project/botas/) · 📙 [API Reference](/api/generated/python/botas/index.html)
 
 ## Installation
 


### PR DESCRIPTION
Adds API Reference links prominently at the top of each language guide (next to the package badges) and a new API Reference section on the overview page.

**Changes:**
- **dotnet.md** — DocFX ref link next to NuGet badge
- **nodejs.md** — TypeDoc ref link next to npm badges  
- **python.md** — pdoc ref link next to PyPI badge
- **index.md** — New API Reference section with all three languages

The existing API Reference sections at the bottom of each language guide are preserved.