### PR TITLE
feat: publish botas-core as native JSR package (@botas/core)

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 jobs:
   changes:
@@ -133,6 +134,11 @@ jobs:
         run: npm publish --workspace packages/botas-express --access public --tag ${{ needs.changes.outputs.is_release == 'true' && 'latest' || 'dev' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish botas-core to JSR
+        if: needs.changes.outputs.is_release == 'true'
+        working-directory: node/packages/botas-core
+        run: npx jsr publish --allow-dirty
 
   python:
     needs: changes

--- a/node/packages/botas-core/README.md
+++ b/node/packages/botas-core/README.md
@@ -10,6 +10,18 @@ A lightweight, multi-language library for building [Microsoft Teams](https://lea
 npm install botas-core
 ```
 
+### Deno (via JSR)
+
+```bash
+deno add jsr:@botas/core
+```
+
+Or use the npm specifier directly:
+
+```typescript
+import { BotApplication } from "npm:botas-core"
+```
+
 ## Quick start (with Express)
 
 ```typescript

--- a/node/packages/botas-core/jsr.json
+++ b/node/packages/botas-core/jsr.json
@@ -1,0 +1,10 @@
+{
+  "name": "@botas/core",
+  "version": "0.1.0",
+  "license": "MIT",
+  "exports": "./src/index.ts",
+  "publish": {
+    "include": ["src/**/*.ts", "README.md"],
+    "exclude": ["src/**/*.spec.ts"]
+  }
+}

--- a/node/packages/botas-core/src/teams-activity.ts
+++ b/node/packages/botas-core/src/teams-activity.ts
@@ -66,7 +66,7 @@ export interface TeamsActivity extends CoreActivity {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const TeamsActivity = {
+export const TeamsActivity: { fromActivity(activity: CoreActivity): TeamsActivity } = {
   /**
    * Creates a TeamsActivity from a CoreActivity.
    * Copies all fields and treats channelData as TeamsChannelData.


### PR DESCRIPTION
## Summary

Adds JSR publishing support for botas-core as @botas/core, enabling first-class Deno consumption without the npm: compatibility layer.

### Changes

- jsr.json - JSR package config
- teams-activity.ts - Explicit type for JSR slow-type checker
- CD.yml - JSR publish step (release-only, OIDC)
- README.md - Deno/JSR install instructions

### Validation

- jsr publish --dry-run passes
- All Node.js tests pass (109)

Closes #296