### PR TITLE
feat: separate JSR publish job with version sync and add Deno sample

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -135,8 +135,47 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish botas-core to JSR
-        if: needs.changes.outputs.is_release == 'true'
+  jsr:
+    needs: [changes, node]
+    if: needs.changes.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: node/package-lock.json
+
+      - name: Install dependencies
+        working-directory: node
+        run: npm ci
+
+      - name: Set package version
+        working-directory: node/packages/botas-core
+        run: npx nbgv-setversion
+
+      - name: Sync version to jsr.json
+        working-directory: node/packages/botas-core
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Publishing @botas/core@${VERSION} to JSR"
+          node -e "const f='jsr.json'; const j=JSON.parse(require('fs').readFileSync(f,'utf8')); j.version=process.argv[1]; require('fs').writeFileSync(f, JSON.stringify(j, null, 2)+'\n')" "$VERSION"
+          cat jsr.json
+
+      - name: Publish to JSR
         working-directory: node/packages/botas-core
         run: npx jsr publish --allow-dirty
 

--- a/node/samples/deno/README.md
+++ b/node/samples/deno/README.md
@@ -1,0 +1,43 @@
+# Deno Echo Bot
+
+A minimal bot sample using [`@botas/core`](https://jsr.io/@botas/core) from JSR with Deno's built-in HTTP server — no frameworks or build step needed.
+
+## Prerequisites
+
+- [Deno](https://deno.land/) v2+
+- A registered Bot Service app (see [setup guide](../../../specs/setup.md))
+
+## Run
+
+```bash
+deno run --allow-net --allow-env main.ts
+```
+
+With authentication enabled (recommended for production):
+
+```bash
+CLIENT_ID=<your-app-id> CLIENT_SECRET=<your-secret> TENANT_ID=<your-tenant> \
+  deno run --allow-net --allow-env main.ts
+```
+
+The bot listens on `http://localhost:3978/api/messages`.
+
+## How it works
+
+This sample uses Deno's native `Deno.serve()` — no Express, Hono, or other framework required. The `@botas/core` package is imported directly from JSR:
+
+```ts
+import { BotApplication, validateBotToken, BotAuthError } from 'jsr:@botas/core'
+```
+
+The bot:
+1. Validates the incoming JWT token (when `CLIENT_ID` is set)
+2. Dispatches the activity through the `BotApplication` pipeline
+3. Echoes back any message the user sends
+
+## Endpoints
+
+| Method | Path            | Description          |
+|--------|-----------------|----------------------|
+| POST   | /api/messages   | Bot Framework endpoint |
+| GET    | /health         | Health check         |

--- a/node/samples/deno/main.ts
+++ b/node/samples/deno/main.ts
@@ -1,0 +1,47 @@
+// Echo Bot — minimal Deno sample using @botas/core from JSR
+// Run: deno run --allow-net --allow-env main.ts
+
+import { BotApplication, validateBotToken, BotAuthError } from 'jsr:@botas/core'
+
+const bot = new BotApplication()
+
+bot.on('message', async (ctx) => {
+  await ctx.send(`You said: ${ctx.activity.text}`)
+})
+
+bot.on('conversationUpdate', async (ctx) => {
+  console.log('conversation update', ctx.activity.properties?.['membersAdded'])
+})
+
+const PORT = Number(Deno.env.get('PORT') ?? '3978')
+
+Deno.serve({ port: PORT }, async (req) => {
+  const url = new URL(req.url)
+
+  if (req.method === 'POST' && url.pathname === '/api/messages') {
+    const clientId = Deno.env.get('CLIENT_ID')
+    if (clientId) {
+      const header = req.headers.get('authorization') ?? undefined
+      try {
+        await validateBotToken(header, clientId)
+      } catch (err) {
+        if (err instanceof BotAuthError) {
+          return new Response(err.message, { status: 401 })
+        }
+        throw err
+      }
+    }
+
+    const body = await req.text()
+    await bot.processBody(body)
+    return Response.json({})
+  }
+
+  if (req.method === 'GET' && url.pathname === '/health') {
+    return Response.json({ status: 'ok' })
+  }
+
+  return new Response('Not Found', { status: 404 })
+})
+
+console.log(`Listening on http://localhost:${PORT}/api/messages`)


### PR DESCRIPTION
## Changes

### CD Workflow - JSR publish improvements
- Moved JSR publish to a **dedicated job** (instead of a step in the \
ode\ job)
- Added explicit \id-token: write\ permission for OIDC authentication with JSR
- Syncs the version from \package.json\ (set by \
bgv-setversion\) into \jsr.json\ before publishing
- Job depends on \
ode\ job succeeding first (ensures npm publish passed)
- Only runs on release (\is_release == 'true'\)

### Deno sample
- New \
ode/samples/deno/\ with a zero-dependency echo bot using \Deno.serve()\
- Imports \@botas/core\ directly from JSR (\jsr:@botas/core\)
- Includes README with usage instructions

Fixes the \ctorNotScopeMember\ error by isolating the JSR job with proper OIDC permissions.