### PR TITLE
Remove redundant CI push trigger and update documentation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -195,3 +195,9 @@ l
 - **OtelBot created:** New `dotnet/samples/OtelBot/` with Program.cs, OtelBot.csproj, and README.md. Demonstrates `AddSource("botas")`, OTLP + console exporters, with comments for Aspire Dashboard and Azure Monitor.
 - **Solution updated:** Added OtelBot.csproj to `dotnet/Botas.slnx`.
 - **Key insight:** Samples should be single-concern. EchoBot = minimal hello-world; OtelBot = observability showcase.
+
+### ActivitySource Test Isolation Fix (2026-07-17)
+- **Problem:** `StartActivity_ReturnsNull_WhenNoListenerConfigured` failed in CI because xUnit runs test classes in parallel. Other classes (`CoreSpanTests`, `AuthAndConversationClientSpanTests`) register global `ActivityListener`s that leak across parallel test classes.
+- **Fix:** Added `[Collection("ActivitySource")]` attribute to all three test classes that interact with the static `ActivitySource`. This serializes their execution, preventing listener interference.
+- **Key insight:** `System.Diagnostics.ActivitySource` and `ActivityListener` are global/static. Any test asserting "no listener" behavior must be serialized against tests that register listeners. xUnit's `[Collection]` is the correct mechanism.
+- **All 115 tests pass.**

--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -58,6 +58,10 @@ Implemented comprehensive CI/CD fixes based on security audit findings. All crit
 3. Always add version comment: `@<sha> # <version>`
 4. Update all workflows simultaneously to maintain consistency
 
+### Removed Redundant push Trigger from CI (2026-04-16)
+
+Main branch has protection rules preventing direct pushes, so the `push` trigger only fires after a PR merges. This is redundant since CI already ran validation during the PR. Removed the `push` trigger from `.github/workflows/CI.yml`, leaving only the `pull_request` trigger targeting main. Eliminates unnecessary CI runs on merged PRs.
+
 All changes verified and passing validation checks.
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->

--- a/node/packages/botas-core/jsr.json
+++ b/node/packages/botas-core/jsr.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "exports": "./src/index.ts",
   "publish": {
-    "include": ["src/**/*.ts", "README.md"],
+    "include": ["src/**/*.ts", "README.md", "package.json"],
     "exclude": ["src/**/*.spec.ts"]
   }
 }


### PR DESCRIPTION
This pull request primarily removes the redundant push trigger from the CI workflow, ensuring that CI only runs on pull requests targeting the main branch. This change eliminates unnecessary CI runs on merged PRs, as main is already protected from direct pushes. Additionally, there is a minor update to the publish configuration for the `botas-core` package.

CI/CD Improvements:
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L4-L5): Removed the `push` trigger so that CI only runs for `pull_request` events on the `main` branch, preventing redundant runs after PR merges.
* [`.squad/agents/bender/history.md`](diffhunk://#diff-8f439cd7e5def95ae4bbc9e010affd3e54df797cbc35edced235d5a95ccd37e0R61-R64): Documented the rationale for removing the redundant push trigger, referencing main branch protection rules and the elimination of unnecessary CI runs.

Package Publishing:
* [`node/packages/botas-core/jsr.json`](diffhunk://#diff-3bdb00c6159affc4a9b8f132081a9ed6bdc3fb56f41d5ee16e252dd2daf0313aL7-R7): Added `package.json` to the publish include list to ensure it is available in published artifacts.

Testing Insights (Documentation Only):
* [`.squad/agents/amy/history.md`](diffhunk://#diff-f82906afa4f9d88d1bedf7d6b11c88c2d19d8a6a37ce65507747682780b10b64R198-R203): Added a note about test isolation for `ActivitySource` in .NET tests, explaining the use of xUnit `[Collection]` to prevent parallel test interference.