### PR TITLE
feat(python): implement agentic identities (Entra Agent ID)

### DIFF
--- a/python/packages/botas/src/botas/__init__.py
+++ b/python/packages/botas/src/botas/__init__.py
@@ -15,6 +15,7 @@ See the `specs/` directory for protocol details and the README for quickstart gu
 """
 
 from botas._version import __version__
+from botas.agent_token_client import AgenticIdentity, AgentTokenClient
 from botas.bot_application import BotApplication, BotHandlerException, InvokeResponse
 from botas.bot_auth import BotAuthError, validate_bot_token
 from botas.conversation_client import ConversationClient
@@ -51,6 +52,8 @@ from botas.turn_context import TurnContext
 
 __all__ = [
     "ActivityType",
+    "AgenticIdentity",
+    "AgentTokenClient",
     "Attachment",
     "BotApplication",
     "BotApplicationOptions",

--- a/python/packages/botas/src/botas/agent_token_client.py
+++ b/python/packages/botas/src/botas/agent_token_client.py
@@ -1,0 +1,190 @@
+"""Entra Agent ID token acquisition via raw HTTP (3-step token exchange).
+
+Acquires user-delegated tokens without MSAL dependency, for structural parity
+with the .NET and Node.js implementations.
+
+See: https://learn.microsoft.com/en-us/entra/agent-id/identity-platform/agent-user-oauth-flow
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+_logger = logging.getLogger(__name__)
+
+_FMI_EXCHANGE_SCOPE = "api://AzureADTokenExchange/.default"
+_JWT_BEARER_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+_CACHE_TTL_SECONDS = 300  # 5 minutes
+
+
+@dataclass
+class AgenticIdentity:
+    """Value object representing agentic identity fields from a Conversation.
+
+    When present, indicates outbound calls should use the agentic token flow
+    (user-delegated token via Entra Agent ID) instead of standard client credentials.
+
+    Attributes:
+        agentic_app_id: The Agent Identity's application ID (dual-purpose: fmi_path in step 1, client_id in steps 2-3).
+        agentic_user_id: The user OID the agent is acting as.
+        agentic_app_blueprint_id: The Blueprint's application ID.
+    """
+
+    agentic_app_id: str
+    agentic_user_id: str
+    agentic_app_blueprint_id: Optional[str] = None
+
+    @staticmethod
+    def from_conversation(conversation: object | None) -> Optional["AgenticIdentity"]:
+        """Extract an AgenticIdentity from a Conversation if agentic fields are present.
+
+        Args:
+            conversation: A Conversation object (or any object with agentic_app_id/agentic_user_id attrs).
+
+        Returns:
+            An AgenticIdentity instance, or None if required fields are missing.
+        """
+        if conversation is None:
+            return None
+
+        app_id = getattr(conversation, "agentic_app_id", None)
+        user_id = getattr(conversation, "agentic_user_id", None)
+
+        if not app_id or not user_id:
+            return None
+
+        return AgenticIdentity(
+            agentic_app_id=app_id,
+            agentic_user_id=user_id,
+            agentic_app_blueprint_id=getattr(conversation, "agentic_app_blueprint_id", None),
+        )
+
+
+@dataclass
+class _CachedToken:
+    access_token: str
+    expires_at: float
+
+
+class AgentTokenClient:
+    """Acquires user-delegated tokens via the Entra Agent ID 3-step token exchange.
+
+    Uses raw HTTP calls (httpx) - no MSAL dependency - for structural parity
+    with the .NET and Node.js implementations.
+
+    The flow:
+        Step 1: Blueprint acquires FMI exchange token (T1) using fmi_path.
+        Step 2: Agent Identity acquires impersonation token (T2) using T1 as client_assertion.
+        Step 3: Agent Identity acquires resource token via user_fic grant with T1 + T2.
+
+    Args:
+        tenant_id: Azure AD tenant ID.
+        client_id: Blueprint application (client) ID.
+        client_secret: Blueprint client secret.
+    """
+
+    def __init__(self, tenant_id: str, client_id: str, client_secret: str) -> None:
+        self._token_endpoint = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._cache: dict[str, _CachedToken] = {}
+        self._http = httpx.AsyncClient()
+
+    async def get_agent_user_token(self, agent_identity_id: str, agent_user_oid: str, scope: str) -> str:
+        """Acquire a Bearer token for an agent acting as a specific user.
+
+        Implements the 3-step agent user identity (user_fic) flow with built-in caching.
+
+        Args:
+            agent_identity_id: The Agent Identity ID (dual-purpose: fmi_path in step 1, client_id in steps 2-3).
+            agent_user_oid: The user OID to impersonate.
+            scope: Target resource scope (e.g. ``https://api.botframework.com/.default``).
+
+        Returns:
+            A string in the format ``"Bearer {token}"``.
+
+        Raises:
+            RuntimeError: When the token endpoint returns an error.
+        """
+        cache_key = f"{agent_identity_id}:{agent_user_oid}:{scope}"
+        cached = self._cache.get(cache_key)
+
+        if cached and time.time() < cached.expires_at:
+            return f"Bearer {cached.access_token}"
+
+        t1 = await self._step1_get_fmi_exchange_token(agent_identity_id)
+        t2 = await self._step2_get_impersonation_token(agent_identity_id, t1)
+        resource_token = await self._step3_get_resource_token(agent_identity_id, t1, t2, agent_user_oid, scope)
+
+        self._cache[cache_key] = _CachedToken(
+            access_token=resource_token,
+            expires_at=time.time() + _CACHE_TTL_SECONDS,
+        )
+
+        return f"Bearer {resource_token}"
+
+    async def _step1_get_fmi_exchange_token(self, agent_identity_id: str) -> str:
+        """Step 1: Blueprint acquires FMI exchange token (T1) via fmi_path extension."""
+        return await self._post_token_request(
+            {
+                "grant_type": "client_credentials",
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+                "scope": _FMI_EXCHANGE_SCOPE,
+                "fmi_path": agent_identity_id,
+            }
+        )
+
+    async def _step2_get_impersonation_token(self, agent_identity_id: str, t1: str) -> str:
+        """Step 2: Agent Identity acquires impersonation token (T2) using T1 as client_assertion."""
+        return await self._post_token_request(
+            {
+                "grant_type": "client_credentials",
+                "client_id": agent_identity_id,
+                "client_assertion_type": _JWT_BEARER_TYPE,
+                "client_assertion": t1,
+                "scope": _FMI_EXCHANGE_SCOPE,
+            }
+        )
+
+    async def _step3_get_resource_token(
+        self, agent_identity_id: str, t1: str, t2: str, agent_user_oid: str, scope: str
+    ) -> str:
+        """Step 3: Agent Identity acquires resource token via user_fic grant."""
+        return await self._post_token_request(
+            {
+                "grant_type": "user_fic",
+                "client_id": agent_identity_id,
+                "client_assertion_type": _JWT_BEARER_TYPE,
+                "client_assertion": t1,
+                "user_federated_identity_credential": t2,
+                "user_id": agent_user_oid,
+                "requested_token_use": "on_behalf_of",
+                "scope": scope,
+            }
+        )
+
+    async def _post_token_request(self, params: dict[str, str]) -> str:
+        resp = await self._http.post(
+            self._token_endpoint,
+            data=params,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        data = resp.json()
+
+        if not resp.is_success or "error" in data:
+            error = data.get("error", "unknown_error")
+            desc = data.get("error_description", "")
+            _logger.error("Agentic token request failed (HTTP %d): %s - %s", resp.status_code, error, desc)
+            raise RuntimeError(f"Agentic token request failed (HTTP {resp.status_code}): {error} - {desc}")
+
+        return data["access_token"]
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._http.aclose()

--- a/python/packages/botas/src/botas/bot_application.py
+++ b/python/packages/botas/src/botas/bot_application.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
 
+from botas.agent_token_client import AgentTokenClient
 from botas.conversation_client import ConversationClient
 from botas.core_activity import CoreActivity, ResourceResponse
 from botas.i_turn_middleware import TurnMiddleware
@@ -143,7 +144,16 @@ class BotApplication:
         """
         self._token_manager = TokenManager(options)
         token_provider = self._token_manager.get_bot_token
-        self.conversation_client = ConversationClient(token_provider)
+
+        # Create AgentTokenClient when credentials are available
+        agent_token_client: AgentTokenClient | None = None
+        client_id = options.client_id or os.environ.get("CLIENT_ID")
+        client_secret = options.client_secret or os.environ.get("CLIENT_SECRET")
+        tenant_id = options.tenant_id or os.environ.get("TENANT_ID")
+        if client_id and client_secret and tenant_id:
+            agent_token_client = AgentTokenClient(tenant_id, client_id, client_secret)
+
+        self.conversation_client = ConversationClient(token_provider, agent_token_client)
         self._middlewares: list[TurnMiddleware] = []
         self._handlers: dict[str, _ActivityHandler] = {}
         self._invoke_handlers: dict[str, _InvokeActivityHandler] = {}

--- a/python/packages/botas/src/botas/bot_http_client.py
+++ b/python/packages/botas/src/botas/bot_http_client.py
@@ -98,12 +98,15 @@ class _BotHttpClient:
         url: str,
         body: Any,
         options: _BotRequestOptions,
+        extra_headers: Optional[dict[str, str]] = None,
     ) -> Any:
         # Warn if using unencrypted HTTP (production should use HTTPS)
         if url.startswith("http://"):
             _logger.warning("Outbound request uses insecure HTTP: %s", url)
 
         headers = await self._auth_headers()
+        if extra_headers:
+            headers.update(extra_headers)
         resp = await self._client.request(
             method,
             url,
@@ -155,6 +158,7 @@ class _BotHttpClient:
         endpoint: str,
         body: Any,
         options: Optional[_BotRequestOptions] = None,
+        extra_headers: Optional[dict[str, str]] = None,
     ) -> Any:
         """Send a POST request to the Bot Service REST API.
 
@@ -163,6 +167,7 @@ class _BotHttpClient:
             endpoint: API path.
             body: JSON-serializable request body.
             options: Request options for error handling behaviour.
+            extra_headers: Additional headers to merge (overrides default auth).
 
         Returns:
             Parsed JSON response, or ``None`` for empty/204 responses.
@@ -172,7 +177,7 @@ class _BotHttpClient:
         """
         opts = options or _BotRequestOptions()
         url = self._build_url(base_url, endpoint, None)
-        return await self._send("POST", url, body, opts)
+        return await self._send("POST", url, body, opts, extra_headers)
 
     async def put(
         self,

--- a/python/packages/botas/src/botas/conversation_client.py
+++ b/python/packages/botas/src/botas/conversation_client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any, Optional, Union
 from urllib.parse import quote
 
+from botas.agent_token_client import AgenticIdentity, AgentTokenClient
 from botas.bot_http_client import TokenProvider, _BotHttpClient, _BotRequestOptions
 from botas.core_activity import (
     ChannelAccount,
@@ -47,17 +48,28 @@ class ConversationClient:
 
     All methods accept a ``service_url`` and ``conversation_id`` to target
     the correct channel endpoint.  Authentication is handled automatically
-    via the injected :class:`TokenProvider`.
+    via the injected :class:`TokenProvider`.  Supports conditional agentic
+    token flow when an :class:`AgentTokenClient` is configured and the
+    outgoing activity carries agentic identity fields.
     """
 
-    def __init__(self, get_token: Optional[TokenProvider] = None) -> None:
+    def __init__(
+        self,
+        get_token: Optional[TokenProvider] = None,
+        agent_token_client: Optional[AgentTokenClient] = None,
+        agent_scope: str = "https://api.botframework.com/.default",
+    ) -> None:
         """Initialise the conversation client.
 
         Args:
             get_token: Async callable that supplies a bearer token.
                 When ``None``, requests are unauthenticated.
+            agent_token_client: Optional agentic token client for user-delegated token acquisition.
+            agent_scope: The scope to request when using the agentic token flow.
         """
         self._http = _BotHttpClient(get_token)
+        self._agent_token_client = agent_token_client
+        self._agent_scope = agent_scope
 
     async def send_activity_async(
         self,
@@ -114,11 +126,26 @@ class ConversationClient:
     ) -> Optional[ResourceResponse]:
         """Execute the actual HTTP POST for sending an activity."""
         endpoint = f"/v3/conversations/{_encode_conversation_id(conversation_id)}/activities"
+
+        # Conditional agentic auth: override Authorization when agentic identity is present
+        extra_headers: Optional[dict[str, str]] = None
+        conversation = getattr(activity, "conversation", None)
+        agentic_identity = AgenticIdentity.from_conversation(conversation)
+        if agentic_identity and self._agent_token_client:
+            token = await self._agent_token_client.get_agent_user_token(
+                agentic_identity.agentic_app_id,
+                agentic_identity.agentic_user_id,
+                self._agent_scope,
+            )
+            token_value = token.removeprefix("Bearer ")
+            extra_headers = {"Authorization": f"Bearer {token_value}"}
+
         data = await self._http.post(
             service_url,
             endpoint,
             _serialize(activity),
             _BotRequestOptions(operation_description="send activity"),
+            extra_headers,
         )
         return ResourceResponse.model_validate(data) if data else None
 

--- a/python/packages/botas/src/botas/core_activity.py
+++ b/python/packages/botas/src/botas/core_activity.py
@@ -72,9 +72,15 @@ class Conversation(_CamelModel):
 
     Attributes:
         id: Unique conversation identifier on the channel.
+        agentic_app_id: The Agent Identity's application ID, set by the channel when agentic identity should be used.
+        agentic_user_id: The user OID the agent is acting as, set by the channel for user-delegated token flows.
+        agentic_app_blueprint_id: The Blueprint's application ID, set by the channel.
     """
 
     id: str
+    agentic_app_id: Optional[str] = None
+    agentic_user_id: Optional[str] = None
+    agentic_app_blueprint_id: Optional[str] = None
 
 
 class Entity(_CamelModel):

--- a/python/packages/botas/tests/test_agent_token_client.py
+++ b/python/packages/botas/tests/test_agent_token_client.py
@@ -1,0 +1,247 @@
+"""Tests for AgentTokenClient and AgenticIdentity."""
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from botas.agent_token_client import AgenticIdentity, AgentTokenClient
+
+
+class TestAgenticIdentity:
+    """Tests for the AgenticIdentity.from_conversation factory."""
+
+    def test_returns_identity_when_fields_present(self):
+        class FakeConv:
+            agentic_app_id = "agent-app-id"
+            agentic_user_id = "user-oid"
+            agentic_app_blueprint_id = "blueprint-id"
+
+        identity = AgenticIdentity.from_conversation(FakeConv())
+        assert identity is not None
+        assert identity.agentic_app_id == "agent-app-id"
+        assert identity.agentic_user_id == "user-oid"
+        assert identity.agentic_app_blueprint_id == "blueprint-id"
+
+    def test_returns_none_when_conversation_is_none(self):
+        assert AgenticIdentity.from_conversation(None) is None
+
+    def test_returns_none_when_app_id_missing(self):
+        class FakeConv:
+            agentic_app_id = None
+            agentic_user_id = "user-oid"
+
+        assert AgenticIdentity.from_conversation(FakeConv()) is None
+
+    def test_returns_none_when_user_id_missing(self):
+        class FakeConv:
+            agentic_app_id = "agent-app-id"
+            agentic_user_id = None
+
+        assert AgenticIdentity.from_conversation(FakeConv()) is None
+
+    def test_returns_none_when_fields_absent(self):
+        class FakeConv:
+            pass
+
+        assert AgenticIdentity.from_conversation(FakeConv()) is None
+
+    def test_blueprint_id_is_optional(self):
+        class FakeConv:
+            agentic_app_id = "agent-app-id"
+            agentic_user_id = "user-oid"
+
+        identity = AgenticIdentity.from_conversation(FakeConv())
+        assert identity is not None
+        assert identity.agentic_app_blueprint_id is None
+
+
+class TestAgentTokenClient:
+    """Tests for the 3-step token exchange flow."""
+
+    @pytest.fixture
+    def client(self):
+        return AgentTokenClient("tenant-123", "blueprint-client-id", "blueprint-secret")
+
+    def _mock_response(self, token: str) -> httpx.Response:
+        return httpx.Response(200, json={"access_token": token})
+
+    def _mock_error_response(self) -> httpx.Response:
+        return httpx.Response(400, json={"error": "invalid_grant", "error_description": "bad request"})
+
+    @pytest.mark.asyncio
+    async def test_three_step_flow_success(self, client: AgentTokenClient):
+        """Verify the 3-step exchange calls the token endpoint 3 times with correct params."""
+        responses = [
+            self._mock_response("t1-fmi-token"),
+            self._mock_response("t2-impersonation-token"),
+            self._mock_response("final-resource-token"),
+        ]
+        call_index = 0
+
+        async def mock_post(url, *, data, headers):
+            nonlocal call_index
+            resp = responses[call_index]
+            call_index += 1
+            return resp
+
+        client._http = AsyncMock()
+        client._http.post = mock_post
+
+        result = await client.get_agent_user_token("agent-id", "user-oid", "https://api.botframework.com/.default")
+
+        assert result == "Bearer final-resource-token"
+        assert call_index == 3
+
+    @pytest.mark.asyncio
+    async def test_step1_params(self, client: AgentTokenClient):
+        """Verify step 1 sends correct params (client_credentials + fmi_path)."""
+        captured_params: list[dict] = []
+
+        async def mock_post(url, *, data, headers):
+            captured_params.append(data)
+            return self._mock_response(f"token-{len(captured_params)}")
+
+        client._http = AsyncMock()
+        client._http.post = mock_post
+
+        await client.get_agent_user_token("agent-id", "user-oid", "scope")
+
+        step1 = captured_params[0]
+        assert step1["grant_type"] == "client_credentials"
+        assert step1["client_id"] == "blueprint-client-id"
+        assert step1["client_secret"] == "blueprint-secret"
+        assert step1["fmi_path"] == "agent-id"
+        assert step1["scope"] == "api://AzureADTokenExchange/.default"
+
+    @pytest.mark.asyncio
+    async def test_step2_params(self, client: AgentTokenClient):
+        """Verify step 2 sends T1 as client_assertion with agent_identity_id as client_id."""
+        captured_params: list[dict] = []
+
+        async def mock_post(url, *, data, headers):
+            captured_params.append(data)
+            return self._mock_response(f"token-{len(captured_params)}")
+
+        client._http = AsyncMock()
+        client._http.post = mock_post
+
+        await client.get_agent_user_token("agent-id", "user-oid", "scope")
+
+        step2 = captured_params[1]
+        assert step2["grant_type"] == "client_credentials"
+        assert step2["client_id"] == "agent-id"
+        assert step2["client_assertion"] == "token-1"
+        assert step2["client_assertion_type"] == "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+    @pytest.mark.asyncio
+    async def test_step3_params(self, client: AgentTokenClient):
+        """Verify step 3 sends user_fic grant with T1, T2, and user_id."""
+        captured_params: list[dict] = []
+
+        async def mock_post(url, *, data, headers):
+            captured_params.append(data)
+            return self._mock_response(f"token-{len(captured_params)}")
+
+        client._http = AsyncMock()
+        client._http.post = mock_post
+
+        await client.get_agent_user_token("agent-id", "user-oid", "https://resource/.default")
+
+        step3 = captured_params[2]
+        assert step3["grant_type"] == "user_fic"
+        assert step3["client_id"] == "agent-id"
+        assert step3["client_assertion"] == "token-1"
+        assert step3["user_federated_identity_credential"] == "token-2"
+        assert step3["user_id"] == "user-oid"
+        assert step3["requested_token_use"] == "on_behalf_of"
+        assert step3["scope"] == "https://resource/.default"
+
+    @pytest.mark.asyncio
+    async def test_caching_skips_http_calls(self, client: AgentTokenClient):
+        """Verify cached tokens are returned without making HTTP calls."""
+        call_count = 0
+
+        async def mock_post(url, *, data, headers):
+            nonlocal call_count
+            call_count += 1
+            return self._mock_response(f"token-{call_count}")
+
+        client._http = AsyncMock()
+        client._http.post = mock_post
+
+        result1 = await client.get_agent_user_token("agent-id", "user-oid", "scope")
+        result2 = await client.get_agent_user_token("agent-id", "user-oid", "scope")
+
+        assert result1 == result2
+        assert call_count == 3  # Only 3 calls from first invocation
+
+    @pytest.mark.asyncio
+    async def test_different_cache_keys_make_separate_calls(self, client: AgentTokenClient):
+        """Verify different agent/user combinations get separate tokens."""
+        call_count = 0
+
+        async def mock_post(url, *, data, headers):
+            nonlocal call_count
+            call_count += 1
+            return self._mock_response(f"token-{call_count}")
+
+        client._http = AsyncMock()
+        client._http.post = mock_post
+
+        await client.get_agent_user_token("agent-1", "user-1", "scope")
+        await client.get_agent_user_token("agent-2", "user-2", "scope")
+
+        assert call_count == 6  # 3 calls per unique combination
+
+    @pytest.mark.asyncio
+    async def test_error_raises_runtime_error(self, client: AgentTokenClient):
+        """Verify HTTP errors raise RuntimeError with details."""
+
+        async def mock_post(url, *, data, headers):
+            return self._mock_error_response()
+
+        client._http = AsyncMock()
+        client._http.post = mock_post
+
+        with pytest.raises(RuntimeError, match="invalid_grant"):
+            await client.get_agent_user_token("agent-id", "user-oid", "scope")
+
+    @pytest.mark.asyncio
+    async def test_expired_cache_refetches(self, client: AgentTokenClient):
+        """Verify expired cache entries trigger new token requests."""
+        call_count = 0
+
+        async def mock_post(url, *, data, headers):
+            nonlocal call_count
+            call_count += 1
+            return self._mock_response(f"token-{call_count}")
+
+        client._http = AsyncMock()
+        client._http.post = mock_post
+
+        await client.get_agent_user_token("agent-id", "user-oid", "scope")
+        assert call_count == 3
+
+        # Expire the cache
+        for entry in client._cache.values():
+            entry.expires_at = 0
+
+        await client.get_agent_user_token("agent-id", "user-oid", "scope")
+        assert call_count == 6  # 3 more calls for refetch
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_url(self, client: AgentTokenClient):
+        """Verify the token endpoint uses the correct tenant."""
+        captured_urls: list[str] = []
+
+        async def mock_post(url, *, data, headers):
+            captured_urls.append(url)
+            return self._mock_response("token")
+
+        client._http = AsyncMock()
+        client._http.post = mock_post
+
+        await client.get_agent_user_token("agent-id", "user-oid", "scope")
+
+        assert all(url == "https://login.microsoftonline.com/tenant-123/oauth2/v2.0/token" for url in captured_urls)


### PR DESCRIPTION
## Summary

Implements Entra Agent ID (agentic identities) support for the Python port using raw HTTP token exchange, matching the .NET (#316) and Node.js (#317) implementations.

## Changes

- **AgentTokenClient**: 3-step token exchange (FMI → client_assertion → user_fic) with in-memory TTL caching
- **AgenticIdentity**: Dataclass with \rom_conversation()\ factory method
- **Conversation model**: Added \gentic_app_id\, \gentic_user_id\, \gentic_app_blueprint_id\ fields
- **BotHttpClient**: Added \xtra_headers\ support for per-request auth override
- **ConversationClient**: Conditional agentic auth when AgenticIdentity present
- **BotApplication**: Auto-creates AgentTokenClient when credentials available

## Tests

15 unit tests covering:
- AgenticIdentity extraction (6 tests)
- 3-step flow parameter correctness (4 tests)
- Token caching behavior (3 tests)
- Error handling and endpoint URL (2 tests)

## Stack

- Base: #317 (Node.js implementation)
- Spec: PR #315 (\specs/future/agentic-identities.md\)