### PR TITLE
fix(cd): remove versioned docs logic from deploy workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -373,22 +373,6 @@ jobs:
       - name: Generate API docs
         run: cd docs-site && bash generate-api-docs.sh
 
-      - name: Update versions.json
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          cd docs-site
-          # Update current version and add to versions list if not already present
-          node -e "
-            const fs = require('fs');
-            const data = JSON.parse(fs.readFileSync('versions.json', 'utf-8'));
-            data.current = '$VERSION';
-            if (!data.versions.includes('$VERSION')) {
-              data.versions.unshift('$VERSION');
-            }
-            fs.writeFileSync('versions.json', JSON.stringify(data, null, 2) + '\n');
-          "
-          cat versions.json
-
       - name: Build VitePress site
         run: cd docs-site && npm run docs:build
 
@@ -418,33 +402,8 @@ jobs:
             git commit -m "Initialize gh-pages branch"
           fi
 
-          # Save existing versions.json from gh-pages before overwriting
-          if [ -f versions.json ]; then
-            cp versions.json /home/runner/existing-versions.json
-            echo "📋 Found existing versions.json on gh-pages"
-          fi
-
-          # Preserve existing versioned directories
-          # Copy new build to root (latest)
-          rsync -a --exclude='v[0-9]*' --delete /home/runner/docs-build/ ./
-          
-          # Copy new build to versioned directory
-          mkdir -p "v${VERSION}"
-          rsync -a /home/runner/docs-build/ "v${VERSION}/"
-
-          # Merge existing versions into the new versions.json
-          if [ -f /home/runner/existing-versions.json ]; then
-            node -e "
-              const fs = require('fs');
-              const existing = JSON.parse(fs.readFileSync('/home/runner/existing-versions.json', 'utf-8'));
-              const current = JSON.parse(fs.readFileSync('versions.json', 'utf-8'));
-              const merged = [...new Set([...current.versions, ...existing.versions])];
-              merged.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
-              current.versions = merged;
-              fs.writeFileSync('versions.json', JSON.stringify(current, null, 2) + '\n');
-            "
-            echo "✅ Merged versions.json: $(cat versions.json)"
-          fi
+          # Copy new build to root (latest), preserving .git
+          rsync -a --delete /home/runner/docs-build/ ./
 
           # Stage and commit
           git add -A


### PR DESCRIPTION
The version selector feature is on hold. This removes the \ersions.json\ update step (which caused the ENOENT failure in [this run](https://github.com/rido-min/botas/actions/runs/25227681116/job/73975511033#step:10:49)) and the versioned directory copy/merge logic from the gh-pages deploy step.

**Changes:**
- Removed the 'Update versions.json' step that tried to read a non-existent file
- Removed versioned directory copy (\\/\) and versions merge logic from the deploy step
- Deploy now simply copies the build output to gh-pages root