### PR TITLE
docs: remove duplicate Build timing row (closes #279)

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -63,7 +63,6 @@ See [User Stories](./user-stories.md) for detailed behavioral scenarios.
 | Prototype pollution | Not applicable (strongly typed) | `safeJsonParse` strips dangerous keys | SHOULD strip for defense-in-depth |
 | `from` field naming | `From` (C# allows it) | `from` (JS allows it) | `from_account` (`from` is reserved in Python) |
 | Configuration model | `IConfiguration` + DI (ASP.NET pattern) | `BotApplicationOptions` interface | `BotApplicationOptions` dataclass |
-| Build timing | `BotApp.Create()` defers `Build()` to `Run()` — handlers/middleware queued until then | Immediate | Immediate |
 | `version` property | `BotApplication.Version` (static, from assembly) | `BotApplication.version` (static) | `BotApplication.version` (class attribute) |
 | `appId` property | `BotApplication.AppId` (from configuration) | `bot.appId` (from token manager) | `bot.appid` (from token manager) |
 | TeamsActivityBuilder design | Standalone class (not extending CoreActivityBuilder) | Standalone class | Standalone class |


### PR DESCRIPTION
The rationale for .NET deferred \Build()\ timing was already added at line 72 of \specs/README.md\ (via #282), but a duplicate table row remained. This removes the duplicate.

Closes #279