### PR TITLE
fix: conversation ID encoding, docs improvements (#280, #279, #248)

### DIFF
--- a/docs-site/middleware.md
+++ b/docs-site/middleware.md
@@ -120,7 +120,7 @@ class LoggingMiddleware(TurnMiddleware):
 :::
 
 ::: info
-**Middleware type sources (Node.js):** Middleware types (`TurnMiddleware`, `removeMentionMiddleware`, etc.) are defined in `botas-core` and re-exported from `botas-express` for convenience. You can import from either, but imports from `botas-express` are simpler when working with `BotApp`.
+**Middleware type sources (Node.js):** Middleware types (`TurnMiddleware`, `NextTurn`, etc.) and built-in middleware (`removeMentionMiddleware`) are **defined in `botas-core`** and re-exported from `botas-express` for convenience. Both import sources work — examples on this page use `botas-express` since most users work with `BotApp`, but `botas-core` is the canonical source.
 :::
 
 ::: info

--- a/dotnet/src/Botas/ConversationClient.cs
+++ b/dotnet/src/Botas/ConversationClient.cs
@@ -46,7 +46,7 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
 
         ValidateServiceUrl(activity.ServiceUrl);
 
-        string url = $"{activity.ServiceUrl!}v3/conversations/{activity.Conversation!.Id}/activities/";
+        string url = $"{activity.ServiceUrl!}v3/conversations/{Uri.EscapeDataString(activity.Conversation!.Id!)}/activities/";
         string body = activity.ToJson();
 
         HttpRequestMessage request = new(HttpMethod.Post, url)

--- a/dotnet/tests/Botas.Tests/ConversationIdEncodingTests.cs
+++ b/dotnet/tests/Botas.Tests/ConversationIdEncodingTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Botas.Tests;
+
+/// <summary>
+/// Issue #280: Conversation IDs must be fully URL-encoded, not truncated at semicolons.
+/// </summary>
+public class ConversationIdEncodingTests
+{
+    [Fact]
+    public async Task SendActivityAsync_EncodesConversationIdWithSemicolons()
+    {
+        string? capturedUrl = null;
+        var handler = new CaptureUrlHandler(url => capturedUrl = url);
+        var httpClient = new HttpClient(handler);
+        var client = new ConversationClient(httpClient, NullLogger<ConversationClient>.Instance);
+
+        var activity = new CoreActivity
+        {
+            Type = "message",
+            Text = "hello",
+            ServiceUrl = "http://localhost:3978/",
+            Conversation = new() { Id = "a]concat-123;messageid=9876" }
+        };
+
+        await client.SendActivityAsync(activity);
+
+        Assert.NotNull(capturedUrl);
+        // Semicolon must be encoded as %3B, not truncated
+        Assert.Contains("%3B", capturedUrl, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("messageid", capturedUrl);
+        // ] must be encoded
+        Assert.Contains("%5D", capturedUrl, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SendActivityAsync_EncodesSimpleConversationId()
+    {
+        string? capturedUrl = null;
+        var handler = new CaptureUrlHandler(url => capturedUrl = url);
+        var httpClient = new HttpClient(handler);
+        var client = new ConversationClient(httpClient, NullLogger<ConversationClient>.Instance);
+
+        var activity = new CoreActivity
+        {
+            Type = "message",
+            Text = "hello",
+            ServiceUrl = "http://localhost:3978/",
+            Conversation = new() { Id = "simple-conv-123" }
+        };
+
+        await client.SendActivityAsync(activity);
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("simple-conv-123", capturedUrl);
+    }
+
+    /// <summary>
+    /// Test HTTP handler that captures the request URL and returns 200 OK.
+    /// </summary>
+    private class CaptureUrlHandler(Action<string> onRequest) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            onRequest(request.RequestUri?.ToString() ?? "");
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"id\":\"test\"}", System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/node/packages/botas-core/package.json
+++ b/node/packages/botas-core/package.json
@@ -37,7 +37,7 @@
     "clean": "npx rimraf ./dist",
     "build": "tsc -p tsconfig.json",
     "prepack": "npm run build",
-    "test": "node --import tsx --test src/core-activity.spec.ts src/bot-application.spec.ts src/remove-mention-middleware.spec.ts src/teams-activity.spec.ts src/bot-auth-middleware.spec.ts src/typing-activity.spec.ts src/security-fixes.spec.ts src/p2-fixes.spec.ts",
+    "test": "node --import tsx --test src/core-activity.spec.ts src/bot-application.spec.ts src/remove-mention-middleware.spec.ts src/teams-activity.spec.ts src/bot-auth-middleware.spec.ts src/typing-activity.spec.ts src/security-fixes.spec.ts src/p2-fixes.spec.ts src/conversation-client.spec.ts",
     "docs": "typedoc"
   },
   "files": [

--- a/node/packages/botas-core/src/conversation-client.spec.ts
+++ b/node/packages/botas-core/src/conversation-client.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'node:http'
+import { ConversationClient } from './conversation-client.js'
+
+/**
+ * Issue #280: Conversation IDs with semicolons must be URL-encoded, not truncated.
+ */
+describe('ConversationClient conversation ID encoding (#280)', () => {
+  let server: Server
+  let port: number
+  let lastUrl: string
+
+  async function startServer (): Promise<void> {
+    server = createServer((req, res) => {
+      lastUrl = req.url ?? ''
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ id: 'test-response' }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, resolve))
+    port = (server.address() as any).port
+  }
+
+  async function stopServer (): Promise<void> {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+
+  it('sendCoreActivityAsync encodes semicolons in conversation ID', async () => {
+    await startServer()
+    try {
+      const client = new ConversationClient()
+      await client.sendCoreActivityAsync(
+        `http://localhost:${port}`,
+        'a]concat-123;messageid=9876',
+        { type: 'message', text: 'hello' }
+      )
+      // Full conversation ID must be encoded — semicolon becomes %3B
+      assert.ok(lastUrl.includes('%3B') || lastUrl.includes('%3b'), `URL should contain encoded semicolon: ${lastUrl}`)
+      assert.ok(lastUrl.includes('messageid'), `URL should not truncate at semicolon: ${lastUrl}`)
+    } finally {
+      await stopServer()
+    }
+  })
+
+  it('updateActivityAsync encodes semicolons in conversation ID', async () => {
+    await startServer()
+    try {
+      const client = new ConversationClient()
+      await client.updateCoreActivityAsync(
+        `http://localhost:${port}`,
+        'conv;with;semicolons',
+        'activity-1',
+        { type: 'message', text: 'updated' }
+      )
+      assert.ok(lastUrl.includes('%3B') || lastUrl.includes('%3b'), `URL should contain encoded semicolon: ${lastUrl}`)
+      assert.ok(lastUrl.includes('semicolons'), `URL should not truncate at semicolon: ${lastUrl}`)
+    } finally {
+      await stopServer()
+    }
+  })
+})

--- a/node/packages/botas-core/src/conversation-client.ts
+++ b/node/packages/botas-core/src/conversation-client.ts
@@ -289,9 +289,5 @@ export class ConversationClient {
 }
 
 function encodeConversationId (conversationId: string): string {
-  const truncated = conversationId.split(';')[0] ?? conversationId
-  if (truncated !== conversationId) {
-    getLogger().info("Truncating conversation ID for 'agents' channel")
-  }
-  return encodeURIComponent(truncated)
+  return encodeURIComponent(conversationId)
 }

--- a/python/packages/botas/src/botas/conversation_client.py
+++ b/python/packages/botas/src/botas/conversation_client.py
@@ -25,8 +25,7 @@ from botas.core_activity import (
 
 
 def _encode_conversation_id(conversation_id: str) -> str:
-    truncated = conversation_id.split(";")[0]
-    return quote(truncated, safe="")
+    return quote(conversation_id, safe="")
 
 
 def _encode_id(id_value: str) -> str:

--- a/python/packages/botas/tests/test_conversation_client.py
+++ b/python/packages/botas/tests/test_conversation_client.py
@@ -63,3 +63,28 @@ class TestPathParameterEncoding:
 
             endpoint = mock_delete.call_args[0][1]
             assert "user%26admin" in endpoint
+
+
+class TestConversationIdEncoding:
+    """Issue #280: conversation ID must be fully URL-encoded, not truncated at semicolons."""
+
+    @pytest.mark.asyncio
+    async def test_send_activity_preserves_semicolons_in_conversation_id(self):
+        """Conversation IDs with semicolons must be URL-encoded, not truncated."""
+        client = ConversationClient()
+
+        with patch.object(client._http, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"id": "response-id"}
+
+            await client.send_activity_async(
+                "https://smba.trafficmanager.net/teams/",
+                "a]concat-123;messageid=9876",
+                CoreActivity(type="message", text="hello"),
+            )
+
+            endpoint = mock_post.call_args[0][1]
+            # Full conversation ID must be encoded — semicolon becomes %3B
+            assert "a%5D" in endpoint or "a%5d" in endpoint  # ] encoded
+            assert "%3B" in endpoint or "%3b" in endpoint  # ; encoded
+            # Must NOT be truncated before the semicolon
+            assert "messageid" in endpoint

--- a/specs/README.md
+++ b/specs/README.md
@@ -61,6 +61,9 @@ See [User Stories](./user-stories.md) for detailed behavioral scenarios.
 | Prototype pollution | Not applicable (strongly typed) | `safeJsonParse` strips dangerous keys | SHOULD strip for defense-in-depth |
 | `from` field naming | `From` (C# allows it) | `from` (JS allows it) | `from_account` (`from` is reserved in Python) |
 | Configuration model | `IConfiguration` + DI (ASP.NET pattern) | `BotApplicationOptions` interface | `BotApplicationOptions` dataclass |
+| Build timing | `BotApp.Create()` defers `Build()` to `Run()` — handlers/middleware queued until then | Immediate | Immediate |
+
+> **Why .NET defers `Build()`:** `On()` and `Use()` register handlers and middleware on the `BotApp` instance, but the underlying `BotApplication` isn't available until after `WebApplicationBuilder.Build()`. So registrations are queued in pending lists and wired into the `BotApplication` during `Run()`.
 
 These differences are intentional and should be preserved per language when porting.
 

--- a/specs/protocol.md
+++ b/specs/protocol.md
@@ -291,7 +291,7 @@ POST {serviceUrl}/v3/conversations/{conversationId}/activities
 - `{serviceUrl}` — the `serviceUrl` from the original inbound activity (unique per conversation). Implementations MUST normalize trailing slashes — the URL should have exactly one `/` between `{serviceUrl}` and `v3` regardless of whether `serviceUrl` ends with `/`.
 - `{conversationId}` — `activity.conversation.id`.
 
-> **Note**: Some channels (e.g., Microsoft Teams agents channel) include semicolons in conversation IDs (e.g., `a]concat-123;messageid=9876`). When constructing the URL, implementations MUST truncate the conversation ID at the first `;` character before URL-encoding it. The full conversation ID is still used in the activity body.
+> **Note**: Some channels (e.g., Microsoft Teams agents channel) include semicolons in conversation IDs (e.g., `a]concat-123;messageid=9876`). When constructing the URL, implementations MUST URL-encode the full conversation ID to ensure special characters are safely included in the path. Do NOT truncate at `;` or any other character.
 
 ### Request
 


### PR DESCRIPTION
## Summary

Fixes #280, #279, #248. Closes #278 (duplicate of #279). #246 already resolved (imports present).

### Bug fix: Conversation ID encoding (#280)
- **Node.js**: Removed semicolon truncation from \ncodeConversationId()\ — now encodes full ID
- **Python**: Removed semicolon truncation from \_encode_conversation_id()\ — now encodes full ID
- **.NET**: Added \Uri.EscapeDataString()\ for conversation ID in URL construction (was raw-inserted)
- **Spec**: Updated \protocol.md\ to say MUST NOT truncate at semicolons
- **Tests**: Added regression tests in all 3 languages for conversation IDs with semicolons

### Docs: .NET deferred Build() rationale (#279)
Added \Build timing\ row to the Language-Specific Differences table in \specs/README.md\ with rationale explaining why .NET defers \Build()\ to \Run()\.

### Docs: Middleware import clarity (#248)
Updated the info box in \docs-site/middleware.md\ to clearly explain that middleware types are defined in \otas-core\ and re-exported from \otas-express\.

### Test results
- .NET: 97 passed
- Node.js: 127 passed
- Python: 110 passed