### PR TITLE
feat: Action.Submit handling, mention e2e, and specs/docs updates

### DIFF
--- a/.squad/agents/nibbler/charter.md
+++ b/.squad/agents/nibbler/charter.md
@@ -23,6 +23,54 @@
 - Run per-language tests: `dotnet test`, `npm test`, `pytest`
 - Environment variables: CLIENT_ID, CLIENT_SECRET, TENANT_ID, PORT
 
+## Running E2E Tests
+
+### Unit tests (no bot needed)
+```bash
+cd dotnet && dotnet test Botas.slnx            # .NET — 95 tests
+cd node && npm test --workspaces --if-present   # Node — 12 tests
+cd python/packages/botas && python -m pytest tests/ -v  # Python — 109 tests
+```
+
+### External bot API tests (bot must be running)
+Uses the `e2e/dotnet/` xUnit tests. Each script starts the bot, waits for `/health`, runs tests, then stops the bot:
+```bash
+# From repo root:
+cd e2e && ./run-e2e-ts.sh   # Node bot
+cd e2e && ./run-e2e-dn.sh   # .NET bot
+cd e2e && ./run-e2e-py.sh   # Python bot
+```
+
+### Playwright Teams E2E tests (bot + devtunnel must be running)
+**Prerequisites:** A devtunnel exposing port 3978 must be active. Teams auth must be set up (`cd e2e/playwright && npm run setup`). Verify `e2e/playwright/storageState.json` exists and `e2e/playwright/.env` has `TEAMS_BOT_NAME`.
+
+**Use the orchestrator script** — it starts the bot, waits for `/health`, runs all 3 Playwright specs, then stops the bot:
+```powershell
+# Run all 3 languages (starts/stops each bot in sequence):
+cd e2e
+.\run-playwright-tests.ps1
+
+# Run a single language:
+.\run-playwright-tests.ps1 -Language node
+.\run-playwright-tests.ps1 -Language dotnet
+.\run-playwright-tests.ps1 -Language python
+
+# Headed mode (visible browser):
+.\run-playwright-tests.ps1 -Language node -Headed
+```
+
+**What the script does for each language:**
+1. Loads `.env` from repo root into process environment
+2. Starts the test-bot sample (`dotnet run`, `npx tsx`, or `python main.py`)
+3. Polls `http://localhost:3978/health` until ready (30s timeout)
+4. Runs `npx playwright test --project=teams-tests`
+5. Stops the bot process
+
+**Test specs** (`e2e/playwright/tests/`):
+- `echo-bot.spec.ts` — sends message, verifies echo reply
+- `invoke-bot.spec.ts` — sends "card", clicks Action.Execute button, verifies card update
+- `submit-bot.spec.ts` — sends "submit", clicks Action.Submit button, verifies value echo
+
 ## Boundaries
 
 **I handle:** E2E tests, integration tests, cross-language test validation, test strategy

--- a/docs-site/teams-features.md
+++ b/docs-site/teams-features.md
@@ -286,6 +286,126 @@ Card (Action.Execute with verb + data)
 
 ---
 
