### PR TITLE
fix: return 400 for missing required activity fields (#260)

### DIFF
--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -110,3 +110,12 @@
 - All existing tests still pass; build clean
 - **Issue:** #261 (fix/typed-id-channelid-261)
 
+### Input Validation 400 Response (2026-04-25)
+- **Added `ActivityValidationError` class** — typed error for activity validation failures, mirrors `BotAuthError` pattern
+- `assertCoreActivity` now throws `ActivityValidationError` instead of plain `Error` for all validation failures
+- `processAsync` catches `ActivityValidationError` → returns HTTP 400 with JSON `{ error: '<message>' }` (was 500)
+- `processBody` throws `ActivityValidationError` which callers (Hono adapters etc.) can catch and map to 400
+- New tests: empty string type/serviceUrl, processAsync 400 integration tests
+- All 119 core + 12 express tests pass
+- **Branch:** `fix/input-validation-400-260` — Fixes #260
+

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -115,4 +115,18 @@
 - Added 5 new tests: deserialization, not-in-extra, serialization, round-trip, defaults-to-none.
 - **Test status:** 100 passed, 11 skipped; ruff clean.
 - **Branch:** fix/typed-id-channelid-261
+### Invoke Dispatch Fix — 200 for No Handlers, 501 for No Match (#262) (2026-04-25)
+- **Fixed `_dispatch_invoke_async` in `bot_application.py`:** Added early return of `InvokeResponse(status=200, body={})` when `self._invoke_handlers` dict is empty (bot doesn't handle invokes at all).
+- **Previous behavior:** Always returned 501 when no handler matched, even if zero invoke handlers were registered.
+- **New behavior:** No invoke handlers → 200 {}; handlers exist but none match → 501.
+- **Tests updated:** Replaced 2 old tests (expected 501 with no handlers) with 4 new tests covering both paths.
+- **Branch:** fix/invoke-dispatch-262
+- **All tests pass; ruff clean.**
+
+### Input Validation 400 Tests — Empty String Coverage (#260) (2026-04-25)
+- **Existing validation already correct:** `_assert_activity` in `bot_application.py` uses `not activity.type` / `not activity.service_url` which catches both None and empty strings; FastAPI adapter catches `ValueError` → returns HTTP 400.
+- **Tightened existing tests:** Changed `pytest.raises(Exception, ...)` to `pytest.raises(ValueError, ...)` for missing type, serviceUrl, and conversation.id tests — ensures the correct exception type is asserted.
+- **Added 3 new tests:** `test_raises_on_empty_type`, `test_raises_on_empty_service_url`, `test_valid_activity_proceeds_normally`.
+- **Branch:** fix/input-validation-400-260
+- **All tests pass; ruff clean.**
 

--- a/dotnet/src/Botas/BotApplication.cs
+++ b/dotnet/src/Botas/BotApplication.cs
@@ -155,15 +155,21 @@ public class BotApplication
 
         if (string.IsNullOrEmpty(activity.Type))
         {
-            throw new InvalidOperationException("Activity Type is required");
+            httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+            httpContext.Response.ContentType = "application/json";
+            await httpContext.Response.WriteAsync("{\"error\":\"BadRequest\",\"message\":\"Missing required field: type\"}", cancellationToken);
+            return activity;
+        }
+        if (string.IsNullOrEmpty(activity.ServiceUrl))
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+            httpContext.Response.ContentType = "application/json";
+            await httpContext.Response.WriteAsync("{\"error\":\"BadRequest\",\"message\":\"Missing required field: serviceUrl\"}", cancellationToken);
+            return activity;
         }
         if (activity.Conversation?.Id is null)
         {
             throw new InvalidOperationException("Activity Conversation.Id is required");
-        }
-        if (string.IsNullOrEmpty(activity.ServiceUrl))
-        {
-            throw new InvalidOperationException("Activity ServiceUrl is required");
         }
 
         if (_logger.IsEnabled(LogLevel.Trace))

--- a/dotnet/tests/Botas.Tests/InputValidationTests.cs
+++ b/dotnet/tests/Botas.Tests/InputValidationTests.cs
@@ -1,0 +1,150 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace Botas.Tests;
+
+/// <summary>
+/// Tests for input validation of required activity fields (#260).
+/// Missing or empty required fields should return 400 Bad Request.
+/// </summary>
+public class InputValidationTests : IAsyncLifetime
+{
+    private WebApplication? _app;
+    private HttpClient? _client;
+    private BotApplication? _bot;
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        // Register a keyed ConversationClient so ProcessAsync can resolve it
+        builder.Services.AddHttpClient("BotFrameworkNoAuth", client =>
+            client.Timeout = TimeSpan.FromSeconds(30));
+        builder.Services.AddKeyedScoped<ConversationClient>("AzureAd", (sp, _) =>
+            new ConversationClient(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient("BotFrameworkNoAuth"),
+                NullLoggerFactory.Instance.CreateLogger<ConversationClient>()));
+
+        _app = builder.Build();
+
+        _bot = new BotApplication(
+            new ConfigurationBuilder().Build(),
+            NullLogger<BotApplication>.Instance);
+        _bot.On("message", (ctx, ct) => Task.CompletedTask);
+
+        _app.UseExceptionHandler(errorApp =>
+        {
+            errorApp.Run(async context =>
+            {
+                context.Response.StatusCode = 500;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync("{}");
+            });
+        });
+        _app.MapPost("/api/messages", async (HttpContext httpContext, CancellationToken ct) =>
+        {
+            await _bot.ProcessAsync(httpContext, ct);
+        });
+
+        await _app.StartAsync();
+        _client = _app.GetTestClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_app != null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+
+    private StringContent JsonContent(object obj)
+    {
+        var json = JsonSerializer.Serialize(obj);
+        return new StringContent(json, Encoding.UTF8, "application/json");
+    }
+
+    [Fact]
+    public async Task NullType_Returns400()
+    {
+        // Send JSON with explicit null type to bypass the constructor default
+        var json = """{"type":null,"serviceUrl":"https://smba.trafficmanager.net/teams/","conversation":{"id":"conv1"}}""";
+        var response = await _client!.PostAsync("/api/messages",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        string body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("BadRequest", doc.RootElement.GetProperty("error").GetString());
+        Assert.Contains("type", doc.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task EmptyType_Returns400()
+    {
+        var activity = new { type = "", serviceUrl = "https://smba.trafficmanager.net/teams/", conversation = new { id = "conv1" } };
+        var response = await _client!.PostAsync("/api/messages", JsonContent(activity));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        string body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("BadRequest", doc.RootElement.GetProperty("error").GetString());
+        Assert.Contains("type", doc.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task MissingServiceUrl_Returns400()
+    {
+        var activity = new { type = "message", conversation = new { id = "conv1" } };
+        var response = await _client!.PostAsync("/api/messages", JsonContent(activity));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        string body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("BadRequest", doc.RootElement.GetProperty("error").GetString());
+        Assert.Contains("serviceUrl", doc.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task EmptyServiceUrl_Returns400()
+    {
+        var activity = new { type = "message", serviceUrl = "", conversation = new { id = "conv1" } };
+        var response = await _client!.PostAsync("/api/messages", JsonContent(activity));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        string body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("BadRequest", doc.RootElement.GetProperty("error").GetString());
+        Assert.Contains("serviceUrl", doc.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task ValidActivity_DoesNotReturn400()
+    {
+        var activity = new { type = "message", text = "hello", serviceUrl = "https://smba.trafficmanager.net/teams/", conversation = new { id = "conv1" } };
+        var response = await _client!.PostAsync("/api/messages", JsonContent(activity));
+
+        // Should not be 400 — it may be 500 due to missing ConversationClient in this test setup,
+        // but importantly it should NOT be 400
+        Assert.NotEqual(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/node/packages/botas-core/src/bot-application.spec.ts
+++ b/node/packages/botas-core/src/bot-application.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { BotApplication, BotHandlerException } from './bot-application.js'
+import { BotApplication, BotHandlerException, ActivityValidationError } from './bot-application.js'
 import type { CoreActivity } from './core-activity.js'
 import type { TurnContext } from './turn-context.js'
 
@@ -73,22 +73,62 @@ describe('BotApplication', () => {
       assert.equal(received.activity.type, 'Typing')
     })
 
-    it('throws on missing type field', async () => {
+    it('throws ActivityValidationError on missing type field', async () => {
       const bot = new BotApplication()
       const body = JSON.stringify({ serviceUrl: 'http://s', conversation: { id: 'c' } })
-      await assert.rejects(() => bot.processBody(body), /type/)
+      await assert.rejects(() => bot.processBody(body), (err: unknown) => {
+        assert.ok(err instanceof ActivityValidationError)
+        assert.match(err.message, /type/)
+        return true
+      })
     })
 
-    it('throws on missing serviceUrl field', async () => {
+    it('throws ActivityValidationError on missing serviceUrl field', async () => {
       const bot = new BotApplication()
       const body = JSON.stringify({ type: 'message', conversation: { id: 'c' } })
-      await assert.rejects(() => bot.processBody(body), /serviceUrl/)
+      await assert.rejects(() => bot.processBody(body), (err: unknown) => {
+        assert.ok(err instanceof ActivityValidationError)
+        assert.match(err.message, /serviceUrl/)
+        return true
+      })
     })
 
-    it('throws on missing conversation.id', async () => {
+    it('throws ActivityValidationError on missing conversation.id', async () => {
       const bot = new BotApplication()
       const body = JSON.stringify({ type: 'message', serviceUrl: 'http://s', conversation: {} })
-      await assert.rejects(() => bot.processBody(body), /conversation/)
+      await assert.rejects(() => bot.processBody(body), (err: unknown) => {
+        assert.ok(err instanceof ActivityValidationError)
+        assert.match(err.message, /conversation/)
+        return true
+      })
+    })
+
+    it('throws ActivityValidationError on empty string type', async () => {
+      const bot = new BotApplication()
+      const body = JSON.stringify({ type: '', serviceUrl: 'https://smba.trafficmanager.botframework.com/api', conversation: { id: 'c' } })
+      await assert.rejects(() => bot.processBody(body), (err: unknown) => {
+        assert.ok(err instanceof ActivityValidationError)
+        assert.match(err.message, /type/)
+        return true
+      })
+    })
+
+    it('throws ActivityValidationError on empty string serviceUrl', async () => {
+      const bot = new BotApplication()
+      const body = JSON.stringify({ type: 'message', serviceUrl: '', conversation: { id: 'c' } })
+      await assert.rejects(() => bot.processBody(body), (err: unknown) => {
+        assert.ok(err instanceof ActivityValidationError)
+        assert.match(err.message, /serviceUrl/)
+        return true
+      })
+    })
+
+    it('proceeds normally when type and serviceUrl are present', async () => {
+      const bot = new BotApplication()
+      let received = false
+      bot.on('message', async () => { received = true })
+      await bot.processBody(makeBody())
+      assert.ok(received)
     })
 
     it('does not pollute Object prototype via __proto__ key', async () => {
@@ -386,6 +426,46 @@ describe('BotApplication', () => {
 
       assert.equal(response.status, 200)
       assert.deepEqual(json, { statusCode: 200, type: 'application/vnd.microsoft.card.adaptive' })
+    })
+
+    it('processAsync returns 400 for missing required fields', async () => {
+      const { createServer } = await import('node:http')
+      const bot = new BotApplication()
+
+      const server = createServer((req, res) => { bot.processAsync(req, res) })
+      await new Promise<void>((resolve) => server.listen(0, resolve))
+      const addr = server.address() as { port: number }
+
+      const response = await fetch(`http://localhost:${addr.port}/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ conversation: { id: 'c' } })
+      })
+      const json = await response.json() as { error: string }
+      server.close()
+
+      assert.equal(response.status, 400)
+      assert.match(json.error, /type/)
+    })
+
+    it('processAsync returns 400 for empty serviceUrl', async () => {
+      const { createServer } = await import('node:http')
+      const bot = new BotApplication()
+
+      const server = createServer((req, res) => { bot.processAsync(req, res) })
+      await new Promise<void>((resolve) => server.listen(0, resolve))
+      const addr = server.address() as { port: number }
+
+      const response = await fetch(`http://localhost:${addr.port}/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'message', serviceUrl: '', conversation: { id: 'c' } })
+      })
+      const json = await response.json() as { error: string }
+      server.close()
+
+      assert.equal(response.status, 400)
+      assert.match(json.error, /serviceUrl/)
     })
   })
 })

--- a/node/packages/botas-core/src/bot-application.ts
+++ b/node/packages/botas-core/src/bot-application.ts
@@ -190,6 +190,9 @@ export class BotApplication {
       if (err instanceof RequestBodyTooLargeError) {
         res.writeHead(413)
         res.end(err.message)
+      } else if (err instanceof ActivityValidationError) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: err.message }))
       } else {
         getLogger().error('processAsync returning 500: %s', err instanceof Error ? err.message : String(err))
         if (!res.headersSent) {
@@ -344,16 +347,29 @@ const MAX_ENTITIES_COUNT = 100
 /** Maximum number of attachments allowed on a single activity. */
 const MAX_ATTACHMENTS_COUNT = 50
 
+/**
+ * Thrown when an incoming activity fails structural validation (missing or
+ * empty required fields, oversized payloads, etc.).
+ *
+ * The HTTP layer should return `400 Bad Request` when this error is caught.
+ */
+export class ActivityValidationError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'ActivityValidationError'
+  }
+}
+
 function assertCoreActivity (value: unknown): asserts value is CoreActivity {
   if (typeof value !== 'object' || value === null) {
-    throw new Error('CoreActivity must be a JSON object')
+    throw new ActivityValidationError('CoreActivity must be a JSON object')
   }
   const a = value as Record<string, unknown>
   if (typeof a['type'] !== 'string' || !a['type']) {
-    throw new Error('CoreActivity missing required field: type')
+    throw new ActivityValidationError('Missing required field: type')
   }
   if (typeof a['serviceUrl'] !== 'string' || !a['serviceUrl']) {
-    throw new Error('CoreActivity missing required field: serviceUrl')
+    throw new ActivityValidationError('Missing required field: serviceUrl')
   }
   if (
     typeof a['conversation'] !== 'object' ||
@@ -361,17 +377,17 @@ function assertCoreActivity (value: unknown): asserts value is CoreActivity {
     typeof (a['conversation'] as Record<string, unknown>)['id'] !== 'string' ||
     !(a['conversation'] as Record<string, unknown>)['id']
   ) {
-    throw new Error('CoreActivity missing required field: conversation.id')
+    throw new ActivityValidationError('Missing required field: conversation.id')
   }
   // #76: Validate activity field sizes to prevent abuse
   if (typeof a['text'] === 'string' && a['text'].length > MAX_ACTIVITY_TEXT_LENGTH) {
-    throw new Error(`CoreActivity text exceeds maximum length of ${MAX_ACTIVITY_TEXT_LENGTH}`)
+    throw new ActivityValidationError(`CoreActivity text exceeds maximum length of ${MAX_ACTIVITY_TEXT_LENGTH}`)
   }
   if (Array.isArray(a['entities']) && a['entities'].length > MAX_ENTITIES_COUNT) {
-    throw new Error(`CoreActivity entities array exceeds maximum size of ${MAX_ENTITIES_COUNT}`)
+    throw new ActivityValidationError(`CoreActivity entities array exceeds maximum size of ${MAX_ENTITIES_COUNT}`)
   }
   if (Array.isArray(a['attachments']) && a['attachments'].length > MAX_ATTACHMENTS_COUNT) {
-    throw new Error(`CoreActivity attachments array exceeds maximum size of ${MAX_ATTACHMENTS_COUNT}`)
+    throw new ActivityValidationError(`CoreActivity attachments array exceeds maximum size of ${MAX_ATTACHMENTS_COUNT}`)
   }
 }
 

--- a/python/packages/botas/tests/test_bot_application.py
+++ b/python/packages/botas/tests/test_bot_application.py
@@ -94,7 +94,7 @@ class TestProcessBody:
 
         bot = BotApplication()
         body = json.dumps({"serviceUrl": "http://localhost:3978/", "conversation": {"id": "c"}})
-        with pytest.raises(Exception, match="type"):
+        with pytest.raises(ValueError, match="type"):
             await bot.process_body(body)
 
     async def test_raises_on_missing_service_url(self):
@@ -102,7 +102,7 @@ class TestProcessBody:
 
         bot = BotApplication()
         body = json.dumps({"type": "message", "conversation": {"id": "c"}})
-        with pytest.raises(Exception, match="serviceUrl"):
+        with pytest.raises(ValueError, match="serviceUrl"):
             await bot.process_body(body)
 
     async def test_raises_on_missing_conversation_id(self):
@@ -110,8 +110,48 @@ class TestProcessBody:
 
         bot = BotApplication()
         body = json.dumps({"type": "message", "serviceUrl": "http://localhost:3978/", "conversation": {}})
-        with pytest.raises(Exception, match="conversation"):
+        with pytest.raises(ValueError, match="conversation"):
             await bot.process_body(body)
+
+    async def test_raises_on_empty_type(self):
+        import json
+
+        bot = BotApplication()
+        body = json.dumps(
+            {
+                "type": "",
+                "serviceUrl": "http://localhost:3978/",
+                "conversation": {"id": "c"},
+            }
+        )
+        with pytest.raises(ValueError, match="type"):
+            await bot.process_body(body)
+
+    async def test_raises_on_empty_service_url(self):
+        import json
+
+        bot = BotApplication()
+        body = json.dumps(
+            {
+                "type": "message",
+                "serviceUrl": "",
+                "conversation": {"id": "c"},
+            }
+        )
+        with pytest.raises(ValueError, match="serviceUrl"):
+            await bot.process_body(body)
+
+    async def test_valid_activity_proceeds_normally(self):
+        bot = BotApplication()
+        received: list[TurnContext] = []
+
+        async def handler(ctx: TurnContext):
+            received.append(ctx)
+
+        bot.on("message", handler)
+        await bot.process_body(_make_body())
+        assert len(received) == 1
+        assert received[0].activity.type == "message"
 
 
 class TestTurnContext:


### PR DESCRIPTION
Closes #260

Validates required fields (type, serviceUrl) upfront before entering the middleware pipeline. Returns HTTP 400 Bad Request with a descriptive JSON error instead of letting downstream exceptions produce 500s.

### Changes

| Language | Approach | Tests Added |
|----------|----------|-------------|
| .NET | Return 400 JSON error in ProcessAsync before pipeline entry | 5 new |
| Node.js | New ActivityValidationError class, caught in processAsync -> 400 | tests updated + new |
| Python | Existing _assert_activity already correct; tightened + added tests | 3 tightened + 3 new |

### Verification
- .NET: 89 tests pass
- Node.js: 131 tests pass
- Python: all tests pass, ruff clean
