### PR TITLE
docs: add logging configuration guide

### DIFF
--- a/.squad/agents/kif/history.md
+++ b/.squad/agents/kif/history.md
@@ -210,3 +210,37 @@ Cross-links in markdown tables must NOT be inside backtick code spans. Markdown 
 
 **Pattern**: Breaking large content blocks into separate spec files improves discoverability (user stories live in their own file, not buried in README) and keeps reference sections consistent across languages. Template headers (purpose + status) establish consistency and make the spec tree browsable.
 
+
+### 2026-XX-XX: Logging documentation created (logging.md)
+
+**Branch**: `docs/logging-guide`
+
+**What**: Created comprehensive logging documentation covering all three language implementations (.NET, Node.js, Python) with configuration examples and troubleshooting guidance.
+
+**Structure**:
+- Quick Start section with side-by-side configuration for all languages
+- Per-language deep dives: .NET (ILogger + appsettings.json), Node.js (Logger interface + debug/console/noop), Python (stdlib logging)
+- "What botas logs" section covering activity processing, token acquisition, JWT validation, and errors
+- Middleware integration section for custom logging
+- Troubleshooting section addressing common issues (logs not appearing, too many logs)
+
+**Key implementation details documented**:
+- .NET: Uses ASP.NET Core's `ILogger<BotApplication>` injected via `BotApp.Create(args)` DI setup; logs at Trace/Information/Error levels; configure via appsettings.json or launchSettings.json
+- Node.js: Custom Logger interface with 5 levels (trace/debug/info/warn/error); three built-in loggers (debugLogger with `debug` package + `DEBUG=botas:*` env var, consoleLogger, noopLogger); configure via `configure()` function at startup; supports custom logger implementations (pino, winston, etc.); MSAL logs wired through token-manager.ts
+- Python: Uses stdlib `logging` module with per-module loggers (`logging.getLogger(__name__)`); namespaces follow module path (`botas.bot_auth`, `botas.bot_http_client`); configure via basicConfig or dictConfig
+
+**VitePress integration**:
+- Added "Logging" to sidebar in `docs-site/.vitepress/config.mts` (after Middleware, before Teams Features)
+- Added to Quick Links in `docs-site/index.md` (between Middleware and Authentication)
+
+**Files created/modified**:
+- `docs-site/logging.md` (new file, ~11.7KB)
+- `docs-site/.vitepress/config.mts` (sidebar update)
+- `docs-site/index.md` (Quick Links update)
+
+**Pattern**: Multi-language docs should follow VitePress code-group blocks for side-by-side comparisons, use collapsible sections (`:::`) for alternatives, and link to existing specs/guides instead of duplicating content. Follow middleware.md and authentication.md structure: overview → per-language sections → what the library logs → when to customize → troubleshooting → learn more.
+
+**Reference files**:
+- `node/packages/botas-core/src/logger.ts` (Node.js Logger interface and built-in implementations)
+- `dotnet/src/Botas/BotApplication.cs` (ILogger usage in .NET)
+- `python/packages/botas/src/botas/bot_auth.py` (Python stdlib logging usage)

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -38,6 +38,7 @@ export default defineConfig({
           { text: 'Setup Guide', link: '/setup' },
           { text: 'Authentication', link: '/authentication' },
           { text: 'Middleware', link: '/middleware' },
+          { text: 'Logging', link: '/logging' },
           { text: 'Teams Features', link: '/teams-features' },
         ],
       },

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -88,6 +88,7 @@ app.start()
 - [Languages](languages/) — Language-specific guides for .NET, Node.js, and Python
 - [Teams Features](teams-features) — Mentions, Adaptive Cards, Suggested Actions, and Typing Indicators
 - [Middleware](middleware) — Extend the turn pipeline with custom middleware
+- [Logging](logging) — Configure logging in .NET, Node.js, and Python
 - [Authentication](authentication) — How the two-auth model works under the hood
 
 ## API Reference

