### PR TITLE
fix: link jsr-publish as reusable workflow from CD

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -135,6 +135,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  jsr:
+    needs: [changes, node]
+    if: needs.changes.outputs.is_release == 'true'
+    uses: ./.github/workflows/jsr-publish.yml
 
   python:
     needs: changes

--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -1,10 +1,7 @@
 name: JSR Publish
 
 on:
-  workflow_run:
-    workflows: ["CD"]
-    types: [completed]
-    branches: [release/**]
+  workflow_call: {}
   workflow_dispatch: {}
 
 permissions:
@@ -14,7 +11,6 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
Follow-up to #299.

- Converts \jsr-publish.yml\ to a **reusable workflow** (\workflow_call\) so CD can invoke it directly
- Adds a \jsr\ job in \CD.yml\ that calls \./.github/workflows/jsr-publish.yml\ after the \
ode\ job succeeds (release only)
- Still supports \workflow_dispatch\ for manual runs

This keeps the JSR publish visible in the CD pipeline while maintaining the required filename for OIDC auth.