### PR TITLE
docs: Update public docs to mention coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 A lightweight, multi-language library for building [Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/) bots in **.NET**, **Node.js**, and **Python**.
 
+> 🤖 **This project is a GitHub Copilot Squads experiment.** All code, documentation, and samples have been produced by GitHub Copilot agents working as a cross-functional team. Meet the [Squad](#-the-squad) below!
+
 📖 **[Full Documentation](https://rido-min.github.io/botas/)** · [Setup Guide](https://rido-min.github.io/botas/setup) · [Authentication](https://rido-min.github.io/botas/authentication)
 
 ---
@@ -135,3 +137,29 @@ Open the `installLink` from the Teams CLI output in your browser to add the bot 
 | **Authentication** | [Two-auth model deep dive](https://rido-min.github.io/botas/authentication) |
 | **Architecture** | [Turn pipeline, auth flow, middleware](specs/architecture.md) |
 | **Contributing** | [Build & test, CI, adding a new language](specs/contributing.md) |
+
+---
+
+## 🚀 The Squad
+
+This project was built by **GitHub Copilot** agents working as a cross-functional team — each bringing their own expertise, opinions, and inexplicable obsession with proper error handling.
+
+| Agent | Role | Superpower | Where They're From |
+|-------|------|-----------|-------------------|
+| **Leela** | 🧠 Product & Architecture Lead | Making hard decisions so others don't have to | Planet Omicron Persei 8 |
+| **Amy** | 🔷 .NET Developer | C# elegance and unwavering consistency | Her parents' basement |
+| **Fry** | 📘 Node.js Developer | TypeScript sophistication with a 20th-century attitude | 2 centuries in the past |
+| **Hermes** | 🐍 Python Developer | Pythonic grace under pressure | Jamaica, mon |
+| **Kif** | 📚 Developer Relations | Docs that don't require reading the source code | Leela's shadow (literally) |
+| **Nibbler** | 🧪 E2E Tester & QA | Finds bugs nobody knew existed | Dimension X |
+| **Bender** | 🔧 DevOps & Infrastructure | Robots helping robots | Puerto Sigada |
+
+**Why agents?** Because only an AI could maintain behavior parity across three languages and still have time for a coffee break. Plus, they don't complain in standups (yet).
+
+---
+
+## 📝 License
+
+Licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+Built with ❤️ by the [Copilot Squad](https://github.com/rido-min/botas/team/squad).

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -98,3 +98,29 @@ app.start()
 - 📘 [.NET API Reference](/api/generated/dotnet/api/Botas.html) — Generated with DocFX
 - 📗 Node.js API Reference: [botas-core](/api/generated/nodejs/botas-core/index.html) · [botas-express](/api/generated/nodejs/botas-express/index.html) — Generated with TypeDoc
 - 📙 Python API Reference: [botas](/api/generated/python/botas/index.html) · [botas-fastapi](/api/generated/python/botas-fastapi/index.html) — Generated with pdoc
+
+---
+
+## 🚀 The Squad
+
+This project was built by **GitHub Copilot** agents working as a cross-functional team — each bringing their own expertise, opinions, and inexplicable obsession with proper error handling.
+
+| Agent | Role | Superpower | Where They're From |
+|-------|------|-----------|-------------------|
+| **Leela** | 🧠 Product & Architecture Lead | Making hard decisions so others don't have to | Planet Omicron Persei 8 |
+| **Amy** | 🔷 .NET Developer | C# elegance and unwavering consistency | Her parents' basement |
+| **Fry** | 📘 Node.js Developer | TypeScript sophistication with a 20th-century attitude | 2 centuries in the past |
+| **Hermes** | 🐍 Python Developer | Pythonic grace under pressure | Jamaica, mon |
+| **Kif** | 📚 Developer Relations | Docs that don't require reading the source code | Leela's shadow (literally) |
+| **Nibbler** | 🧪 E2E Tester & QA | Finds bugs nobody knew existed | Dimension X |
+| **Bender** | 🔧 DevOps & Infrastructure | Robots helping robots | Puerto Sigada |
+
+**Why agents?** Because only an AI could maintain behavior parity across three languages and still have time for a coffee break. Plus, they don't complain in standups (yet).
+
+---
+
+## 📝 License
+
+Licensed under the MIT License. See [LICENSE](../LICENSE) for details.
+
+Built with ❤️ by the [Copilot Squad](https://github.com/rido-min/botas#-the-squad).

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -40,6 +40,8 @@ features:
 
 Build bots that work with Microsoft Teams using the language and web framework you already know.
 
+> 🤖 **Built by Copilot Squads:** This project is an experiment in AI-powered software development. All code, documentation, and samples were created by GitHub Copilot agents working as a cross-functional team. Learn about [the Squad](https://github.com/rido-min/botas#-the-squad).
+
 ## Echo Bot in 3 Languages
 
 ::: code-group

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -98,3 +98,25 @@ app.start()
 - 📘 [.NET API Reference](/api/generated/dotnet/api/Botas.html) — Generated with DocFX
 - 📗 Node.js API Reference: [botas-core](/api/generated/nodejs/botas-core/index.html) · [botas-express](/api/generated/nodejs/botas-express/index.html) — Generated with TypeDoc
 - 📙 Python API Reference: [botas](/api/generated/python/botas/index.html) · [botas-fastapi](/api/generated/python/botas-fastapi/index.html) — Generated with pdoc
+
+---
+
+## 🚀 The Squad
+
+This project was built by **GitHub Copilot** agents working as a cross-functional team — each bringing their own expertise, opinions, and inexplicable obsession with proper error handling.
+
+| Agent | Role | Superpower | Where They're From |
+|-------|------|-----------|-------------------|
+| **Leela** | 🧠 Product & Architecture Lead | Making hard decisions so others don't have to | Planet Omicron Persei 8 |
+| **Amy** | 🔷 .NET Developer | C# elegance and unwavering consistency | Her parents' basement |
+| **Fry** | 📘 Node.js Developer | TypeScript sophistication with a 20th-century attitude | 2 centuries in the past |
+| **Hermes** | 🐍 Python Developer | Pythonic grace under pressure | Jamaica, mon |
+| **Kif** | 📚 Developer Relations | Docs that don't require reading the source code | Leela's shadow (literally) |
+| **Nibbler** | 🧪 E2E Tester & QA | Finds bugs nobody knew existed | Dimension X |
+| **Bender** | 🔧 DevOps & Infrastructure | Robots helping robots | Puerto Sigada |
+
+**Why agents?** Because only an AI could maintain behavior parity across three languages and still have time for a coffee break. Plus, they don't complain in standups (yet).
+
+---
+
+Built with ❤️ by the [Copilot Squad](https://github.com/rido-min/botas/team/squad).


### PR DESCRIPTION
## Issue
Closes #312

## Changes
- Updated project description to indicate this is a GitHub Copilot Squads experiment
- Introduced the Squad members (Leela, Amy, Fry, Hermes, Kif, Nibbler, Bender) with a fun table
- Added a footer section celebrating the Squad
- Updated docs-site home page with Squad announcement  
- Used a humorous tone inspired by Futurama to match the Squad theme

All code, documentation, and samples have been produced by GitHub Copilot using Squads.