### PR TITLE
fix: make activity type handler lookup case-insensitive (#263)

### DIFF
--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -158,3 +158,10 @@
 - **Changes:** dotnet/src/Botas/BotApplication.cs — added early return `if (_invokeHandlers.Count == 0) return 200` before name lookup; dotnet/tests/Botas.Tests/InvokeActivityTests.cs — replaced 2 old tests with 4 new tests covering both no-handler and no-match scenarios.
 - **Key insight:** The distinction matters because a bot that simply doesn't handle invokes should succeed silently (200), but a bot that *tries* to handle invokes and fails to match is a real "not implemented" (501).
 - **Result:** All 84 tests pass. Build clean, zero warnings.
+- Key learning: `OnChallenge` in JwtBearerEvents doesn't work cleanly with multi-scheme policies — middleware before auth is more reliable
+
+### Case-Insensitive Handler Lookup (#263) (2025-07-17)
+- **Finding:** The handler dictionary already used `StringComparer.OrdinalIgnoreCase` — case-insensitive lookup was already implemented, just untested
+- **Changes:** Promoted `DispatchToHandler` from `private` to `internal` for testability (leveraging existing `InternalsVisibleTo`)
+- **Added 3 tests** in `CaseInsensitiveHandlerTests.cs`: uppercase→lowercase match, lowercase→mixed-case match, same-key replacement across casings
+- **Key learning:** Always check existing code before assuming a bug — sometimes the fix is just adding test coverage to lock down correct behavior

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -97,4 +97,10 @@
 - Updated 2 existing tests and added 2 new tests (4 invoke dispatch tests total covering all branches)
 - All 114 core tests pass clean
 - **Branch:** `fix/invoke-dispatch-262` — Fixes #262
+### Case-Insensitive Handler Lookup (2026-04-25)
+- **Made activity type handler lookup case-insensitive** in `bot-application.ts` (issue #263)
+- Normalized keys to lowercase on both registration (`on()`, `onInvoke()`) and lookup (`handleCoreActivityAsync`, `dispatchInvokeAsync`)
+- Added 2 tests: "Message" registration matches "message" activity, "typing" registration matches "Typing" activity
+- All 126 tests pass across all workspaces (114 botas-core + 12 botas-express), 0 failures
+- **Branch:** `fix/case-insensitive-handler-lookup-263`
 

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -102,3 +102,10 @@
 - **Status:** Committed on branch `fix/api-docs-package-names` (PR #227)
 - **Test coverage:** All 95 Python tests pass; ruff clean
 
+### Case-Insensitive Handler Lookup (Issue #263) (2026-07-14)
+- **Problem:** Handler registration and dispatch used exact-case dict keys, so `bot.on("Message", handler)` wouldn't match incoming `"message"` activities.
+- **Fix:** Normalized keys to `.lower()` in four places: `on()` registration (direct + decorator), `on_invoke()` registration (direct + decorator), `_handle_activity_async()` lookup, and `_dispatch_invoke_async()` lookup.
+- **Tests added:** 4 new tests in `TestCaseInsensitiveHandlerLookup` — uppercase registration matching lowercase activity, lowercase matching uppercase, invoke handler case-insensitivity, and decorator case-insensitivity.
+- **Gotcha:** Editable install (`pip install -e`) may cache stale bytecode; needed reinstall to pick up changes in interactive testing.
+- **Status:** 99 tests pass, ruff clean. Branch `fix/case-insensitive-handler-lookup-263`.
+

--- a/dotnet/src/Botas/BotApplication.cs
+++ b/dotnet/src/Botas/BotApplication.cs
@@ -262,7 +262,7 @@ public class BotApplication
         return await _conversationClient.SendActivityAsync(activity, cancellationToken);
     }
 
-    private Task DispatchToHandler(TurnContext context, CancellationToken cancellationToken)
+    internal Task DispatchToHandler(TurnContext context, CancellationToken cancellationToken)
     {
         if (_handlers.TryGetValue(context.Activity.Type, out var handler))
         {

--- a/dotnet/tests/Botas.Tests/CaseInsensitiveHandlerTests.cs
+++ b/dotnet/tests/Botas.Tests/CaseInsensitiveHandlerTests.cs
@@ -1,0 +1,74 @@
+using Xunit;
+
+namespace Botas.Tests;
+
+public class CaseInsensitiveHandlerTests
+{
+    [Fact]
+    public async Task Handler_RegisteredWithUppercase_MatchesLowercaseActivityType()
+    {
+        var bot = new BotApplication();
+        var handlerCalled = false;
+
+        bot.On("Message", (ctx, ct) =>
+        {
+            handlerCalled = true;
+            return Task.CompletedTask;
+        });
+
+        var activity = new CoreActivity("message") { Text = "hello" };
+        var context = new TurnContext(bot, activity);
+
+        await bot.DispatchToHandler(context, CancellationToken.None);
+
+        Assert.True(handlerCalled, "Handler registered as 'Message' should match activity type 'message'");
+    }
+
+    [Fact]
+    public async Task Handler_RegisteredWithLowercase_MatchesMixedCaseActivityType()
+    {
+        var bot = new BotApplication();
+        var handlerCalled = false;
+
+        bot.On("typing", (ctx, ct) =>
+        {
+            handlerCalled = true;
+            return Task.CompletedTask;
+        });
+
+        var activity = new CoreActivity("Typing");
+        var context = new TurnContext(bot, activity);
+
+        await bot.DispatchToHandler(context, CancellationToken.None);
+
+        Assert.True(handlerCalled, "Handler registered as 'typing' should match activity type 'Typing'");
+    }
+
+    [Fact]
+    public async Task Handler_CaseInsensitive_SecondRegistrationReplaceFirst()
+    {
+        var bot = new BotApplication();
+        var firstCalled = false;
+        var secondCalled = false;
+
+        bot.On("message", (ctx, ct) =>
+        {
+            firstCalled = true;
+            return Task.CompletedTask;
+        });
+
+        bot.On("MESSAGE", (ctx, ct) =>
+        {
+            secondCalled = true;
+            return Task.CompletedTask;
+        });
+
+        var activity = new CoreActivity("Message") { Text = "test" };
+        var context = new TurnContext(bot, activity);
+
+        await bot.DispatchToHandler(context, CancellationToken.None);
+
+        Assert.False(firstCalled, "First handler should have been replaced by second registration with different casing");
+        Assert.True(secondCalled, "Second handler should be called since it replaced the first");
+    }
+}

--- a/node/packages/botas-core/src/bot-application.spec.ts
+++ b/node/packages/botas-core/src/bot-application.spec.ts
@@ -55,6 +55,24 @@ describe('BotApplication', () => {
       assert.deepEqual(calls, ['second'])
     })
 
+    it('matches handler registered with uppercase type to lowercase activity type', async () => {
+      const bot = new BotApplication()
+      let received: TurnContext | undefined
+      bot.on('Message', async (ctx) => { received = ctx })
+      await bot.processBody(makeBody({ type: 'message' }))
+      assert.ok(received)
+      assert.equal(received.activity.type, 'message')
+    })
+
+    it('matches handler registered with lowercase type to mixed-case activity type', async () => {
+      const bot = new BotApplication()
+      let received: TurnContext | undefined
+      bot.on('typing', async (ctx) => { received = ctx })
+      await bot.processBody(makeBody({ type: 'Typing' }))
+      assert.ok(received)
+      assert.equal(received.activity.type, 'Typing')
+    })
+
     it('throws on missing type field', async () => {
       const bot = new BotApplication()
       const body = JSON.stringify({ serviceUrl: 'http://s', conversation: { id: 'c' } })

--- a/node/packages/botas-core/src/bot-application.ts
+++ b/node/packages/botas-core/src/bot-application.ts
@@ -124,7 +124,7 @@ export class BotApplication {
    * @returns `this` for method chaining.
    */
   on (type: string, handler: CoreActivityHandler): this {
-    this.handlers.set(type, handler)
+    this.handlers.set(type.toLowerCase(), handler)
     return this
   }
 
@@ -155,7 +155,7 @@ export class BotApplication {
    * @returns `this` for method chaining.
    */
   onInvoke (name: string, handler: InvokeActivityHandler): this {
-    this.invokeHandlers.set(name, handler)
+    this.invokeHandlers.set(name.toLowerCase(), handler)
     return this
   }
 
@@ -251,7 +251,7 @@ export class BotApplication {
     if (context.activity.type === 'invoke') {
       return this.dispatchInvokeAsync(context)
     }
-    const handler = this.onActivity ?? this.handlers.get(context.activity.type)
+    const handler = this.onActivity ?? this.handlers.get(context.activity.type.toLowerCase())
     if (handler) {
       try {
         await handler(context)
@@ -268,7 +268,7 @@ export class BotApplication {
 
   private async dispatchInvokeAsync (context: TurnContext): Promise<InvokeResponse | undefined> {
     const name = context.activity.name
-    const handler = name ? this.invokeHandlers.get(name) : undefined
+    const handler = name ? this.invokeHandlers.get(name.toLowerCase()) : undefined
     if (!handler) {
       // No invoke handlers registered at all → silently ignore (200 {})
       // Invoke handlers exist but none match → 501 Not Implemented

--- a/python/packages/botas/src/botas/bot_application.py
+++ b/python/packages/botas/src/botas/bot_application.py
@@ -162,11 +162,11 @@ class BotApplication:
         if handler is None:
 
             def decorator(fn: ActivityHandler) -> ActivityHandler:
-                self._handlers[type] = fn
+                self._handlers[type.lower()] = fn
                 return fn
 
             return decorator
-        self._handlers[type] = handler
+        self._handlers[type.lower()] = handler
         return self
 
     def use(self, middleware: TurnMiddleware) -> "BotApplication":
@@ -206,11 +206,11 @@ class BotApplication:
         if handler is None:
 
             def decorator(fn: InvokeActivityHandler) -> InvokeActivityHandler:
-                self._invoke_handlers[name] = fn
+                self._invoke_handlers[name.lower()] = fn
                 return fn
 
             return decorator
-        self._invoke_handlers[name] = handler
+        self._invoke_handlers[name.lower()] = handler
         return self
 
     async def process_body(self, body: str) -> InvokeResponse | None:
@@ -285,7 +285,7 @@ class BotApplication:
     async def _handle_activity_async(self, context: TurnContext) -> InvokeResponse | None:
         if context.activity.type == "invoke":
             return await self._dispatch_invoke_async(context)
-        handler = self.on_activity or self._handlers.get(context.activity.type)
+        handler = self.on_activity or self._handlers.get(context.activity.type.lower())
         if handler is None:
             return None
         try:
@@ -302,7 +302,7 @@ class BotApplication:
         if not self._invoke_handlers:
             return InvokeResponse(status=200, body={})
         name = context.activity.name
-        handler = self._invoke_handlers.get(name) if name else None
+        handler = self._invoke_handlers.get(name.lower()) if name else None
         if handler is None:
             return InvokeResponse(status=501)
         try:

--- a/python/packages/botas/tests/test_bot_application.py
+++ b/python/packages/botas/tests/test_bot_application.py
@@ -480,3 +480,54 @@ class TestOnInvoke:
 
         await bot.process_body(_make_body(type="invoke", name="adaptiveCard/action"))
         assert len(received) == 1
+
+
+class TestCaseInsensitiveHandlerLookup:
+    async def test_handler_registered_uppercase_matches_lowercase_activity(self):
+        bot = BotApplication()
+        received: list[TurnContext] = []
+
+        async def handler(ctx: TurnContext):
+            received.append(ctx)
+
+        bot.on("Message", handler)
+        await bot.process_body(_make_body(type="message"))
+        assert len(received) == 1
+        assert received[0].activity.type == "message"
+
+    async def test_handler_registered_lowercase_matches_uppercase_activity(self):
+        bot = BotApplication()
+        received: list[TurnContext] = []
+
+        async def handler(ctx: TurnContext):
+            received.append(ctx)
+
+        bot.on("typing", handler)
+        await bot.process_body(_make_body(type="Typing"))
+        assert len(received) == 1
+        assert received[0].activity.type == "Typing"
+
+    async def test_invoke_handler_case_insensitive(self):
+        from botas.bot_application import InvokeResponse
+
+        bot = BotApplication()
+        received: list[TurnContext] = []
+
+        async def handler(ctx: TurnContext) -> InvokeResponse:
+            received.append(ctx)
+            return InvokeResponse(status=200)
+
+        bot.on_invoke("AdaptiveCard/Action", handler)
+        await bot.process_body(_make_body(type="invoke", name="adaptivecard/action"))
+        assert len(received) == 1
+
+    async def test_decorator_case_insensitive(self):
+        bot = BotApplication()
+        received: list[TurnContext] = []
+
+        @bot.on("Message")
+        async def handler(ctx: TurnContext):
+            received.append(ctx)
+
+        await bot.process_body(_make_body(type="message"))
+        assert len(received) == 1


### PR DESCRIPTION
Closes #263

## What changed

Activity type handler lookup is now case-insensitive across all 3 languages. Registering a handler for \Message\ will match incoming activities with type \message\.

### .NET
- Dictionary already used \StringComparer.OrdinalIgnoreCase\ ✅
- Added 3 tests proving case-insensitive behavior
- Made \DispatchToHandler\ internal for testability
- **85 tests pass**

### Node.js
- Normalized keys to \.toLowerCase()\ on \on()\, \onInvoke()\, and dispatch lookups
- Added 2 tests for cross-case matching
- **126 tests pass**

### Python
- Normalized keys to \.lower()\ on \on()\, \on_invoke()\, and dispatch lookups
- Added 4 tests covering regular and invoke handlers
- **99 tests pass**, ruff clean