### PR TITLE
fix(node): remove remaining createRequire calls for Deno compatibility

### DIFF
--- a/node/packages/botas-core/src/meter-provider.ts
+++ b/node/packages/botas-core/src/meter-provider.ts
@@ -2,9 +2,17 @@
 // Licensed under the MIT License.
 
 import type { Counter, Histogram, Meter } from '@opentelemetry/api'
-import { createRequire } from 'node:module'
+import { VERSION } from './version.js'
 
-const require = createRequire(import.meta.url)
+// Optional peer dependency. Loaded via dynamic import so the module works in
+// environments without `@opentelemetry/api` (and avoids `createRequire`,
+// which fails on Deno when modules are loaded from a remote URL like JSR).
+let _api: typeof import('@opentelemetry/api') | null = null
+try {
+  _api = await import('@opentelemetry/api')
+} catch {
+  _api = null
+}
 
 let _meter: Meter | null | undefined // undefined = not yet initialized
 
@@ -16,12 +24,9 @@ export function resetMeter (): void {
 
 export function getMeter (): Meter | null {
   if (_meter !== undefined) return _meter
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const api = require('@opentelemetry/api') as typeof import('@opentelemetry/api')
-    const pkg = require('../package.json') as { version: string }
-    _meter = api.metrics.getMeter('botas', pkg.version)
-  } catch {
+  if (_api) {
+    _meter = _api.metrics.getMeter('botas', VERSION)
+  } else {
     _meter = null
   }
   return _meter

--- a/node/packages/botas-core/src/otel-logger.ts
+++ b/node/packages/botas-core/src/otel-logger.ts
@@ -2,9 +2,17 @@
 // Licensed under the MIT License.
 
 import type { Logger } from './logger.js'
-import { createRequire } from 'node:module'
+import { VERSION } from './version.js'
 
-const require = createRequire(import.meta.url)
+// Optional peer dependency. Loaded via dynamic import so the module works in
+// environments without `@opentelemetry/api-logs` (and avoids `createRequire`,
+// which fails on Deno when modules are loaded from a remote URL like JSR).
+let _logsApi: typeof import('@opentelemetry/api-logs') | null = null
+try {
+  _logsApi = await import('@opentelemetry/api-logs')
+} catch {
+  _logsApi = null
+}
 
 /**
  * A logger that emits log records via the OpenTelemetry Logs API.
@@ -23,11 +31,10 @@ const require = createRequire(import.meta.url)
  * ```
  */
 export function createOtelLogger (): Logger | null {
+  if (!_logsApi) return null
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const logsApi = require('@opentelemetry/api-logs') as typeof import('@opentelemetry/api-logs')
-    const pkg = require('../package.json') as { version: string }
-    const otelLogger = logsApi.logs.getLogger('botas', pkg.version)
+    const logsApi = _logsApi
+    const otelLogger = logsApi.logs.getLogger('botas', VERSION)
 
     const { SeverityNumber } = logsApi
 

--- a/node/packages/botas-core/src/tracer-provider.ts
+++ b/node/packages/botas-core/src/tracer-provider.ts
@@ -2,12 +2,19 @@
 // Licensed under the MIT License.
 
 import type { Span, Tracer } from '@opentelemetry/api'
-import { createRequire } from 'node:module'
+import { VERSION } from './version.js'
 
-const require = createRequire(import.meta.url)
+// Optional peer dependency. Loaded via dynamic import so the module works in
+// environments without `@opentelemetry/api` (and avoids `createRequire`,
+// which fails on Deno when modules are loaded from a remote URL like JSR).
+let _api: typeof import('@opentelemetry/api') | null = null
+try {
+  _api = await import('@opentelemetry/api')
+} catch {
+  _api = null
+}
 
 let _tracer: Tracer | null | undefined // undefined = not yet initialized
-let _api: typeof import('@opentelemetry/api') | null = null
 
 /**
  * Returns the shared OpenTelemetry tracer for botas instrumentation.
@@ -17,17 +24,13 @@ let _api: typeof import('@opentelemetry/api') | null = null
 /** @internal Reset the cached tracer — for testing only. */
 export function resetTracer (): void {
   _tracer = undefined
-  _api = null
 }
 
 export function getTracer (): Tracer | null {
   if (_tracer !== undefined) return _tracer
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    _api = require('@opentelemetry/api') as typeof import('@opentelemetry/api')
-    const pkg = require('../package.json') as { version: string }
-    _tracer = _api.trace.getTracer('botas', pkg.version)
-  } catch {
+  if (_api) {
+    _tracer = _api.trace.getTracer('botas', VERSION)
+  } else {
     _tracer = null
   }
   return _tracer


### PR DESCRIPTION
Closes #301.

Applies the VERSION-constant pattern (already used in ot-application.ts) to the 3 remaining files that broke on Deno when loaded from JSR:

- `node/packages/botas-core/src/meter-provider.ts`
- `node/packages/botas-core/src/otel-logger.ts`
- `node/packages/botas-core/src/tracer-provider.ts`

Each previously did `const require = createRequire(import.meta.url)` at module load, which crashes on Deno when `import.meta.url` is a remote `https://jsr.io/...` URL.

### Changes per file
- `createRequire(import.meta.url)` removed entirely.
- Package version is now sourced from the build-time `VERSION` constant in `./version.js` (auto-generated by `scripts/sync-version.mjs`).
- Optional peer deps (`@opentelemetry/api`, `@opentelemetry/api-logs`) are now loaded via top-level `await import()` wrapped in try/catch, which works on both Node and Deno. When the package is unavailable, the modules gracefully return `null` (no-op telemetry).

### Verification
- `npm run build` — passes
- `npm test` — 148 + 12 tests pass
- `deno check main.ts` on `samples/02-advanced-hosting-deno` — passes
- `deno eval` smoke test confirms `BotApplication.version`, `getTracer()`, `getMeter()`, `createOtelLogger()` all load without crashing on Deno.