### PR TITLE
fix: move JSR publish to jsr-publish.yml for OIDC auth

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -135,49 +135,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  jsr:
-    needs: [changes, node]
-    if: needs.changes.outputs.is_release == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: node/package-lock.json
-
-      - name: Install dependencies
-        working-directory: node
-        run: npm ci
-
-      - name: Set package version
-        working-directory: node/packages/botas-core
-        run: npx nbgv-setversion
-
-      - name: Sync version to jsr.json
-        working-directory: node/packages/botas-core
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "Publishing @botas/core@${VERSION} to JSR"
-          node -e "const f='jsr.json'; const j=JSON.parse(require('fs').readFileSync(f,'utf8')); j.version=process.argv[1]; require('fs').writeFileSync(f, JSON.stringify(j, null, 2)+'\n')" "$VERSION"
-          cat jsr.json
-
-      - name: Publish to JSR
-        working-directory: node/packages/botas-core
-        run: npx jsr publish --allow-dirty
 
   python:
     needs: changes

--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -1,0 +1,53 @@
+name: JSR Publish
+
+on:
+  workflow_run:
+    workflows: ["CD"]
+    types: [completed]
+    branches: [release/**]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: node/package-lock.json
+
+      - name: Install dependencies
+        working-directory: node
+        run: npm ci
+
+      - name: Set package version
+        working-directory: node/packages/botas-core
+        run: npx nbgv-setversion
+
+      - name: Sync version to jsr.json
+        working-directory: node/packages/botas-core
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Publishing @botas/core@${VERSION} to JSR"
+          node -e "const f='jsr.json'; const j=JSON.parse(require('fs').readFileSync(f,'utf8')); j.version=process.argv[1]; require('fs').writeFileSync(f, JSON.stringify(j, null, 2)+'\n')" "$VERSION"
+          cat jsr.json
+
+      - name: Publish to JSR
+        working-directory: node/packages/botas-core
+        run: npx jsr publish --allow-dirty


### PR DESCRIPTION
## Root Cause

JSR requires the workflow file to be named **exactly** \.github/workflows/jsr-publish.yml\ for OIDC token verification to work. The previous setup had JSR publish as a job inside \CD.yml\, which JSR doesn't recognize as an authorized caller.

## Changes

- **Removed** the \jsr\ job from \CD.yml\
- **Created** \.github/workflows/jsr-publish.yml\ — a dedicated workflow that:
  - Triggers after CD completes successfully on release branches
  - Also supports \workflow_dispatch\ for manual runs
  - Has \id-token: write\ permission for OIDC
  - Syncs the version from \package.json\ → \jsr.json\ before publishing

This should fix the \ctorNotScopeMember\ error.