### PR TITLE
fix: invoke dispatch returns 200 when no handlers, 501 on mismatch (#262)

### DIFF
--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -146,3 +146,15 @@
 - Used middleware approach (not OnChallenge) because ASP.NET multi-scheme auth challenges fire per-scheme, causing conflicts
 - Added `ErrorResponseFormatTests` integration tests using `Microsoft.AspNetCore.TestHost`
 - Key learning: `OnChallenge` in JwtBearerEvents doesn't work cleanly with multi-scheme policies — middleware before auth is more reliable
+
+### Promote Id and ChannelId to Typed Fields (#261) (2026-07-15)
+- **Task:** Added `Id` and `ChannelId` as typed string properties on `CoreActivity`, following the same `[JsonPropertyName]` pattern as existing fields (Type, Text, ServiceUrl, etc.).
+- **Changes:** `dotnet/src/Botas/CoreActivity.cs` — two new nullable string properties; `dotnet/tests/Botas.Tests/CoreActivityTests.cs` — three new tests (deserialization, serialization, round-trip).
+- **Key insight:** System.Text.Json's `[JsonExtensionData]` automatically excludes typed properties from the extension dictionary — no extra exclusion logic needed.
+- **Result:** All 85 tests pass. Fields deserialize from JSON, stay out of `Properties`, and round-trip correctly.
+
+### Fix Invoke Dispatch: 200 when no handlers, 501 when no match (#262) (2026-04-25)
+- **Task:** Changed invoke dispatch so bots with zero invoke handlers return HTTP 200 (not 501) for invoke activities, while bots with handlers that don't match the invoke name still return 501.
+- **Changes:** dotnet/src/Botas/BotApplication.cs — added early return `if (_invokeHandlers.Count == 0) return 200` before name lookup; dotnet/tests/Botas.Tests/InvokeActivityTests.cs — replaced 2 old tests with 4 new tests covering both no-handler and no-match scenarios.
+- **Key insight:** The distinction matters because a bot that simply doesn't handle invokes should succeed silently (200), but a bot that *tries* to handle invokes and fails to match is a real "not implemented" (501).
+- **Result:** All 84 tests pass. Build clean, zero warnings.

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -90,3 +90,11 @@
 - **Key audit finding:** `botAuthHono` is sample code only, not an exported library function
 - **Issue:** #259 (docs/specs-overhaul-259)
 
+### Invoke Dispatch Fix (2026-04-25)
+- **Fixed `dispatchInvokeAsync`** to distinguish between zero invoke handlers (return 200 {}) vs handlers exist but none match (return 501)
+- Key change in `bot-application.ts`: check `this.invokeHandlers.size > 0` before returning 501
+- Return type changed from `Promise<InvokeResponse>` to `Promise<InvokeResponse | undefined>` — undefined means 200 {}
+- Updated 2 existing tests and added 2 new tests (4 invoke dispatch tests total covering all branches)
+- All 114 core tests pass clean
+- **Branch:** `fix/invoke-dispatch-262` — Fixes #262
+

--- a/dotnet/src/Botas/BotApplication.cs
+++ b/dotnet/src/Botas/BotApplication.cs
@@ -273,6 +273,11 @@ public class BotApplication
 
     internal async Task<InvokeResponse> DispatchInvokeHandler(TurnContext context, CancellationToken cancellationToken)
     {
+        if (_invokeHandlers.Count == 0)
+        {
+            return new InvokeResponse { Status = 200 };
+        }
+
         var name = context.Activity.Name;
         if (name is not null && _invokeHandlers.TryGetValue(name, out var handler))
         {

--- a/dotnet/tests/Botas.Tests/InvokeActivityTests.cs
+++ b/dotnet/tests/Botas.Tests/InvokeActivityTests.cs
@@ -30,9 +30,36 @@ namespace Botas.Tests
         }
 
         [Fact]
-        public async Task DispatchInvoke_Returns501_WhenNoHandlerRegistered()
+        public async Task DispatchInvoke_Returns200_WhenNoInvokeHandlersRegistered()
         {
             var bot = new BotApplication();
+            var activity = MakeInvokeActivity("task/fetch");
+            var context = new TurnContext(bot, activity);
+
+            var response = await bot.DispatchInvokeHandler(context, CancellationToken.None);
+
+            Assert.Equal(200, response.Status);
+        }
+
+        [Fact]
+        public async Task DispatchInvoke_Returns200_WhenNoInvokeHandlersAndNoName()
+        {
+            var bot = new BotApplication();
+            var activity = MakeInvokeActivity(name: null);
+            var context = new TurnContext(bot, activity);
+
+            var response = await bot.DispatchInvokeHandler(context, CancellationToken.None);
+
+            Assert.Equal(200, response.Status);
+        }
+
+        [Fact]
+        public async Task DispatchInvoke_Returns501_WhenHandlersExistButNoneMatch()
+        {
+            var bot = new BotApplication();
+            bot.OnInvoke("adaptiveCard/action", (ctx, ct) =>
+                Task.FromResult(new InvokeResponse { Status = 200 }));
+
             var activity = MakeInvokeActivity("task/fetch");
             var context = new TurnContext(bot, activity);
 
@@ -42,9 +69,12 @@ namespace Botas.Tests
         }
 
         [Fact]
-        public async Task DispatchInvoke_Returns501_WhenActivityHasNoName()
+        public async Task DispatchInvoke_Returns501_WhenHandlersExistButActivityHasNoName()
         {
             var bot = new BotApplication();
+            bot.OnInvoke("adaptiveCard/action", (ctx, ct) =>
+                Task.FromResult(new InvokeResponse { Status = 200 }));
+
             var activity = MakeInvokeActivity(name: null);
             var context = new TurnContext(bot, activity);
 

--- a/node/packages/botas-core/src/bot-application.spec.ts
+++ b/node/packages/botas-core/src/bot-application.spec.ts
@@ -294,14 +294,28 @@ describe('BotApplication', () => {
       assert.deepEqual(result, { status: 200, body: { ok: true } })
     })
 
-    it('returns 501 when no handler registered for invoke name', async () => {
+    it('returns 200 undefined when no invoke handlers registered at all', async () => {
       const bot = new BotApplication()
+      const result = await bot.processBody(makeBody({ type: 'invoke', name: 'task/fetch' }))
+      assert.equal(result, undefined)
+    })
+
+    it('returns 200 undefined when invoke activity has no name and no handlers registered', async () => {
+      const bot = new BotApplication()
+      const result = await bot.processBody(makeBody({ type: 'invoke' }))
+      assert.equal(result, undefined)
+    })
+
+    it('returns 501 when invoke handlers exist but none match the name', async () => {
+      const bot = new BotApplication()
+      bot.onInvoke('adaptiveCard/action', async () => ({ status: 200, body: { ok: true } }))
       const result = await bot.processBody(makeBody({ type: 'invoke', name: 'task/fetch' }))
       assert.deepEqual(result, { status: 501 })
     })
 
-    it('returns 501 when invoke activity has no name', async () => {
+    it('returns 501 when invoke handlers exist but activity has no name', async () => {
       const bot = new BotApplication()
+      bot.onInvoke('adaptiveCard/action', async () => ({ status: 200 }))
       const result = await bot.processBody(makeBody({ type: 'invoke' }))
       assert.deepEqual(result, { status: 501 })
     })

--- a/node/packages/botas-core/src/bot-application.ts
+++ b/node/packages/botas-core/src/bot-application.ts
@@ -266,11 +266,13 @@ export class BotApplication {
     return undefined
   }
 
-  private async dispatchInvokeAsync (context: TurnContext): Promise<InvokeResponse> {
+  private async dispatchInvokeAsync (context: TurnContext): Promise<InvokeResponse | undefined> {
     const name = context.activity.name
     const handler = name ? this.invokeHandlers.get(name) : undefined
     if (!handler) {
-      return { status: 501 }
+      // No invoke handlers registered at all → silently ignore (200 {})
+      // Invoke handlers exist but none match → 501 Not Implemented
+      return this.invokeHandlers.size > 0 ? { status: 501 } : undefined
     }
     try {
       return await handler(context)

--- a/python/packages/botas/src/botas/bot_application.py
+++ b/python/packages/botas/src/botas/bot_application.py
@@ -221,7 +221,8 @@ class BotApplication:
         pipeline followed by handler dispatch.
 
         For ``invoke`` activities, returns the :class:`InvokeResponse` produced
-        by the registered handler (or a 501 response if none is registered).
+        by the registered handler, a 200 response if no invoke handlers are
+        registered, or a 501 response if handlers exist but none match.
         Returns ``None`` for all other activity types.
 
         Args:
@@ -298,6 +299,8 @@ class BotApplication:
         return None
 
     async def _dispatch_invoke_async(self, context: TurnContext) -> InvokeResponse:
+        if not self._invoke_handlers:
+            return InvokeResponse(status=200, body={})
         name = context.activity.name
         handler = self._invoke_handlers.get(name) if name else None
         if handler is None:

--- a/python/packages/botas/tests/test_bot_application.py
+++ b/python/packages/botas/tests/test_bot_application.py
@@ -380,14 +380,42 @@ class TestOnInvoke:
         assert result.status == 200
         assert result.body == {"ok": True}
 
-    async def test_returns_501_when_no_handler_for_name(self):
+    async def test_returns_200_when_no_invoke_handlers_registered(self):
         bot = BotApplication()
+        result = await bot.process_body(_make_body(type="invoke", name="task/fetch"))
+        assert result is not None
+        assert result.status == 200
+        assert result.body == {}
+
+    async def test_returns_200_when_no_invoke_handlers_and_no_name(self):
+        bot = BotApplication()
+        result = await bot.process_body(_make_body(type="invoke"))
+        assert result is not None
+        assert result.status == 200
+        assert result.body == {}
+
+    async def test_returns_501_when_handlers_exist_but_none_match(self):
+        from botas.bot_application import InvokeResponse
+
+        bot = BotApplication()
+
+        async def handler(ctx: TurnContext) -> InvokeResponse:
+            return InvokeResponse(status=200, body={"ok": True})
+
+        bot.on_invoke("adaptiveCard/action", handler)
         result = await bot.process_body(_make_body(type="invoke", name="task/fetch"))
         assert result is not None
         assert result.status == 501
 
-    async def test_returns_501_when_invoke_has_no_name(self):
+    async def test_returns_501_when_handlers_exist_but_invoke_has_no_name(self):
+        from botas.bot_application import InvokeResponse
+
         bot = BotApplication()
+
+        async def handler(ctx: TurnContext) -> InvokeResponse:
+            return InvokeResponse(status=200, body={"ok": True})
+
+        bot.on_invoke("adaptiveCard/action", handler)
         result = await bot.process_body(_make_body(type="invoke"))
         assert result is not None
         assert result.status == 501


### PR DESCRIPTION
Closes #262

Fixes invoke dispatch across all 3 languages to distinguish between:
- **No invoke handlers registered** → return HTTP 200 \{}\ (bot doesn't handle invokes)
- **Handlers registered but none match** → return HTTP 501 Not Implemented

### Changes

| Language | Logic | Tests |
|----------|-------|-------|
| .NET | Early-return in \DispatchInvokeHandler\ when \_invokeHandlers.Count == 0\ | 4 tests (replaced 2 old + 2 new) |
| Node.js | Check \invokeHandlers.size > 0\ before returning 501 | 2 new + 2 updated |
| Python | Check \self._invoke_handlers\ before returning 501 | 2 new + 2 updated |

### Verification
- .NET: 84 tests pass
- Node.js: 114 tests pass
- Python: all tests pass, ruff clean