+## Action.Submit Handling
+
+Unlike `Action.Execute` (which sends an invoke activity), `Action.Submit` sends a **message** activity with `activity.value` set and `activity.text` empty. The bot detects this pattern inside its regular message handler.
+
+For the full spec comparison, see [Action.Submit vs Action.Execute](https://github.com/rido-min/botas/blob/main/specs/invoke-activities.md#actionsubmit-vs-actionexecute).
+
+### Sending an Action.Submit Card
+
+::: code-group
+```csharp [.NET]
+using FluentCards;
+
+var card = AdaptiveCardBuilder.Create()
+    .WithVersion(AdaptiveCardVersion.V1_5)
+    .AddTextBlock(tb => tb
+        .WithText("Action.Submit Test Card")
+        .WithWeight(TextWeight.Bolder))
+    .AddTextBlock(tb => tb
+        .WithText("Click the button to send a message with value."))
+    .AddAction(a => a
+        .Submit()
+        .WithTitle("Send")
+        .WithData("{\"source\":\"e2e\",\"action\":\"submit\"}"))
+    .Build();
+
+var reply = new TeamsActivityBuilder()
+    .WithConversationReference(ctx.Activity)
+    .WithAdaptiveCardAttachment(card.ToJsonElement())
+    .Build();
+await ctx.SendAsync(reply, ct);
+```
+
+```typescript [Node.js]
+import { AdaptiveCardBuilder, TextWeight, toObject } from 'fluent-cards'
+
+const card = AdaptiveCardBuilder.create()
+  .withVersion('1.5')
+  .addTextBlock(tb => tb.withText('Action.Submit Test Card').withWeight(TextWeight.Bolder))
+  .addTextBlock(tb => tb.withText('Click the button to send a message with value.'))
+  .addAction(a => a.submit().withTitle('Send').withData({ source: 'e2e', action: 'submit' }))
+  .build()
+
+await ctx.send({
+  type: 'message',
+  attachments: [{
+    contentType: 'application/vnd.microsoft.card.adaptive',
+    content: toObject(card)
+  }]
+})
+```
+
+```python [Python]
+from fluent_cards import AdaptiveCardBuilder, TextWeight, to_dict
+from botas import TeamsActivityBuilder
+
+card = (
+    AdaptiveCardBuilder.create()
+    .with_version("1.5")
+    .add_text_block(lambda tb: tb.with_text("Action.Submit Test Card").with_weight(TextWeight.Bolder))
+    .add_text_block(lambda tb: tb.with_text("Click the button to send a message with value."))
+    .add_action(lambda a: a.submit().with_title("Send").with_data({"source": "e2e", "action": "submit"}))
+    .build()
+)
+
+reply = (
+    TeamsActivityBuilder()
+    .with_conversation_reference(ctx.activity)
+    .with_adaptive_card_attachment(to_dict(card))
+    .build()
+)
+await ctx.send(reply)
+```
+:::
+
+### Handling the Submit
+
+When the user clicks the button, Teams sends a message with `value` and no `text`. Detect this in your message handler:
+
+::: code-group
+```csharp [.NET]
+app.On("message", async (ctx, ct) =>
+{
+    if (ctx.Activity.Value is not null && string.IsNullOrWhiteSpace(ctx.Activity.Text))
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(ctx.Activity.Value);
+        await ctx.SendAsync($"Submit received: {json}", ct);
+        return;
+    }
+    // ... handle normal messages
+});
+```
+
+```typescript [Node.js]
+app.on('message', async (ctx) => {
+  if (ctx.activity.value && !ctx.activity.text) {
+    await ctx.send(`Submit received: ${JSON.stringify(ctx.activity.value)}`)
+    return
+  }
+  // ... handle normal messages
+})
+```
+
+```python [Python]
+@app.on("message")
+async def on_message(ctx):
+    if ctx.activity.value is not None and not ctx.activity.text:
+        import json
+        await ctx.send(f"Submit received: {json.dumps(ctx.activity.value)}")
+        return
+    # ... handle normal messages
+```
+:::
+
+::: tip Action.Submit vs Action.Execute
+- **Action.Execute** → invoke activity → requires `InvokeResponse` (use for card updates)
+- **Action.Submit** → message activity with `value` → fire-and-forget (use for simple data collection)
+:::
+
+---
+
 ## Suggested Actions
 
 Offer quick-reply buttons to the user with `withSuggestedActions()`. Each button is a `CardAction` with a type (typically `"imBack"`), a display title, and a value sent back when clicked.
@@ -396,6 +516,7 @@ Each language has a complete sample in the repository using [FluentCards](https:
 | Command | Response |
 |---------|----------|
 | `cards` | Sends an Adaptive Card with an `Action.Execute` button |
+| `submit` | Sends an Adaptive Card with an `Action.Submit` button |
 | `actions` | Sends Suggested Actions (quick-reply buttons) |
 | *(anything else)* | Echoes back with an @mention of the sender |
 

--- a/dotnet/samples/TestBot/Program.cs
+++ b/dotnet/samples/TestBot/Program.cs
@@ -64,6 +64,17 @@ app.On("message", async (context, ct) =>
         };
         await context.SendAsync(reply, ct);
     }
+    else if (text.StartsWith("mention", StringComparison.OrdinalIgnoreCase))
+    {
+        var sender = context.Activity.From!;
+        var displayName = sender.Name ?? sender.Id ?? "user";
+        var reply = new TeamsActivityBuilder()
+            .WithConversationReference(context.Activity)
+            .WithText($"<at>{displayName}</at> said: {context.Activity.Text}")
+            .AddMention(sender)
+            .Build();
+        await context.SendAsync(reply, ct);
+    }
     else if (context.Activity.Value is not null && string.IsNullOrWhiteSpace(text))
     {
         // Action.Submit produces a message with activity.value (no text)

--- a/dotnet/samples/TestBot/Program.cs
+++ b/dotnet/samples/TestBot/Program.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Botas;
+using FluentCards;
 
 var version = BotApplication.Version;
 var platform = RuntimeInformation.FrameworkDescription;
@@ -13,26 +14,17 @@ app.On("message", async (context, ct) =>
     var text = (context.Activity.Text ?? "").Trim();
     if (text.Equals("card", StringComparison.OrdinalIgnoreCase))
     {
-        var card = new JsonObject
-        {
-            ["type"] = "AdaptiveCard",
-            ["version"] = "1.5",
-            ["body"] = new JsonArray
-            {
-                new JsonObject { ["type"] = "TextBlock", ["text"] = "Invoke Test Card", ["weight"] = "bolder" },
-                new JsonObject { ["type"] = "TextBlock", ["text"] = "Click the button to trigger an invoke." }
-            },
-            ["actions"] = new JsonArray
-            {
-                new JsonObject
-                {
-                    ["type"] = "Action.Execute",
-                    ["title"] = "Submit",
-                    ["verb"] = "test",
-                    ["data"] = new JsonObject { ["source"] = "e2e" }
-                }
-            }
-        };
+        var card = AdaptiveCardBuilder.Create()
+            .WithVersion(AdaptiveCardVersion.V1_5)
+            .AddTextBlock(tb => tb.WithText("Invoke Test Card").WithWeight(TextWeight.Bolder))
+            .AddTextBlock(tb => tb.WithText("Click the button to trigger an invoke."))
+            .AddAction(a => a
+                .Execute()
+                .WithTitle("Submit")
+                .WithVerb("test")
+                .WithData("{\"source\":\"e2e\"}"))
+            .Build();
+
         var reply = new CoreActivity("message")
         {
             Attachments = new JsonArray
@@ -40,11 +32,42 @@ app.On("message", async (context, ct) =>
                 new JsonObject
                 {
                     ["contentType"] = "application/vnd.microsoft.card.adaptive",
-                    ["content"] = card
+                    ["content"] = card.ToJsonNode()
                 }
             }
         };
         await context.SendAsync(reply, ct);
+    }
+    else if (text.Equals("submit", StringComparison.OrdinalIgnoreCase))
+    {
+        // Action.Submit card — clicking produces a message activity with flat activity.value
+        var card = AdaptiveCardBuilder.Create()
+            .WithVersion(AdaptiveCardVersion.V1_5)
+            .AddTextBlock(tb => tb.WithText("Action.Submit Test Card").WithWeight(TextWeight.Bolder))
+            .AddTextBlock(tb => tb.WithText("Click the button to send a message with value."))
+            .AddAction(a => a
+                .Submit()
+                .WithTitle("Send")
+                .WithData("{\"source\":\"e2e\",\"action\":\"submit\"}"))
+            .Build();
+
+        var reply = new CoreActivity("message")
+        {
+            Attachments = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["contentType"] = "application/vnd.microsoft.card.adaptive",
+                    ["content"] = card.ToJsonNode()
+                }
+            }
+        };
+        await context.SendAsync(reply, ct);
+    }
+    else if (context.Activity.Value is not null && string.IsNullOrWhiteSpace(text))
+    {
+        // Action.Submit produces a message with activity.value (no text)
+        await context.SendAsync($"Submit received: {JsonSerializer.Serialize(context.Activity.Value)}", ct);
     }
     else
     {

--- a/dotnet/samples/TestBot/TestBot.csproj
+++ b/dotnet/samples/TestBot/TestBot.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\..\src\Botas\Botas.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentCards" Version="0.2.0-beta-0004" />
+  </ItemGroup>
+
 </Project>

--- a/e2e/dotnet/ExternalSubmitTests.cs
+++ b/e2e/dotnet/ExternalSubmitTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Botas.E2ETests;
+
+/// <summary>
+/// E2E tests for Action.Submit handling against a bot running in a separate process.
+/// Action.Submit produces a message activity with flat activity.value (no text).
+/// The test-bot detects this and echoes "Submit received: {value}".
+/// Requires CLIENT_ID, CLIENT_SECRET, TENANT_ID env vars for token acquisition.
+/// </summary>
+public abstract class ExternalSubmitTests : IAsyncLifetime
+{
+    private ConversationService _callbackServer = null!;
+    private HttpClient _httpClient = null!;
+    private string _botEndpoint = null!;
+    private string _token = null!;
+
+    public async Task InitializeAsync()
+    {
+        _callbackServer = new ConversationService();
+        await _callbackServer.StartAsync();
+
+        _httpClient = new HttpClient();
+        _botEndpoint = Environment.GetEnvironmentVariable("BOT_URL") ?? "http://localhost:3978";
+        _botEndpoint = _botEndpoint.TrimEnd('/') + "/api/messages";
+
+        _token = await TokenProvider.GetTokenAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _httpClient.Dispose();
+        await _callbackServer.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Bot_EchoesValue_ForActionSubmit()
+    {
+        string conversationId = Guid.NewGuid().ToString();
+        var submitData = new { source = "e2e", action = "submit" };
+
+        // Action.Submit sends a message activity with value but no text
+        CoreActivity activity = new("message")
+        {
+            Value = JsonSerializer.SerializeToElement(submitData),
+            ServiceUrl = _callbackServer.BaseUrl,
+            Conversation = new Conversation { Id = conversationId },
+            From = new ChannelAccount { Id = "user1" },
+            Recipient = new ChannelAccount { Id = "bot1" },
+        };
+
+        Task<CoreActivity> replyTask = _callbackServer.WaitForActivityAsync();
+
+        HttpResponseMessage response = await SendAuthorizedAsync(activity);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        CoreActivity reply = await replyTask;
+        Assert.Equal("message", reply.Type);
+        Assert.Contains("Submit received:", reply.Text);
+        Assert.Contains("e2e", reply.Text);
+        Assert.Contains("submit", reply.Text);
+    }
+
+    private async Task<HttpResponseMessage> SendAuthorizedAsync(CoreActivity activity)
+    {
+        HttpRequestMessage request = new(HttpMethod.Post, _botEndpoint)
+        {
+            Content = new StringContent(activity.ToJson(), Encoding.UTF8, "application/json")
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        return await _httpClient.SendAsync(request);
+    }
+}
+
+[Trait("Category", "External")]
+[Trait("Category", "SubmitDotNet")]
+public sealed class DotNetSubmitTests : ExternalSubmitTests;
+
+[Trait("Category", "External")]
+[Trait("Category", "SubmitNode")]
+public sealed class NodeSubmitTests : ExternalSubmitTests;
+
+[Trait("Category", "External")]
+[Trait("Category", "SubmitPython")]
+public sealed class PythonSubmitTests : ExternalSubmitTests;

--- a/e2e/env2azad.ps1
+++ b/e2e/env2azad.ps1
@@ -106,6 +106,22 @@ if ($ClientSecret) {
     } else {
         $envVars | Add-Member -NotePropertyName $secretKey -NotePropertyValue $ClientSecret
     }
+    # SourceType is required by Microsoft.Identity.Web to recognize the credential
+    $sourceTypeKey = "AzureAd__ClientCredentials__0__SourceType"
+    if ($envVars.PSObject.Properties[$sourceTypeKey]) {
+        $envVars.$sourceTypeKey = "ClientSecret"
+    } else {
+        $envVars | Add-Member -NotePropertyName $sourceTypeKey -NotePropertyValue "ClientSecret"
+    }
+}
+
+# Set Instance (required by Microsoft.Identity.Web for token acquisition)
+$instanceKey = "AzureAd__Instance"
+$instanceValue = "https://login.microsoftonline.com/"
+if ($envVars.PSObject.Properties[$instanceKey]) {
+    $envVars.$instanceKey = $instanceValue
+} else {
+    $envVars | Add-Member -NotePropertyName $instanceKey -NotePropertyValue $instanceValue
 }
 
 # Write back

--- a/e2e/playwright/tests/mention-bot.spec.ts
+++ b/e2e/playwright/tests/mention-bot.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * E2E test: send "mention" and verify the bot replies with an @mention of the sender.
+ *
+ * The test bot uses TeamsActivityBuilder.addMention() to create a mention entity,
+ * then replies with "<at>DisplayName</at> said: mention [nonce]".
+ * In the Teams UI the <at> tag renders as a styled mention — we verify the
+ * visible text "said: mention" plus the nonce to avoid stale-history matches.
+ *
+ * Prerequisites:
+ *   1. Run `npm run setup` to authenticate with Teams
+ *   2. Have the test bot running with the mention handler
+ *   3. Set TEAMS_BOT_NAME in .env
+ */
+import { test, expect } from "@playwright/test";
+import {
+  assertStorageStateValid,
+  ensureTeamsLoaded,
+  navigateToBotChat,
+  sendMessage,
+} from "../teams-helpers";
+
+const BOT_NAME = process.env.TEAMS_BOT_NAME || "EchoBot";
+
+test.beforeEach(async () => {
+  assertStorageStateValid();
+});
+
+test("mention reply contains @mention of sender", async ({ page }) => {
+  await ensureTeamsLoaded(page);
+  await navigateToBotChat(page, BOT_NAME);
+
+  // sendMessage appends a nonce: "mention [abcd1234]"
+  // The bot echoes the full text back, so we can match on the nonce
+  const sentText = await sendMessage(page, "mention");
+  const nonceMatch = sentText.match(/\[([a-f0-9]+)\]/);
+  const nonce = nonceMatch![1];
+
+  // The bot replies: "<at>DisplayName</at> said: mention [nonce]"
+  // Teams renders the <at> tag as a mention span, so visible text is:
+  //   "DisplayName said: mention [nonce]"
+  const replyPattern = new RegExp(`said:.*mention.*${nonce}`, "i");
+
+  await expect(async () => {
+    const pageVisible = await page
+      .getByText(replyPattern)
+      .last()
+      .isVisible()
+      .catch(() => false);
+    if (pageVisible) return;
+
+    for (const frame of page.frames()) {
+      const frameVisible = await frame
+        .getByText(replyPattern)
+        .last()
+        .isVisible()
+        .catch(() => false);
+      if (frameVisible) return;
+    }
+    expect(false).toBe(true);
+  }).toPass({ timeout: 30_000 });
+});

--- a/e2e/playwright/tests/submit-bot.spec.ts
+++ b/e2e/playwright/tests/submit-bot.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * E2E test: trigger an Action.Submit via Adaptive Card button click in Teams.
+ *
+ * The test bot sends an Adaptive Card with Action.Submit when it receives "submit".
+ * Clicking the card's "Send" button triggers a message activity with flat activity.value.
+ * The bot detects the value and replies "Submit received: {value}".
+ *
+ * Prerequisites:
+ *   1. Run `npm run setup` to authenticate with Teams
+ *   2. Have the test bot running with the submit handler
+ *   3. Set TEAMS_BOT_NAME in .env
+ */
+import { test, expect } from "@playwright/test";
+import {
+  assertStorageStateValid,
+  ensureTeamsLoaded,
+  navigateToBotChat,
+  sendRawMessage,
+} from "../teams-helpers";
+
+const BOT_NAME = process.env.TEAMS_BOT_NAME || "EchoBot";
+
+test.beforeEach(async () => {
+  assertStorageStateValid();
+});
+
+test("action.submit echoes value back as message", async ({ page }) => {
+  await ensureTeamsLoaded(page);
+  await navigateToBotChat(page, BOT_NAME);
+
+  // Send "submit" to trigger the bot to send an Action.Submit card
+  await sendRawMessage(page, "submit");
+
+  // Wait for the card to render
+  await page.waitForTimeout(5_000);
+
+  // Scroll to the bottom of the chat to ensure new messages are visible
+  await page.keyboard.press("End");
+  await page.waitForTimeout(2_000);
+
+  // Find and click the "Send" button on the Action.Submit card
+  let sendClicked = false;
+
+  // Try page-level first
+  const pageSend = page.getByText("Send", { exact: true }).last();
+  if (await pageSend.isVisible().catch(() => false)) {
+    await pageSend.click();
+    sendClicked = true;
+  }
+
+  // If not found at page level, search frames
+  if (!sendClicked) {
+    for (const frame of page.frames()) {
+      const btn = frame.getByText("Send", { exact: true }).last();
+      if (await btn.isVisible().catch(() => false)) {
+        await btn.click();
+        sendClicked = true;
+        break;
+      }
+    }
+  }
+
+  if (!sendClicked) {
+    throw new Error(
+      "Could not find Send button at page level or in any iframe. " +
+        "Check that the bot sent an Action.Submit card in response to 'submit'."
+    );
+  }
+
+  // Wait for the bot to reply with the submitted value
+  const submitText = /Submit received/i;
+
+  await expect(async () => {
+    const pageVisible = await page
+      .getByText(submitText)
+      .last()
+      .isVisible()
+      .catch(() => false);
+    if (pageVisible) return;
+
+    for (const frame of page.frames()) {
+      const frameVisible = await frame
+        .getByText(submitText)
+        .last()
+        .isVisible()
+        .catch(() => false);
+      if (frameVisible) return;
+    }
+    expect(false).toBe(true);
+  }).toPass({ timeout: 30_000 });
+});

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -5847,7 +5847,8 @@
     "samples/test-bot": {
       "version": "0.1.0",
       "dependencies": {
-        "botas-express": "*"
+        "botas-express": "*",
+        "fluent-cards": "0.2.0-beta.4"
       }
     },
     "samples/typing-indicator": {

--- a/node/packages/botas-core/src/bot-application.spec.ts
+++ b/node/packages/botas-core/src/bot-application.spec.ts
@@ -352,16 +352,16 @@ describe('BotApplication', () => {
       assert.deepEqual(result, { status: 200, body: { ok: true } })
     })
 
-    it('returns 200 undefined when no invoke handlers registered at all', async () => {
+    it('returns 501 when no invoke handlers registered at all', async () => {
       const bot = new BotApplication()
       const result = await bot.processBody(makeBody({ type: 'invoke', name: 'task/fetch' }))
-      assert.equal(result, undefined)
+      assert.deepEqual(result, { status: 501 })
     })
 
-    it('returns 200 undefined when invoke activity has no name and no handlers registered', async () => {
+    it('returns 501 when invoke activity has no name and no handlers registered', async () => {
       const bot = new BotApplication()
       const result = await bot.processBody(makeBody({ type: 'invoke' }))
-      assert.equal(result, undefined)
+      assert.deepEqual(result, { status: 501 })
     })
 
     it('returns 501 when invoke handlers exist but none match the name', async () => {

--- a/node/packages/botas-core/src/bot-application.ts
+++ b/node/packages/botas-core/src/bot-application.ts
@@ -275,9 +275,7 @@ export class BotApplication {
     const name = context.activity.name
     const handler = name ? this.invokeHandlers.get(name.toLowerCase()) : undefined
     if (!handler) {
-      // No invoke handlers registered at all → silently ignore (200 {})
-      // Invoke handlers exist but none match → 501 Not Implemented
-      return this.invokeHandlers.size > 0 ? { status: 501 } : undefined
+      return { status: 501 }
     }
     try {
       return await handler(context)

--- a/node/samples/test-bot/index.ts
+++ b/node/samples/test-bot/index.ts
@@ -3,6 +3,7 @@
 
 import { BotApp } from 'botas-express'
 import { BotApplication } from 'botas-core'
+import { AdaptiveCardBuilder, TextWeight, toObject } from 'fluent-cards'
 
 const platform = `Node.js ${process.version} ${process.platform} ${process.arch}`
 
@@ -11,26 +12,39 @@ const app = new BotApp()
 app.on('message', async (ctx) => {
   const text = (ctx.activity.text ?? '').trim()
   if (text.toLowerCase() === 'card') {
+    const card = AdaptiveCardBuilder.create()
+      .withVersion('1.5')
+      .addTextBlock(tb => tb.withText('Invoke Test Card').withWeight(TextWeight.Bolder))
+      .addTextBlock(tb => tb.withText('Click the button to trigger an invoke.'))
+      .addAction(a => a.execute().withTitle('Submit').withVerb('test').withData({ source: 'e2e' }))
+      .build()
+
     await ctx.send({
       type: 'message',
       attachments: [{
         contentType: 'application/vnd.microsoft.card.adaptive',
-        content: {
-          type: 'AdaptiveCard',
-          version: '1.5',
-          body: [
-            { type: 'TextBlock', text: 'Invoke Test Card', weight: 'bolder' },
-            { type: 'TextBlock', text: 'Click the button to trigger an invoke.' }
-          ],
-          actions: [{
-            type: 'Action.Execute',
-            title: 'Submit',
-            verb: 'test',
-            data: { source: 'e2e' }
-          }]
-        }
+        content: toObject(card)
       }]
     })
+  } else if (text.toLowerCase() === 'submit') {
+    // Action.Submit card — clicking produces a message activity with flat activity.value
+    const card = AdaptiveCardBuilder.create()
+      .withVersion('1.5')
+      .addTextBlock(tb => tb.withText('Action.Submit Test Card').withWeight(TextWeight.Bolder))
+      .addTextBlock(tb => tb.withText('Click the button to send a message with value.'))
+      .addAction(a => a.submit().withTitle('Send').withData({ source: 'e2e', action: 'submit' }))
+      .build()
+
+    await ctx.send({
+      type: 'message',
+      attachments: [{
+        contentType: 'application/vnd.microsoft.card.adaptive',
+        content: toObject(card)
+      }]
+    })
+  } else if (ctx.activity.value && !text) {
+    // Action.Submit produces a message with activity.value (no text)
+    await ctx.send(`Submit received: ${JSON.stringify(ctx.activity.value)}`)
   } else {
     await ctx.send(`Echo: ${ctx.activity.text} [botas-node v${BotApplication.version} | ${platform}]`)
   }

--- a/node/samples/test-bot/index.ts
+++ b/node/samples/test-bot/index.ts
@@ -2,7 +2,7 @@
 // Run: npx tsx index.ts
 
 import { BotApp } from 'botas-express'
-import { BotApplication } from 'botas-core'
+import { BotApplication, TeamsActivityBuilder } from 'botas-core'
 import { AdaptiveCardBuilder, TextWeight, toObject } from 'fluent-cards'
 
 const platform = `Node.js ${process.version} ${process.platform} ${process.arch}`
@@ -42,6 +42,15 @@ app.on('message', async (ctx) => {
         content: toObject(card)
       }]
     })
+  } else if (text.toLowerCase().startsWith('mention')) {
+    const sender = ctx.activity.from
+    const displayName = sender?.name ?? sender?.id ?? 'user'
+    const reply = new TeamsActivityBuilder()
+      .withConversationReference(ctx.activity)
+      .withText(`<at>${displayName}</at> said: ${text}`)
+      .addMention(sender!)
+      .build()
+    await ctx.send(reply)
   } else if (ctx.activity.value && !text) {
     // Action.Submit produces a message with activity.value (no text)
     await ctx.send(`Submit received: ${JSON.stringify(ctx.activity.value)}`)

--- a/node/samples/test-bot/package.json
+++ b/node/samples/test-bot/package.json
@@ -7,6 +7,7 @@
     "dev": "node --import tsx --watch index.ts"
   },
   "dependencies": {
-    "botas-express": "*"
+    "botas-express": "*",
+    "fluent-cards": "0.2.0-beta.4"
   }
 }

--- a/python/samples/test-bot/main.py
+++ b/python/samples/test-bot/main.py
@@ -1,10 +1,12 @@
 # Test Bot — feature-rich bot for E2E/Playwright testing
 # Run: python main.py
 
+import json
 import logging
 import platform
 
 from botas_fastapi import BotApp
+from fluent_cards import AdaptiveCardBuilder, TextWeight, to_dict
 
 from botas import BotApplication, InvokeResponse
 
@@ -17,32 +19,53 @@ app = BotApp()
 async def on_message(ctx):
     text = (ctx.activity.text or "").strip()
     if text.lower() == "card":
+        card = (
+            AdaptiveCardBuilder.create()
+            .with_version("1.5")
+            .add_text_block(lambda tb: tb.with_text("Invoke Test Card").with_weight(TextWeight.Bolder))
+            .add_text_block(lambda tb: tb.with_text("Click the button to trigger an invoke."))
+            .add_action(lambda a: a.execute().with_title("Submit").with_verb("test").with_data({"source": "e2e"}))
+            .build()
+        )
+
         await ctx.send(
             {
                 "type": "message",
                 "attachments": [
                     {
                         "contentType": "application/vnd.microsoft.card.adaptive",
-                        "content": {
-                            "type": "AdaptiveCard",
-                            "version": "1.5",
-                            "body": [
-                                {"type": "TextBlock", "text": "Invoke Test Card", "weight": "bolder"},
-                                {"type": "TextBlock", "text": "Click the button to trigger an invoke."},
-                            ],
-                            "actions": [
-                                {
-                                    "type": "Action.Execute",
-                                    "title": "Submit",
-                                    "verb": "test",
-                                    "data": {"source": "e2e"},
-                                }
-                            ],
-                        },
+                        "content": to_dict(card),
                     }
                 ],
             }
         )
+    elif text.lower() == "submit":
+        # Action.Submit card — clicking produces a message activity with flat activity.value
+        card = (
+            AdaptiveCardBuilder.create()
+            .with_version("1.5")
+            .add_text_block(lambda tb: tb.with_text("Action.Submit Test Card").with_weight(TextWeight.Bolder))
+            .add_text_block(lambda tb: tb.with_text("Click the button to send a message with value."))
+            .add_action(
+                lambda a: a.submit().with_title("Send").with_data({"source": "e2e", "action": "submit"})
+            )
+            .build()
+        )
+
+        await ctx.send(
+            {
+                "type": "message",
+                "attachments": [
+                    {
+                        "contentType": "application/vnd.microsoft.card.adaptive",
+                        "content": to_dict(card),
+                    }
+                ],
+            }
+        )
+    elif ctx.activity.value is not None and not text:
+        # Action.Submit produces a message with activity.value (no text)
+        await ctx.send(f"Submit received: {json.dumps(ctx.activity.value)}")
     else:
         plat = f"Python {platform.python_version()} ({platform.system()})"
         await ctx.send(f"Echo: {ctx.activity.text} [botas-python v{BotApplication.version} | {plat}]")

--- a/python/samples/test-bot/main.py
+++ b/python/samples/test-bot/main.py
@@ -8,7 +8,7 @@ import platform
 from botas_fastapi import BotApp
 from fluent_cards import AdaptiveCardBuilder, TextWeight, to_dict
 
-from botas import BotApplication, InvokeResponse
+from botas import BotApplication, InvokeResponse, TeamsActivityBuilder
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -63,6 +63,17 @@ async def on_message(ctx):
                 ],
             }
         )
+    elif text.lower().startswith("mention"):
+        sender = ctx.activity.from_account
+        display_name = (sender.name if sender else None) or (sender.id if sender else None) or "user"
+        reply = (
+            TeamsActivityBuilder()
+            .with_conversation_reference(ctx.activity)
+            .with_text(f"<at>{display_name}</at> said: {ctx.activity.text}")
+            .add_mention(sender)
+            .build()
+        )
+        await ctx.send(reply)
     elif ctx.activity.value is not None and not text:
         # Action.Submit produces a message with activity.value (no text)
         await ctx.send(f"Submit received: {json.dumps(ctx.activity.value)}")

--- a/python/samples/test-bot/pyproject.toml
+++ b/python/samples/test-bot/pyproject.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "botas-fastapi",
+    "fluent-cards",
 ]

--- a/specs/README.md
+++ b/specs/README.md
@@ -26,7 +26,7 @@
 | Spec | Purpose |
 |------|---------|
 | [proactive-messaging.md](./proactive-messaging.md) | Out-of-turn messaging |
-| [invoke-activities.md](./invoke-activities.md) | Invoke activity dispatch |
+| [invoke-activities.md](./invoke-activities.md) | Invoke activity dispatch and Action.Submit vs Action.Execute |
 | [teams-activity.md](./teams-activity.md) | Teams-specific features (TeamsActivity, TeamsActivityBuilder) |
 
 For **developer guides** on middleware patterns, use cases, and samples, see the [Middleware Guide](../docs-site/middleware.md).

--- a/specs/activity-schema.md
+++ b/specs/activity-schema.md
@@ -47,7 +47,7 @@ Fields present on activities received from the Bot Service Service (`POST /api/m
 | `channelId` | `string` | No | Channel identifier (e.g., `"msteams"`, `"webchat"`). **Note**: Currently stored in extension data; will be promoted to typed field (Decision 6, code change pending). |
 | `text` | `string` | No | Message text content |
 | `name` | `string` | No | Invoke action name (e.g., `"adaptiveCard/action"`). Used for [invoke dispatch](./invoke-activities.md). |
-| `value` | `any` | No | Action-specific payload for invoke activities |
+| `value` | `any` | No | Action-specific payload. Present on invoke activities (e.g., `adaptiveCard/action`) and on message activities produced by Adaptive Card `Action.Submit` buttons. See [Card Actions — Action.Submit vs Action.Execute](./invoke-activities.md#actionsubmit-vs-actionexecute). |
 | `from` | [ChannelAccount](#channelaccount) | **Yes** | Sender information |
 | `recipient` | [ChannelAccount](#channelaccount) | No | Recipient (the bot) |
 | `conversation` | [Conversation](#conversation) | **Yes** | Conversation context |

--- a/specs/invoke-activities.md
+++ b/specs/invoke-activities.md
@@ -74,6 +74,53 @@ If an invoke handler does NOT return an `InvokeResponse`, the framework SHOULD r
 
 ---
 
+## Action.Submit vs Action.Execute
+
+Adaptive Cards support two action types that bots must handle differently:
+
+### Action.Execute (invoke activity)
+
+`Action.Execute` sends an **invoke** activity (`type: "invoke"`, `name: "adaptiveCard/action"`) containing the `verb` and `data` in `activity.value.action`. This is a request-response pattern — the handler **must** return an `InvokeResponse` with a status code and optional body (typically an updated card).
+
+```
+Card (Action.Execute with verb + data)
+  → User clicks button
+    → Teams sends invoke activity (name="adaptiveCard/action")
+      → Bot invoke handler returns InvokeResponse (updated card)
+```
+
+### Action.Submit (message activity)
+
+`Action.Submit` sends a **message** activity (`type: "message"`) with `activity.value` set to the card's data payload and `activity.text` empty or absent. This is a fire-and-forget pattern — no synchronous response is expected. The bot detects a card submit by checking for `value` present + `text` empty within its message handler.
+
+```
+Card (Action.Submit with data)
+  → User clicks button
+    → Teams sends message activity (value={...}, text="")
+      → Bot message handler detects value + no text → processes submit
+```
+
+### Detection Pattern
+
+All three languages use the same detection logic inside the message handler:
+
+| Language | Detection |
+|----------|-----------|
+| .NET | `activity.Value is not null && string.IsNullOrWhiteSpace(activity.Text)` |
+| Node.js | `ctx.activity.value && !ctx.activity.text` |
+| Python | `ctx.activity.value is not None and not ctx.activity.text` |
+
+### When to Use Which
+
+| Action Type | Use case | Activity type | Return contract |
+|-------------|----------|---------------|-----------------|
+| `Action.Execute` | Update the card in-place, task modules, sign-in | `invoke` | `InvokeResponse` (required) |
+| `Action.Submit` | Simple form submission, fire-and-forget data collection | `message` | None (fire-and-forget) |
+
+> **Tip**: Prefer `Action.Execute` when the bot needs to update the card or return a structured response. Use `Action.Submit` for simple data collection where the bot just needs the submitted values.
+
+---
+
 ## References
 
 - [teams.net TeamsBotApplication.cs](https://github.com/microsoft/teams.net/blob/next/core/core/src/Microsoft.Teams.Bot.Apps/TeamsBotApplication.cs) — Reference implementation


### PR DESCRIPTION
## Summary

Adds Action.Submit invoke handling and AddMention e2e validation across all three language test-bots, with corresponding Playwright tests and spec/doc updates.

### Code & Samples
- **Node/Python/.NET test-bot samples**: Handle `Action.Submit` (card button to message with value, no text) and `mention` (reply with @mention via TeamsActivityBuilder)
- **Null-safe display name**: All bots fall back to `sender.id` or `"user"` when `sender.name` is absent
- **Node core**: Fixed 501 invoke response to always return when no handler matches (aligns with spec)

### E2E Tests (Playwright)
- `submit-bot.spec.ts` — Clicks Action.Submit card button, verifies `Submit received:` echo
- `mention-bot.spec.ts` — Sends `mention [nonce]`, verifies bot replies with @mention containing nonce
- All 4 tests pass: echo, invoke, submit, mention (1.0m total)

### Specs
- `specs/invoke-activities.md` — New **Action.Submit vs Action.Execute** section: dispatch differences, detection patterns, when-to-use guidance
- `specs/activity-schema.md` — Fixed `value` field description (present on both invoke and message activities)
- `specs/README.md` — Updated invoke-activities feature description

### Docs
- `docs-site/teams-features.md` — New **Action.Submit Handling** section with card-building and detection examples for all 3 languages; updated command table with `submit` entry

### Other
- `e2e/env2azad.ps1` helper script
- `.squad/agents/nibbler/charter.md` agent charter
- `.NET ExternalSubmitTests.cs` for external integration testing
