### PR TITLE
Remove redundant push trigger from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -48,6 +48,10 @@ Implemented comprehensive CI/CD fixes based on security audit findings. All crit
 **Documentation:**
 - Added clear comment to build-all.sh indicating it's build-only (tests run separately in CI)
 
+### Removed Redundant push Trigger from CI (2026-04-16)
+
+Main branch has protection rules preventing direct pushes, so the `push` trigger only fires after a PR merges. This is redundant since CI already ran validation during the PR. Removed the `push` trigger from `.github/workflows/CI.yml`, leaving only the `pull_request` trigger targeting main. Eliminates unnecessary CI runs on merged PRs.
+
 **Squad Workflows:**
 - Updated all squad-*.yml workflows from checkout@v4 to SHA-pinned v6 for consistency
 - Reviewed token fallback pattern in squad-heartbeat.yml (working as designed)


### PR DESCRIPTION
The push trigger only fires after PR merges, which already ran CI. Main branch protection rules prevent direct pushes, so this trigger is redundant. Removing it eliminates unnecessary CI runs.