### PR TITLE
ci: add npm run typecheck to node CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Test
         run: npm test --workspaces --if-present
 


### PR DESCRIPTION
## Summary

Adds TypeScript type checking to the Node.js CI job.

## Changes
- Add "Typecheck" step to the node CI job
- Runs AFTER Build step and BEFORE Test step  
- Uses `npm run typecheck` to validate types across all node samples

## Context
This builds on PR #331 (feat/node-samples-typecheck) which added the workspace-level typecheck script.

## Notes
- Minimal change: single step addition to the workflow
- No impact on other jobs or workflows