--- a/docs-site/logging.md
+++ b/docs-site/logging.md
@@ -1,0 +1,439 @@
+---
+outline: deep
+---
+
+# Logging
+
+botas logs operational events — incoming activities, token acquisition, handler errors — using each language's standard logging framework. You control the verbosity and destination by configuring the logger before your bot starts.
+
+---
+
+## Quick Start
+
+Enable debug logs to see what your bot is doing:
+
+::: code-group
+```json [.NET (appsettings.json)]
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Botas": "Debug"         // ← all botas components at Debug level
+    }
+  }
+}
+```
+
+```bash [Node.js (environment)]
+# Enable all botas logs
+DEBUG=botas:* node index.js
+
+# Or just errors and warnings
+DEBUG=botas:error,botas:warn node index.js
+```
+
+```python [Python (code)]
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,      # ← show all levels including botas.* loggers
+    format="%(levelname)s %(name)s: %(message)s"
+)
+```
+:::
+
+---
+
+## .NET Logging
+
+botas uses ASP.NET Core's `ILogger<T>` for all logging. The `BotApp.Create(args)` helper wires up dependency injection automatically so `ILogger` is injected into `BotApplication`.
+
+### Log levels
+
+| Level | When botas logs |
+|-------|----------------|
+| **Trace** | Received activity type and payload details |
+| **Information** | Started bot listener, finished processing activity |
+| **Error** | Error processing activity (includes exception) |
+
+### Configure via `appsettings.json`
+
+```json
+{
+  "$schema": "https://json.schemastore.org/appsettings.json",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Botas": "Information"      // ← all botas namespaces
+    }
+  }
+}
+```
+
+### Configure via `launchSettings.json`
+
+```json
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "local": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "Logging__LogLevel__Botas": "Debug"   // ← override for development
+      }
+    }
+  }
+}
+```
+
+### Configure with code
+
+If you're not using `BotApp`, configure logging when building your `WebApplication`:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Logging.AddConsole();
+builder.Logging.SetMinimumLevel(LogLevel.Debug);    // ← global minimum
+builder.Services.AddBotApplication<BotApplication>();
+```
+
+For more details, see the [ASP.NET Core logging docs](https://learn.microsoft.com/aspnet/core/fundamentals/logging/).
+
+---
+
+## Node.js Logging
+
+botas defines a minimal `Logger` interface with five levels: `trace`, `debug`, `info`, `warn`, `error`. Three built-in loggers are available, or you can implement the `Logger` interface to integrate with pino, winston, etc.
+
+### Built-in loggers
+
+| Logger | Description |
+|--------|-------------|
+| **`debugLogger`** (default) | Uses the [`debug`](https://www.npmjs.com/package/debug) package with `botas:*` namespaces. Enable via `DEBUG=botas:*`. |
+| **`consoleLogger`** | Writes to `console` with a level prefix (`[INFO]`, `[ERROR]`, etc.). |
+| **`noopLogger`** | Discards all messages (useful in tests). |
+
+### Log levels
+
+Each level maps to a separate `debug` namespace so you can filter precisely:
+
+```bash
+DEBUG=botas:*                         # all levels
+DEBUG=botas:info,botas:warn,botas:error  # info and above
+DEBUG=botas:error                     # errors only
+```
+
+### Configure the logger
+
+Call `configure()` once at application startup, **before** creating a `BotApplication`:
+
+::: code-group
+```typescript [debugLogger (default)]
+import { configure, debugLogger } from 'botas-core'
+
+configure(debugLogger)      // ← optional: debugLogger is the default
+```
+
+```typescript [consoleLogger]
+import { configure, consoleLogger } from 'botas-core'
+
+configure(consoleLogger)    // ← always logs to console (no DEBUG env var needed)
+```
+
+```typescript [noopLogger (tests)]
+import { configure, noopLogger } from 'botas-core'
+
+configure(noopLogger)       // ← silence all logs (useful in tests)
+```
+:::
+
+### Custom logger (pino, winston, etc.)
+
+Implement the `Logger` interface to integrate with any logging framework:
+
+```typescript
+import { configure, type Logger } from 'botas-core'
+import pino from 'pino'
+
+const pinoInstance = pino({ level: 'debug' })
+
+const pinoLogger: Logger = {
+  trace: (msg, ...args) => pinoInstance.trace(msg, ...args),
+  debug: (msg, ...args) => pinoInstance.debug(msg, ...args),
+  info: (msg, ...args) => pinoInstance.info(msg, ...args),
+  warn: (msg, ...args) => pinoInstance.warn(msg, ...args),
+  error: (msg, ...args) => pinoInstance.error(msg, ...args),
+}
+
+configure(pinoLogger)
+```
+
+### MSAL (token acquisition) logs
+
+MSAL logs are automatically wired through to the botas logger via the token manager. You'll see messages like:
+
+```
+[INFO]  Acquired token for https://api.botframework.com/.default (expires in 3599s)
+```
+
+---
+
+## Python Logging
+
+botas uses Python's stdlib `logging` module. Each module creates its own logger with `logging.getLogger(__name__)`. Namespaces follow the module path: `botas.bot_auth`, `botas.bot_http_client`, etc.
+
+### Log levels
+
+botas logs at the following levels:
+
+| Level | When botas logs |
+|-------|----------------|
+| **DEBUG** | Token acquisition, JWKS refresh, HTTP request details |
+| **INFO** | Activity received, handler dispatched, response sent |
+| **WARNING** | Recoverable issues, unexpected responses |
+| **ERROR** | Handler exceptions, auth failures, network errors |
+
+### Configure with `basicConfig`
+
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,                          # ← show all levels
+    format="%(levelname)s %(name)s: %(message)s"  # ← include logger name
+)
+```
+
+### Configure specific loggers
+
+```python
+import logging
+
+# Show debug logs from botas only
+logging.getLogger("botas").setLevel(logging.DEBUG)
+
+# Or filter to specific modules
+logging.getLogger("botas.bot_auth").setLevel(logging.DEBUG)
+logging.getLogger("botas.bot_http_client").setLevel(logging.INFO)
+```
+
+### Configure with `dictConfig` (production)
+
+For more control (handlers, formatters, propagation), use `logging.config.dictConfig`:
+
+```python
+import logging.config
+
+logging.config.dictConfig({
+    "version": 1,
+    "formatters": {
+        "standard": {
+            "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "standard",
+        }
+    },
+    "loggers": {
+        "botas": {
+            "level": "INFO",
+            "handlers": ["console"],
+            "propagate": False,
+        }
+    }
+})
+```
+
+For more details, see the [Python logging docs](https://docs.python.org/3/library/logging.html).
+
+---
+
+## What botas logs
+
+### Activity processing
+
+Every incoming activity is logged at **Info** level (**.NET / Node**) or **INFO** (**Python**):
+
+```
+INFO: Received activity type=message from=user-id-123
+INFO: Handler for 'message' completed in 42ms
+```
+
+### Token acquisition (outbound auth)
+
+When botas acquires an OAuth2 token for outbound API calls, you'll see:
+
+```
+DEBUG: Acquiring token for https://api.botframework.com/.default
+INFO: Token acquired (expires in 3599s)
+```
+
+### JWT validation (inbound auth)
+
+When the Bot Service sends a JWT bearer token, botas validates it and logs:
+
+```
+DEBUG: Fetching JWKS from https://login.botframework.com/v1/.well-known/openid-configuration
+DEBUG: Validating JWT signature with kid=abc123
+```
+
+### Errors
+
+Handler exceptions are logged at **Error** level (**.NET / Node**) or **ERROR** (**Python**):
+
+```
+ERROR: Error processing activity type=message: ArgumentNullException: Value cannot be null
+```
+
+---
+
+## When to use middleware for logging
+
+If you need to log **custom data** (user IDs, conversation IDs, handler latency), use middleware instead of relying on botas's built-in logs:
+
+::: code-group
+```csharp [.NET]
+using Botas;
+
+public class CustomLoggingMiddleware : ITurnMiddleWare
+{
+    private readonly ILogger<CustomLoggingMiddleware> _logger;
+
+    public CustomLoggingMiddleware(ILogger<CustomLoggingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task OnTurnAsync(
+        TurnContext context,
+        NextDelegate next,
+        CancellationToken cancellationToken = default)
+    {
+        var start = DateTime.UtcNow;
+        _logger.LogInformation("▶ {Type} from {User}",
+            context.Activity.Type, context.Activity.From?.Id);
+
+        await next(cancellationToken);
+
+        var duration = (DateTime.UtcNow - start).TotalMilliseconds;
+        _logger.LogInformation("◀ {Type} completed in {Duration}ms",
+            context.Activity.Type, duration);
+    }
+}
+```
+
+```typescript [Node.js]
+import { getLogger } from 'botas-core'
+import type { TurnMiddleware } from 'botas-express'
+
+const customLoggingMiddleware: TurnMiddleware = async (context, next) => {
+  const logger = getLogger()
+  const start = Date.now()
+
+  logger.info(`▶ ${context.activity.type} from ${context.activity.from?.id}`)
+  await next()
+
+  const duration = Date.now() - start
+  logger.info(`◀ ${context.activity.type} completed in ${duration}ms`)
+}
+```
+
+```python [Python]
+import logging
+import time
+from botas import TurnMiddleware
+from botas.turn_context import TurnContext
+
+_logger = logging.getLogger(__name__)
+
+class CustomLoggingMiddleware(TurnMiddleware):
+    async def on_turn(self, context: TurnContext, next) -> None:
+        start = time.time()
+        _logger.info(f"▶ {context.activity.type} from {context.activity.from_.id}")
+
+        await next()
+
+        duration = (time.time() - start) * 1000
+        _logger.info(f"◀ {context.activity.type} completed in {duration:.0f}ms")
+```
+:::
+
+For more on middleware, see the [Middleware guide](middleware).
+
+---
+
+## Troubleshooting
+
+### Logs not appearing (.NET)
+
+Check that `appsettings.json` exists and is set to **Copy to Output Directory** (in your `.csproj`):
+
+```xml
+<ItemGroup>
+  <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+</ItemGroup>
+```
+
+### Logs not appearing (Node.js)
+
+If using `debugLogger` (the default), make sure the `DEBUG` environment variable is set:
+
+```bash
+DEBUG=botas:* node index.js
+```
+
+Or switch to `consoleLogger` to always log to console:
+
+```typescript
+import { configure, consoleLogger } from 'botas-core'
+configure(consoleLogger)
+```
+
+### Logs not appearing (Python)
+
+Call `logging.basicConfig()` **before** creating your bot application:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.DEBUG)   # ← call FIRST
+
+from botas_fastapi import BotApp
+app = BotApp()
+```
+
+### Too many logs
+
+Reduce the log level to show only warnings and errors:
+
+::: code-group
+```json [.NET]
+{
+  "Logging": {
+    "LogLevel": {
+      "Botas": "Warning"
+    }
+  }
+}
+```
+
+```bash [Node.js]
+DEBUG=botas:warn,botas:error node index.js
+```
+
+```python [Python]
+logging.getLogger("botas").setLevel(logging.WARNING)
+```
+:::
+
+---
+
+## Learn More
+
+- **Middleware**: [Middleware guide](middleware) — write custom logging middleware
+- **Authentication**: [Authentication guide](authentication) — what botas logs during JWT validation and token acquisition
+- **Architecture**: [specs/architecture.md](https://github.com/rido-min/botas/blob/main/specs/architecture.md) — component diagram and logging touchpoints


### PR DESCRIPTION
Adds a new documentation page covering logging configuration for all three languages:

- **.NET**: `ILogger<T>` via ASP.NET Core DI, `appsettings.json` and code-based configuration
- **Node.js**: Built-in `debugLogger`/`consoleLogger`/`noopLogger`, custom Logger interface integration (pino, winston)
- **Python**: stdlib `logging` module with per-module loggers

Also updates:
- VitePress sidebar (added after Middleware)
- Homepage Quick Links section

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>