### PR TITLE
fix: docs deploy rsync corruption and improve CI coverage

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -398,7 +398,7 @@ jobs:
           fi
 
           # Copy new build to root (latest), preserving .git
-          rsync -a --delete /home/runner/docs-build/ ./
+          rsync -a --delete --exclude='.git' /home/runner/docs-build/ ./
 
           # Stage and commit
           git add -A

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,7 @@ jobs:
               - 'python/**'
             docs:
               - 'docs-site/**'
+              - '.github/workflows/CD.yml'
 
   docs:
     needs: changes
@@ -52,8 +53,21 @@ jobs:
           cache: 'npm'
           cache-dependency-path: docs-site/package-lock.json
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Generate API docs
+        run: bash generate-api-docs.sh
 
       - name: Build
         run: npm run docs:build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,6 +45,8 @@ jobs:
         working-directory: docs-site
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6


### PR DESCRIPTION
## Problem

The CD docs job failed ([run #25261266865](https://github.com/rido-min/botas/actions/runs/25261266865/job/74068973262)) with:
\\\
fatal: not a git repository (or any of the parent directories): .git
\\\

**Root cause**: \sync -a --delete\ was deleting the \.git\ directory when deploying to gh-pages, because \--delete\ removes everything in the destination not present in the source.

This only manifested when the \gh-pages\ branch didn't exist yet (orphan branch creation path).

## Why it wasn't caught before

1. CI only validated \docs:build\, not the deploy script logic
2. CI docs job was path-filtered to \docs-site/**\ only — workflow file changes didn't trigger it
3. CI didn't run \generate-api-docs.sh\ (parity gap with CD)

## Fixes

1. **\CD.yml\**: Add \--exclude='.git'\ to rsync command
2. **\CI.yml\**: Trigger docs job when \CD.yml\ changes
3. **\CI.yml\**: Add API docs generation step to match CD pipeline