### PR TITLE
feat(dotnet): expose public ConversationClient and add CreateConversationAsync

### DIFF
--- a/dotnet/src/Botas/BotApplication.cs
+++ b/dotnet/src/Botas/BotApplication.cs
@@ -105,6 +105,18 @@ public class BotApplication
     internal TurnMiddleware MiddleWare => _turnMiddleware;
 
     /// <summary>
+    /// The <see cref="Botas.ConversationClient"/> resolved from DI for the current request.
+    /// </summary>
+    /// <remarks>
+    /// This property is populated by <see cref="ProcessAsync"/> on each incoming request and
+    /// returns <c>null</c> until the first request has been processed. It is intended for
+    /// advanced proactive scenarios that need direct access to the lower-level
+    /// <see cref="Botas.ConversationClient"/> API (e.g. <see cref="ConversationClient.CreateConversationAsync"/>)
+    /// from within an activity handler or middleware.
+    /// </remarks>
+    public ConversationClient? ConversationClient => _conversationClient;
+
+    /// <summary>
     /// Optional catch-all activity handler. When set, bypasses all per-type handlers registered via <see cref="On"/>
     /// and receives every activity regardless of type.
     /// </summary>

--- a/dotnet/src/Botas/ConversationClient.cs
+++ b/dotnet/src/Botas/ConversationClient.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 
 namespace Botas;
 
