### PR TITLE
docs: sync docs with latest OTel and JSR/Deno changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![CD](https://github.com/rido-min/botas/actions/workflows/CD.yml/badge.svg)](https://github.com/rido-min/botas/actions/workflows/CD.yml)
 [![NuGet](https://img.shields.io/nuget/v/Botas.svg)](https://www.nuget.org/packages/Botas/)
 [![npm](https://img.shields.io/npm/v/botas-core.svg)](https://www.npmjs.com/package/botas-core)
+[![JSR](https://jsr.io/badges/@botas/core)](https://jsr.io/@botas/core)
 [![PyPI](https://img.shields.io/pypi/v/botas.svg)](https://pypi.org/project/botas/)
 
 A lightweight, multi-language library for building [Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/) bots in **.NET**, **Node.js**, and **Python**.
@@ -54,6 +55,32 @@ app.start()
 
 // Run:
 // cd node && npm ci && npm run build && npx tsx --env-file ../.env samples/echo-bot/index.ts
+```
+
+```typescript [Deno]
+// Install (via JSR — no build step):
+// deno add jsr:@botas/core
+
+import { BotApplication, validateBotToken } from '@botas/core'
+
+const bot = new BotApplication()
+
+bot.on('message', async (ctx) => {
+  await ctx.send(`You said: ${ctx.activity.text}`)
+})
+
+Deno.serve({ port: 3978 }, async (req) => {
+  if (new URL(req.url).pathname === '/api/messages') {
+    const body = await req.json()
+    await validateBotToken(req.headers.get('authorization') ?? '')
+    await bot.processBody(body)
+    return new Response('{}')
+  }
+  return new Response('OK')
+})
+
+// Run:
+// cd node/samples/deno && deno run --allow-net --allow-env --allow-read --allow-sys main.ts
 ```
 
 ```python [Python]

--- a/docs-site/getting-started.md
+++ b/docs-site/getting-started.md
@@ -58,6 +58,32 @@ app.start()
 // npx tsx --env-file .env botapp.ts
 ```
 
+```typescript [Deno]
+// Install:
+// deno add jsr:@botas/core
+
+import { BotApplication, validateBotToken } from '@botas/core'
+
+const bot = new BotApplication()
+
+bot.on('message', async (ctx) => {
+  await ctx.send(`You said: ${ctx.activity.text}`)
+})
+
+Deno.serve({ port: 3978 }, async (req) => {
+  if (new URL(req.url).pathname === '/api/messages') {
+    const body = await req.json()
+    await validateBotToken(req.headers.get('authorization') ?? '')
+    await bot.processBody(body)
+    return new Response('{}')
+  }
+  return new Response('OK')
+})
+
+// Run:
+// deno run --allow-net --allow-env main.ts
+```
+
 ```python [Python]
 # Install:
 # uv add botas botas-fastapi

--- a/docs-site/languages/nodejs.md
+++ b/docs-site/languages/nodejs.md
@@ -21,6 +21,20 @@ npm install botas-express          # recommended — includes botas-core
 npm install botas-core
 ```
 
+### Deno / JSR
+
+The core library is also published on [JSR](https://jsr.io/@botas/core) as **`@botas/core`** for use with Deno (v2+) — no build step or bundler needed:
+
+```bash
+deno add jsr:@botas/core
+```
+
+```ts
+import { BotApplication, validateBotToken } from '@botas/core'
+```
+
+See the [Deno sample](https://github.com/rido-min/botas/tree/main/node/samples/deno) for a complete example using `Deno.serve()` with no framework.
+
 If you're working inside the monorepo, the workspace already links the package:
 
 ```bash

--- a/docs-site/logging.md
+++ b/docs-site/logging.md
@@ -146,6 +146,13 @@ import { configure, noopLogger } from 'botas-core'
 
 configure(noopLogger)       // ← silence all logs (useful in tests)
 ```
+
+```typescript [OTel logger]
+import { configure, consoleLogger, createOtelLogger } from 'botas-core'
+
+// Use OTel logger when available, fall back to console
+configure(createOtelLogger() ?? consoleLogger)
+```
 :::
 
 ### Custom logger (pino, winston, etc.)

--- a/docs-site/observability.md
+++ b/docs-site/observability.md
@@ -58,27 +58,32 @@ await bot.RunAsync();
 ```
 
 ```typescript [Node.js]
-// index.ts — MUST be called before any imports
+// otel-setup.ts — MUST be imported before any other modules
 import { useMicrosoftOpenTelemetry } from "@microsoft/opentelemetry";
 
-// Enable OpenTelemetry first
 useMicrosoftOpenTelemetry({
-  instrumentations: {
-    http: true,
-    azureSdk: true,
+  instrumentationOptions: {
+    http: {
+      enabled: true,
+    },
+    azureSdk: {
+      enabled: true,
+    },
   },
 });
+```
 
-// Now import the bot
+```typescript [Node.js — index.ts]
+import "./otel-setup.js";
+
 import { BotApp } from "botas-express";
 
-const bot = new BotApp();
-bot.on("message", async (ctx) => {
+const app = new BotApp();
+app.on("message", async (ctx) => {
   await ctx.send(`Echo: ${ctx.activity.text}`);
 });
 
-bot.start();
-app.listen(process.env.PORT || 3978);
+app.start();
 ```
 
 ```python [Python]
@@ -226,9 +231,9 @@ Most observability features work the same across .NET, Node.js, and Python. Here
 |---------|------|---------|--------|
 | **Setup location** | After `CreateBuilder()`, before `Build()` | **Before any imports** at top of entry point | **Before any imports** at top of entry point |
 | **Configuration method** | `ExportTarget` enum flags | Env vars only | `enable_azure_monitor=True`, `enable_console=True`, or env vars |
-| **Rate limiting** | Not supported | `tracesPerSecond: 100` in options | Not supported |
+| **Rate limiting** | Not supported | Not supported | Not supported |
 | **Disable signals** | Not supported (all enabled) | Not supported (all enabled) | `disable_tracing=True`, `disable_metrics=True`, `disable_logging=True` |
-| **Sampling config** | `OTEL_TRACES_SAMPLER_ARG` env var | `samplingRatio: 0.1` in options or env var | `OTEL_TRACES_SAMPLER_ARG` env var |
+| **Sampling config** | `OTEL_TRACES_SAMPLER_ARG` env var | `OTEL_TRACES_SAMPLER_ARG` env var | `OTEL_TRACES_SAMPLER_ARG` env var |
 
 For full language-specific details, see the [Observability spec](https://github.com/rido-min/botas/blob/main/specs/observability.md).
 

--- a/docs-site/teams-features.md
+++ b/docs-site/teams-features.md
@@ -37,6 +37,8 @@ await ctx.SendAsync(reply, ct);
 ```
 
 ```typescript [Node.js]
+// npm: import from 'botas-core'
+// Deno/JSR: import from '@botas/core'
 import { TeamsActivityBuilder } from 'botas-core'
 
 const sender = ctx.activity.from

--- a/specs/README.md
+++ b/specs/README.md
@@ -47,7 +47,7 @@ See [User Stories](./user-stories.md) for detailed behavioral scenarios.
 | Concern | dotnet | node | python |
 |---------|--------|------|--------|
 | Simple bot API | `BotApp.Create()` + `app.On()` | `BotApp` (botas-express) | `BotApp()` |
-| Web framework | ASP.NET Core (built-in) | Express (via botas-express) or manual | aiohttp (built-in) or manual FastAPI |
+| Web framework | ASP.NET Core (built-in) | Express (via botas-express) or Deno (via `@botas/core` from JSR) | aiohttp (built-in) or manual FastAPI |
 | Handler registration | `app.On(type, handler)` receiving `TurnContext` | `app.on(type, handler)` receiving `TurnContext` | `@app.on(type)` decorator or `app.on(type, handler)` receiving `TurnContext` |
 | CatchAll handler | `OnActivity` property | `onActivity` property | `on_activity` property |
 | HTTP integration | `ProcessAsync(HttpContext)` | `processAsync(req, res)` or `processBody(body)` | `process_body(body)` |


### PR DESCRIPTION
## Summary

Docs bugbash — updates all documentation to reflect recent releases:

### OTel observability (already shipped)
- **observability.md**: Fixed Node.js example to use \instrumentationOptions\ (not \instrumentations\), split into \otel-setup.ts\ + \index.ts\ matching the actual sample, removed nonexistent \	racesPerSecond\/\samplingRatio\ options from table

### JSR/Deno publishing (already shipped)
- **README.md**: Added Deno tab with \@botas/core\ example, added JSR badge
- **languages/nodejs.md**: Added Deno/JSR installation section with \deno add\ command
- **getting-started.md**: Added Deno quickstart tab
- **teams-features.md**: Clarified npm vs JSR import paths
- **specs/README.md**: Noted Deno/JSR as web framework option

### OTel logger export
- **logging.md**: Added \createOtelLogger()\ fallback pattern example

### Verified
- \
pm run docs:build\ passes with **no warnings**