### PR TITLE
docs: fix README consistency across packages

### DIFF
--- a/dotnet/src/Botas/README.md
+++ b/dotnet/src/Botas/README.md
@@ -1,14 +1,8 @@
+<img src="https://raw.githubusercontent.com/rido-min/botas/main/art/icon-256.png" alt="botas logo" width="96" align="right"/>
+
 # Botas The Bot App SDK
 
-Lightweight library for building [Microsoft Bot Service](https://learn.microsoft.com/azure/bot-service/) bots — .NET / ASP.NET Core.
-A lightweight library for building [Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/) bots in .NET / ASP.NET Core
-
-## What it does
-
-- Enables a chat experience in Teams, for personal, group, channel or meetings chats.
-- Secure inbound messages are dispatched to message handlers
-- Implement rich UX in chats using AdaptiveCards, Suggested Actions, Collect feedback and more
-- Secure outbound messages using standard Entra Application Tokens
+A lightweight library for building [Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/) bots — this is the **.NET** package.
 
 ## Installation
 
@@ -30,6 +24,17 @@ app.On("message", async (ctx, ct) =>
 
 app.Run();
 ```
+
+## API
+
+### `BotApp`
+
+| Method | Description |
+|---|---|
+| `On(type, handler)` | Register a handler for an activity type |
+| `OnInvoke(name, handler)` | Register a handler for an invoke activity by name |
+| `Use(middleware)` | Add a middleware to the turn pipeline (runs in registration order) |
+| `Run()` | Start the ASP.NET Core server |
 
 ## Configure the App Credentials
 
@@ -54,8 +59,6 @@ You can configure the bot app credentials using the `appSettings.json` or overri
   }
 }
 ```
-
-
 
 #### launchSettings.json
 
@@ -82,7 +85,7 @@ You can configure the bot app credentials using the `appSettings.json` or overri
 
 #### env vars
 
-```dotenvenv
+```dotenv
 AzureAd__Instance=https://login.microsoftonline.com/
 AzureAd__ClientId="<your-bot-app-id>"
 AzureAd__TenantId="<your-tenant-id>"

--- a/node/packages/botas-express/README.md
+++ b/node/packages/botas-express/README.md
@@ -52,6 +52,7 @@ Composes a `BotApplication` with an Express server.
 - [Full documentation site](https://rido-min.github.io/botas/)
 - [Full feature specification](https://github.com/rido-min/botas/blob/main/specs/README.md)
 - [Architecture overview](https://github.com/rido-min/botas/blob/main/specs/architecture.md)
+- [Infrastructure setup](https://github.com/rido-min/botas/blob/main/specs/setup.md)
 
 ## License
 

--- a/python/packages/botas-fastapi/README.md
+++ b/python/packages/botas-fastapi/README.md
@@ -89,6 +89,8 @@ Inherited from `BotApplicationOptions` (also resolved from environment variables
 
 - [Full documentation site](https://rido-min.github.io/botas/)
 - [Full feature specification](https://github.com/rido-min/botas/blob/main/specs/README.md)
+- [Architecture overview](https://github.com/rido-min/botas/blob/main/specs/architecture.md)
+- [Infrastructure setup](https://github.com/rido-min/botas/blob/main/specs/setup.md)
 
 ## License
 


### PR DESCRIPTION
## Changes

Fixes inconsistencies across package READMEs:

### dotnet/src/Botas/README.md
- Removed duplicate description lines (Bot Service vs Teams)
- Added botas logo to match Python README
- Added API reference table (matching Node.js and Python READMEs)
- Removed unique 'What it does' section for structural consistency
- Fixed \dotenvenv\ typo → \dotenv\
- Removed extra blank line between config sections

### node/packages/botas-express/README.md
- Added missing 'Infrastructure setup' link to Documentation section

### python/packages/botas-fastapi/README.md
- Added missing 'Architecture overview' and 'Infrastructure setup' links to Documentation section

All package READMEs now follow the same structure and have consistent documentation link sections.