### PR TITLE
fix: decouple JSR publish from CD for OIDC auth

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -135,11 +135,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  jsr:
-    needs: [changes, node]
-    if: needs.changes.outputs.is_release == 'true'
-    uses: ./.github/workflows/jsr-publish.yml
-
   python:
     needs: changes
     if: needs.changes.outputs.python == 'true'

--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -1,7 +1,9 @@
 name: JSR Publish
 
 on:
-  workflow_call: {}
+  workflow_run:
+    workflows: ["CD"]
+    types: [completed]
   workflow_dispatch: {}
 
 permissions:
@@ -10,6 +12,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Problem
JSR publish fails with \ctorNotScopeMember\ when called as a reusable workflow from CD.yml. The OIDC token identity doesn't match what jsr.io expects for the \@botas\ scope.

## Fix
- Removed the \jsr\ job (reusable workflow call) from CD.yml
- Changed \jsr-publish.yml\ trigger from \workflow_call\ to \workflow_run\ — it now fires independently after CD completes successfully on a release tag
- Manual dispatch via \workflow_dispatch\ still works

This gives \jsr-publish.yml\ its own workflow identity for OIDC token generation, matching what jsr.io expects.

## Note
You still need to verify that the \@botas\ scope on jsr.io is linked to this repo's GitHub Actions OIDC. If the \ctorNotScopeMember\ error persists after this change, the scope needs to be linked in jsr.io settings.