### PR TITLE
docs(specs/reference): fix API drift in language reference docs

### DIFF
--- a/specs/reference/dotnet.md
+++ b/specs/reference/dotnet.md
@@ -30,7 +30,11 @@ app.Run();
 | `BotApp.Create(args, routePath?)` | Create app with CLI args and optional custom route path (default: `"api/messages"`) |
 | `app.On(activityType, handler)` | Register handler for activity type |
 | `app.OnInvoke(name, handler)` | Register handler for invoke activity by name |
-| `app.Run()` | Start HTTP server |
+| `app.Use(middleware)` | Register a middleware in the turn pipeline |
+| `app.Run()` | Build and start HTTP server (blocking) |
+| `app.Bot` | Underlying `BotApplication` instance (available after `Run()`) |
+| `app.Builder` | Underlying `WebApplicationBuilder` for advanced configuration |
+| `app.Services` | `IServiceCollection` for registering additional services before `Run()` |
 
 ---
 

--- a/specs/reference/node.md
+++ b/specs/reference/node.md
@@ -26,11 +26,15 @@ app.start()
 
 ### Configuration
 
-| Method | Description |
+| Method / Property | Description |
 |--------|-------------|
-| `new BotApp()` | Create app |
-| `app.on(activityType, handler)` | Register handler |
-| `app.start()` | Start Express server |
+| `new BotApp(options?)` | Create app. `options` extends `BotApplicationOptions` with `port`, `path`, and `auth` fields. |
+| `app.on(activityType, handler)` | Register a handler for an activity type |
+| `app.onInvoke(name, handler)` | Register a handler for an invoke activity by its `activity.name` sub-type |
+| `app.use(middleware)` | Register a middleware in the turn pipeline |
+| `app.sendActivityAsync(serviceUrl, conversationId, activity)` | Proactively send an activity to a conversation |
+| `app.start()` | Start the Express server. Returns the underlying `http.Server`. |
+| `app.bot` | The underlying `BotApplication` instance |
 
 ---
 

--- a/specs/reference/python.md
+++ b/specs/reference/python.md
@@ -26,12 +26,16 @@ app.start()
 
 ### Configuration
 
-| Method | Description |
+| Method / Attribute | Description |
 |--------|-------------|
-| `BotApp()` | Create app |
-| `@app.on(activity_type)` | Register handler (decorator) |
-| `app.on(activity_type, handler)` | Register handler (method) |
-| `app.start()` | Start server |
+| `BotApp(options?, *, port?, path?, auth?)` | Create app. `options` is a `BotApplicationOptions`; `port` defaults to env `PORT` or `3978`, `path` defaults to `"/api/messages"`, `auth` defaults to enabled when a `CLIENT_ID` is configured. |
+| `@app.on(activity_type)` | Register a handler for an activity type (decorator) |
+| `app.on(activity_type, handler)` | Register a handler for an activity type (method) |
+| `@app.on_invoke(name)` / `app.on_invoke(name, handler)` | Register a handler for an invoke activity by its `activity.name` sub-type |
+| `app.use(middleware)` | Register a middleware in the turn pipeline |
+| `await app.send_activity_async(service_url, conversation_id, activity)` | Proactively send an activity to a conversation |
+| `app.start()` | Build the FastAPI app and start Uvicorn (blocking) |
+| `app.bot` | The underlying `BotApplication` instance |
 
 ---
 
@@ -50,8 +54,11 @@ class BotApplication:
     async def process_body(self, body: str) -> InvokeResponse | None
     
     async def send_activity_async(
-        self, service_url: str, conversation_id: str, activity: dict
-    ) -> ResourceResponse
+        self,
+        service_url: str,
+        conversation_id: str,
+        activity: CoreActivity | dict,
+    ) -> ResourceResponse | None
     
     def use(self, middleware: TurnMiddleware) -> "BotApplication"
 ```
@@ -302,7 +309,7 @@ async def messages_handler(request):
 | Concern | Python Behavior |
 |---------|-----------------|
 | Simple bot API | `BotApp()` (botas-fastapi) |
-| Web framework | aiohttp (built-in) or FastAPI (botas-fastapi) |
+| Web framework | Framework-agnostic core (`process_body`); FastAPI host via `botas-fastapi` |
 | Handler registration | `@app.on(type)` decorator or `app.on(type, handler)` |
 | CatchAll handler | `on_activity` property |
 | HTTP integration | `process_body(body)` |
@@ -334,7 +341,7 @@ async def on_message(ctx):
 @app.post("/api/messages")
 async def messages(
     request: Request,
-    auth: None = Depends(bot_auth_dependency)
+    auth: None = Depends(bot_auth_dependency())
 ):
     body = await request.body()
     await bot.process_body(body.decode())


### PR DESCRIPTION
Audit of `specs/reference/{dotnet,node,python}.md` against the actual source code in `dotnet/src/Botas/`, `node/packages/botas-{core,express}/src/`, and `python/packages/botas{,-fastapi}/src/`. The reference docs were largely accurate — only the simplified-host (`BotApp`) tables and a few Python snippets had drifted.

## Fixes

### .NET (`specs/reference/dotnet.md`)
- `BotApp` configuration table was missing `app.Use(middleware)`, `app.Bot`, `app.Builder`, and `app.Services` (all are public on `BotApp.cs`).

### Node.js (`specs/reference/node.md`)
- `BotApp` (`botas-express`) configuration table was missing `onInvoke`, `use`, `sendActivityAsync`, the `bot` property, and the `BotAppOptions` constructor parameter — all defined in `node/packages/botas-express/src/bot-app.ts`.

### Python (`specs/reference/python.md`)
- `BotApp` (`botas-fastapi`) configuration table was missing `on_invoke`, `use`, `send_activity_async`, the `bot` attribute, and the `port`/`path`/`auth` keyword arguments — all defined in `python/packages/botas-fastapi/src/botas_fastapi/bot_app.py`.
- `BotApplication.send_activity_async` signature was incorrect — actual code accepts `Union[CoreActivity, dict[str, Any]]` and returns `Optional[ResourceResponse]`.
- 'Web framework' row claimed an aiohttp built-in that does not exist; the core is framework-agnostic and FastAPI is provided by `botas-fastapi`.
- `bot_auth_dependency` example used `Depends(bot_auth_dependency)` but the function is a factory that must be invoked: `Depends(bot_auth_dependency())`.

No code changes; docs only.