### PR TITLE
fix: add test isolation for ActivitySource tests

### DIFF
--- a/dotnet/tests/Botas.Tests/AuthAndConversationClientSpanTests.cs
+++ b/dotnet/tests/Botas.Tests/AuthAndConversationClientSpanTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 
 namespace Botas.Tests;
 
+[Collection("ActivitySource")]
 public class AuthAndConversationClientSpanTests : IDisposable
 {
     private ActivityListener? _listener;

--- a/dotnet/tests/Botas.Tests/BotActivitySourceTests.cs
+++ b/dotnet/tests/Botas.Tests/BotActivitySourceTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 
 namespace Botas.Tests;
 
+[Collection("ActivitySource")]
 public class BotActivitySourceTests
 {
     [Fact]

--- a/dotnet/tests/Botas.Tests/CoreSpanTests.cs
+++ b/dotnet/tests/Botas.Tests/CoreSpanTests.cs
@@ -12,6 +12,7 @@ using System.Text.Json;
 
 namespace Botas.Tests;
 
+[Collection("ActivitySource")]
 public class CoreSpanTests : IAsyncLifetime
 {
     private WebApplication? _app;


### PR DESCRIPTION
## Problem

The CD workflow fails on .NET tests because \BotActivitySourceTests.StartActivity_ReturnsNull_WhenNoListenerConfigured\ asserts null but gets a non-null Activity. This happens because xUnit runs test classes in parallel, and \ActivityListener\ instances registered in \CoreSpanTests\ or \AuthAndConversationClientSpanTests\ leak into \BotActivitySourceTests\.

## Fix

Add \[Collection("ActivitySource")]\ to all three test classes that register \ActivityListener\:
- \BotActivitySourceTests\
- \CoreSpanTests\  
- \AuthAndConversationClientSpanTests\

This serializes their execution, preventing listener state leakage.

## Verification

All 115 tests pass locally after the fix.

## Note

The JSR publish failure (\ctorNotScopeMember\) is a separate issue — the GitHub Actions OIDC token needs to be authorized for the \@botas\ scope on jsr.io. That requires manual config in the JSR dashboard.