### PR TITLE
fix(node): re-throw errors from processAsync after writing 500

### DIFF
--- a/node/packages/botas-core/README.md
+++ b/node/packages/botas-core/README.md
@@ -37,7 +37,7 @@ bot.on('message', async (ctx) => {
 
 const server = express()
 server.post('/api/messages', botAuthExpress(), (req, res) => {
-  bot.processAsync(req, res)
+  bot.processAsync(req, res).catch(console.error)
 })
 
 server.listen(3978)

--- a/node/packages/botas-core/src/bot-application.spec.ts
+++ b/node/packages/botas-core/src/bot-application.spec.ts
@@ -412,7 +412,9 @@ describe('BotApplication', () => {
         body: { statusCode: 200, type: 'application/vnd.microsoft.card.adaptive' }
       }))
 
-      const server = createServer((req, res) => { bot.processAsync(req, res) })
+      const server = createServer((req, res) => {
+        bot.processAsync(req, res).catch(() => {})
+      })
       await new Promise<void>((resolve) => server.listen(0, resolve))
       const addr = server.address() as { port: number }
 
@@ -432,7 +434,9 @@ describe('BotApplication', () => {
       const { createServer } = await import('node:http')
       const bot = new BotApplication()
 
-      const server = createServer((req, res) => { bot.processAsync(req, res) })
+      const server = createServer((req, res) => {
+        bot.processAsync(req, res).catch(() => {})
+      })
       await new Promise<void>((resolve) => server.listen(0, resolve))
       const addr = server.address() as { port: number }
 
@@ -452,7 +456,9 @@ describe('BotApplication', () => {
       const { createServer } = await import('node:http')
       const bot = new BotApplication()
 
-      const server = createServer((req, res) => { bot.processAsync(req, res) })
+      const server = createServer((req, res) => {
+        bot.processAsync(req, res).catch(() => {})
+      })
       await new Promise<void>((resolve) => server.listen(0, resolve))
       const addr = server.address() as { port: number }
 
@@ -466,6 +472,82 @@ describe('BotApplication', () => {
 
       assert.equal(response.status, 400)
       assert.match(json.error, /serviceUrl/)
+    })
+
+    it('processAsync re-throws BotHandlerException after writing 500', async () => {
+      const { createServer } = await import('node:http')
+      const bot = new BotApplication()
+      const cause = new Error('handler exploded')
+      bot.on('message', async () => { throw cause })
+
+      let rethrown: unknown
+      const server = createServer((req, res) => {
+        bot.processAsync(req, res).catch((err) => { rethrown = err })
+      })
+      await new Promise<void>((resolve) => server.listen(0, resolve))
+      const addr = server.address() as { port: number }
+
+      const response = await fetch(`http://localhost:${addr.port}/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: makeBody()
+      })
+      const text = await response.text()
+      server.close()
+
+      assert.equal(response.status, 500)
+      assert.equal(text, 'Internal server error')
+      assert.ok(rethrown instanceof BotHandlerException)
+      assert.equal((rethrown as BotHandlerException).cause, cause)
+    })
+
+    it('processAsync does NOT re-throw for 400 validation errors', async () => {
+      const { createServer } = await import('node:http')
+      const bot = new BotApplication()
+
+      let rethrown: unknown = 'NOT_CALLED'
+      const server = createServer((req, res) => {
+        bot.processAsync(req, res).catch((err) => { rethrown = err })
+      })
+      await new Promise<void>((resolve) => server.listen(0, resolve))
+      const addr = server.address() as { port: number }
+
+      const response = await fetch(`http://localhost:${addr.port}/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ conversation: { id: 'c' } })
+      })
+      server.close()
+
+      assert.equal(response.status, 400)
+      assert.equal(rethrown, 'NOT_CALLED')
+    })
+
+    it('processAsync does NOT re-throw for 413 body too large errors', async () => {
+      const { createServer } = await import('node:http')
+      const bot = new BotApplication()
+
+      let rethrown: unknown = 'NOT_CALLED'
+      const server = createServer((req, res) => {
+        bot.processAsync(req, res).catch((err) => { rethrown = err })
+      })
+      await new Promise<void>((resolve) => server.listen(0, resolve))
+      const addr = server.address() as { port: number }
+
+      // Send a body larger than the 1MB limit
+      try {
+        const response = await fetch(`http://localhost:${addr.port}/`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: 'x'.repeat(1_100_000)
+        })
+        assert.equal(response.status, 413)
+      } catch {
+        // req.destroy() may cause a fetch error — that's acceptable
+      }
+      server.close()
+
+      assert.equal(rethrown, 'NOT_CALLED')
     })
   })
 })

--- a/node/packages/botas-core/src/bot-application.ts
+++ b/node/packages/botas-core/src/bot-application.ts
@@ -171,7 +171,7 @@ export class BotApplication {
    *
    * @param req - Node.js incoming HTTP request.
    * @param res - Node.js server response to write the result to.
-   * @throws Never — errors are caught and written to `res` as HTTP status codes.
+   * @throws {BotHandlerException} Re-thrown after writing 500 response, if a handler or middleware threw.
    */
   async processAsync (req: IncomingMessage, res: ServerResponse): Promise<void> {
     getLogger().debug('Start processing HTTP request for activity')
@@ -199,6 +199,7 @@ export class BotApplication {
           res.writeHead(500)
         }
         res.end('Internal server error')
+        throw err
       }
     }
   }

--- a/node/packages/botas-express/src/bot-app.ts
+++ b/node/packages/botas-express/src/bot-app.ts
@@ -115,11 +115,15 @@ export class BotApp {
 
     if (authEnabled) {
       app.post(path, botAuthExpress(this.bot.options.clientId), (req, res) => {
-        this.bot.processAsync(req, res)
+        this.bot.processAsync(req, res).catch((err) => {
+          console.error('Bot handler error:', err instanceof Error ? err.message : String(err))
+        })
       })
     } else {
       app.post(path, (req, res) => {
-        this.bot.processAsync(req, res)
+        this.bot.processAsync(req, res).catch((err) => {
+          console.error('Bot handler error:', err instanceof Error ? err.message : String(err))
+        })
       })
     }
 

--- a/node/samples/02-advanced-hosting-express/index.ts
+++ b/node/samples/02-advanced-hosting-express/index.ts
@@ -33,7 +33,9 @@ server.use((req, _res, next) => {
 })
 
 server.post('/api/messages', botAuthExpress(), (req, res) => {
-  void bot.processAsync(req, res)
+  bot.processAsync(req, res).catch((err) => {
+    console.error('Bot handler error:', err instanceof Error ? err.message : String(err))
+  })
 })
 
 server.get('/', (_req, res) => res.send(`Bot ${bot.options.clientId} is running. Send messages to /api/messages`))


### PR DESCRIPTION
## Summary

\processAsync\ previously swallowed handler/middleware errors silently after writing the HTTP 500 response. Now it re-throws the error after sending the response, giving callers visibility into turn-level failures. This matches Python's behavior where errors propagate to the caller.

### Changes

1. **\ot-application.ts\** — \processAsync\ catch block now re-throws after writing 500 (but NOT for 400/413 validation errors). Updated JSDoc accordingly.
2. **\ot-app.ts\ (botas-express)** — Added \.catch()\ to fire-and-forget \processAsync\ calls.
3. **\