@@ -86,6 +87,95 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
         {
             caughtException = ex;
             BotMeter.OutboundErrors.Add(1, new KeyValuePair<string, object?>("operation", "sendActivity"));
+            throw;
+        }
+        finally
+        {
+            if (caughtException is not null)
+            {
+                ccActivity?.SetStatus(ActivityStatusCode.Error, caughtException.Message);
+            }
+            ccActivity?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Creates a new conversation on the specified channel.
+    /// Used for proactive scenarios where the bot starts a thread instead of replying to one.
+    /// The service URL is validated against the SSRF allowlist before sending.
+    /// </summary>
+    /// <param name="serviceUrl">The Bot Service service URL for the target channel.</param>
+    /// <param name="parameters">Conversation creation parameters (members, topic, initial activity, etc.).</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="ConversationResourceResponse"/> with the new conversation's ID and
+    /// service URL on success, or <c>null</c> if the service returned an empty body.
+    /// </returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="serviceUrl"/> is missing or not in the allowed list.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameters"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the Bot Service service returns a non-success status code.</exception>
+    public async Task<ConversationResourceResponse?> CreateConversationAsync(
+        string serviceUrl,
+        ConversationParameters parameters,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        ValidateServiceUrl(serviceUrl);
+
+        BotMeter.OutboundCalls.Add(1, new KeyValuePair<string, object?>("operation", "createConversation"));
+
+        var ccActivity = BotActivitySource.Source.StartActivity("botas.conversation_client");
+        ccActivity?.SetTag("operation", "createConversation");
+        ccActivity?.SetTag("service.url", serviceUrl);
+
+        Exception? caughtException = null;
+        try
+        {
+            string baseUrl = serviceUrl!.EndsWith('/') ? serviceUrl : serviceUrl + "/";
+            string url = $"{baseUrl}v3/conversations";
+            string body = JsonSerializer.Serialize(parameters, CoreActivity.DefaultJsonOptions);
+
+            HttpRequestMessage request = new(HttpMethod.Post, url)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("\n POST {Url} \n\n", url);
+                logger.LogTrace("Body: \n {Body} \n", body);
+            }
+
+            using HttpResponseMessage resp = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            string respContent = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            if (resp.IsSuccessStatusCode)
+            {
+                logger.LogTrace("Response Status {Status}, content {Content}", resp.StatusCode, respContent);
+                if (string.IsNullOrWhiteSpace(respContent))
+                {
+                    return null;
+                }
+                ConversationResourceResponse? result = JsonSerializer.Deserialize<ConversationResourceResponse>(
+                    respContent, CoreActivity.DefaultJsonOptions);
+                if (result?.Id is not null)
+                {
+                    ccActivity?.SetTag("conversation.id", result.Id);
+                }
+                return result;
+            }
+
+            // Log full error details server-side for diagnostics
+            logger.LogError("Error creating conversation at {Url}: {Status} - {Content}", url, resp.StatusCode, respContent);
+
+            // Return only a generic error message to the caller to avoid exposing internal service details
+            throw new InvalidOperationException($"Error creating conversation: {resp.StatusCode}");
+        }
+        catch (Exception ex)
+        {
+            caughtException = ex;
+            BotMeter.OutboundErrors.Add(1, new KeyValuePair<string, object?>("operation", "createConversation"));
             throw;
         }
         finally

--- a/dotnet/src/Botas/ConversationParameters.cs
+++ b/dotnet/src/Botas/ConversationParameters.cs
@@ -1,0 +1,65 @@
+using System.Text.Json.Serialization;
+
+namespace Botas;
+
+/// <summary>
+/// Parameters used to create a new conversation via
+/// <see cref="ConversationClient.CreateConversationAsync"/>.
+/// Mirrors the Bot Framework <c>ConversationParameters</c> object.
+/// </summary>
+public class ConversationParameters
+{
+    /// <summary>Whether to create a group conversation.</summary>
+    [JsonPropertyName("isGroup")]
+    public bool? IsGroup { get; set; }
+
+    /// <summary>Bot account that will participate in the conversation.</summary>
+    [JsonPropertyName("bot")]
+    public ChannelAccount? Bot { get; set; }
+
+    /// <summary>Initial member list for the conversation.</summary>
+    [JsonPropertyName("members")]
+    public IList<ChannelAccount>? Members { get; set; }
+
+    /// <summary>Optional topic name for the conversation.</summary>
+    [JsonPropertyName("topicName")]
+    public string? TopicName { get; set; }
+
+    /// <summary>Tenant ID, when required by the channel (e.g. Microsoft Teams).</summary>
+    [JsonPropertyName("tenantId")]
+    public string? TenantId { get; set; }
+
+    /// <summary>Initial activity to post when the conversation is created.</summary>
+    [JsonPropertyName("activity")]
+    public CoreActivity? Activity { get; set; }
+
+    /// <summary>Channel-specific data payload.</summary>
+    [JsonPropertyName("channelData")]
+    public object? ChannelData { get; set; }
+
+    /// <summary>Extension data dictionary preserving unknown JSON properties on round-trip.</summary>
+    [JsonExtensionData]
+    public Dictionary<string, object?> Properties { get; set; } = [];
+}
+
+/// <summary>
+/// Response returned by the Bot Framework after creating a new conversation.
+/// </summary>
+public class ConversationResourceResponse
+{
+    /// <summary>Identifier of the newly created conversation.</summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>Service URL where the conversation is hosted.</summary>
+    [JsonPropertyName("serviceUrl")]
+    public string? ServiceUrl { get; set; }
+
+    /// <summary>ID of the activity that bootstrapped the conversation, when available.</summary>
+    [JsonPropertyName("activityId")]
+    public string? ActivityId { get; set; }
+
+    /// <summary>Extension data dictionary preserving unknown JSON properties on round-trip.</summary>
+    [JsonExtensionData]
+    public Dictionary<string, object?> Properties { get; set; } = [];
+}

--- a/dotnet/tests/Botas.Tests/PublicConversationClientTests.cs
+++ b/dotnet/tests/Botas.Tests/PublicConversationClientTests.cs
@@ -1,0 +1,217 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace Botas.Tests;
+
+/// <summary>
+/// Tests for #342 — public ConversationClient access and CreateConversationAsync parity
+/// with the Node.js and Python implementations.
+/// </summary>
+public class PublicConversationClientTests : IAsyncLifetime
+{
+    private WebApplication? _app;
+    private HttpClient? _client;
+    private BotApplication? _bot;
+    private ConversationClient? _registeredClient;
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddHttpClient("BotFrameworkNoAuth", client => client.Timeout = TimeSpan.FromSeconds(30));
+        builder.Services.AddKeyedScoped<ConversationClient>("AzureAd", (sp, _) =>
+        {
+            _registeredClient = new ConversationClient(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient("BotFrameworkNoAuth"),
+                NullLoggerFactory.Instance.CreateLogger<ConversationClient>());
+            return _registeredClient;
+        });
+
+        _app = builder.Build();
+
+        _bot = new BotApplication(new ConfigurationBuilder().Build(), NullLogger<BotApplication>.Instance);
+        _bot.On("message", (ctx, ct) => Task.CompletedTask);
+
+        _app.MapPost("/api/messages", async (HttpContext httpContext, CancellationToken ct) =>
+        {
+            await _bot.ProcessAsync(httpContext, ct);
+        });
+
+        await _app.StartAsync();
+        _client = _app.GetTestClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_app != null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public void ConversationClient_IsNull_BeforeAnyRequest()
+    {
+        var bot = new BotApplication();
+        Assert.Null(bot.ConversationClient);
+    }
+
+    [Fact]
+    public async Task ConversationClient_IsAccessible_AfterProcessAsync()
+    {
+        var activityJson = JsonSerializer.Serialize(new
+        {
+            type = "message",
+            text = "hi",
+            serviceUrl = "https://test.botframework.com/",
+            conversation = new { id = "conv-1" },
+            from = new { id = "user-1" },
+            recipient = new { id = "bot-1" }
+        });
+
+        var resp = await _client!.PostAsync("/api/messages",
+            new StringContent(activityJson, Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        Assert.NotNull(_bot!.ConversationClient);
+        Assert.Same(_registeredClient, _bot.ConversationClient);
+    }
+
+    [Fact]
+    public async Task CreateConversationAsync_PostsToCorrectEndpoint_AndDeserializesResponse()
+    {
+        HttpRequestMessage? captured = null;
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(
+                    "{\"id\":\"new-conv-123\",\"serviceUrl\":\"https://test.botframework.com/\",\"activityId\":\"act-1\"}",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var ccClient = new ConversationClient(httpClient,
+            NullLoggerFactory.Instance.CreateLogger<ConversationClient>());
+
+        var parameters = new ConversationParameters
+        {
+            IsGroup = false,
+            Bot = new ChannelAccount { Id = "bot-1", Name = "Bot" },
+            Members = [new ChannelAccount { Id = "user-1", Name = "User" }],
+            TopicName = "Proactive thread",
+            TenantId = "tenant-1"
+        };
+
+        var result = await ccClient.CreateConversationAsync(
+            "https://test.botframework.com/",
+            parameters);
+
+        Assert.NotNull(result);
+        Assert.Equal("new-conv-123", result!.Id);
+        Assert.Equal("https://test.botframework.com/", result.ServiceUrl);
+        Assert.Equal("act-1", result.ActivityId);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Post, captured!.Method);
+        Assert.Equal("https://test.botframework.com/v3/conversations", captured.RequestUri!.ToString());
+
+        var body = await captured.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("Proactive thread", doc.RootElement.GetProperty("topicName").GetString());
+        Assert.Equal("tenant-1", doc.RootElement.GetProperty("tenantId").GetString());
+        Assert.Equal("bot-1", doc.RootElement.GetProperty("bot").GetProperty("id").GetString());
+    }
+
+    [Fact]
+    public async Task CreateConversationAsync_AppendsSlash_WhenServiceUrlMissingTrailingSlash()
+    {
+        HttpRequestMessage? captured = null;
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"id\":\"c\"}", Encoding.UTF8, "application/json")
+            });
+
+        var ccClient = new ConversationClient(
+            new HttpClient(mockHandler.Object),
+            NullLoggerFactory.Instance.CreateLogger<ConversationClient>());
+
+        await ccClient.CreateConversationAsync(
+            "https://test.botframework.com",
+            new ConversationParameters());
+
+        Assert.Equal("https://test.botframework.com/v3/conversations", captured!.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task CreateConversationAsync_Throws_OnNonSuccessStatus()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"error\":\"bad\"}", Encoding.UTF8, "application/json")
+            });
+
+        var ccClient = new ConversationClient(
+            new HttpClient(mockHandler.Object),
+            NullLoggerFactory.Instance.CreateLogger<ConversationClient>());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ccClient.CreateConversationAsync(
+                "https://test.botframework.com/",
+                new ConversationParameters()));
+
+        Assert.Contains("BadRequest", ex.Message);
+    }
+
+    [Fact]
+    public async Task CreateConversationAsync_Throws_OnDisallowedServiceUrl()
+    {
+        var ccClient = new ConversationClient(
+            new HttpClient(),
+            NullLoggerFactory.Instance.CreateLogger<ConversationClient>());
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            ccClient.CreateConversationAsync(
+                "https://evil.example.com/",
+                new ConversationParameters()));
+    }
+
+    [Fact]
+    public async Task CreateConversationAsync_Throws_OnNullParameters()
+    {
+        var ccClient = new ConversationClient(
+            new HttpClient(),
+            NullLoggerFactory.Instance.CreateLogger<ConversationClient>());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            ccClient.CreateConversationAsync("https://test.botframework.com/", null!));
+    }
+}


### PR DESCRIPTION
Closes #342. Achieves parity with Node and Python proactive messaging APIs.