### PR TITLE
fix(node): silence OpenTelemetry DiagAPI logger overwrite warnings

### DIFF
--- a/node/samples/05-ai-langchain-otel/otel-setup.ts
+++ b/node/samples/05-ai-langchain-otel/otel-setup.ts
@@ -12,7 +12,19 @@
 //   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 OTEL_SERVICE_NAME=langchain-bot npx tsx index.ts
 
 import { useMicrosoftOpenTelemetry } from '@microsoft/opentelemetry'
-import { trace, SpanStatusCode, type Span } from '@opentelemetry/api'
+import { diag, trace, SpanStatusCode, type Span } from '@opentelemetry/api'
+
+// Suppress noisy "Current logger will be overwritten" / "will overwrite one already
+// registered" warnings emitted when @microsoft/opentelemetry's NodeSDK calls
+// diag.setLogger() without passing { suppressOverrideMessage: true }.
+// See https://github.com/rido-min/botas/issues/311
+const originalSetLogger = diag.setLogger.bind(diag)
+diag.setLogger = (logger, optionsOrLogLevel) => {
+    if (typeof optionsOrLogLevel === 'number') {
+        return originalSetLogger(logger, { logLevel: optionsOrLogLevel, suppressOverrideMessage: true })
+    }
+    return originalSetLogger(logger, { ...optionsOrLogLevel, suppressOverrideMessage: true })
+}
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base'
 import type { Serialized } from '@langchain/core/load/serializable'
 import type { LLMResult } from '@langchain/core/outputs'

--- a/node/samples/05-observability/otel-setup.ts
+++ b/node/samples/05-observability/otel-setup.ts
@@ -12,7 +12,19 @@
 //   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 OTEL_SERVICE_NAME=langchain-bot npx tsx index.ts
 
 import { useMicrosoftOpenTelemetry } from '@microsoft/opentelemetry'
-import { trace, SpanStatusCode, type Span } from '@opentelemetry/api'
+import { diag, trace, SpanStatusCode, type Span } from '@opentelemetry/api'
+
+// Suppress noisy "Current logger will be overwritten" / "will overwrite one already
+// registered" warnings emitted when @microsoft/opentelemetry's NodeSDK calls
+// diag.setLogger() without passing { suppressOverrideMessage: true }.
+// See https://github.com/rido-min/botas/issues/311
+const originalSetLogger = diag.setLogger.bind(diag)
+diag.setLogger = (logger, optionsOrLogLevel) => {
+    if (typeof optionsOrLogLevel === 'number') {
+        return originalSetLogger(logger, { logLevel: optionsOrLogLevel, suppressOverrideMessage: true })
+    }
+    return originalSetLogger(logger, { ...optionsOrLogLevel, suppressOverrideMessage: true })
+}
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base'
 import type { Serialized } from '@langchain/core/load/serializable'
 import type { LLMResult } from '@langchain/core/outputs'


### PR DESCRIPTION
Closes #311.

## Problem

The OTel-enabled samples emit two noisy warnings on startup:

```
Current logger will be overwritten from Error
    at DiagAPI.setLogger (.../@opentelemetry/api/src/api/diag.ts:97:23)
    at new NodeSDK (.../@opentelemetry/sdk-node/src/sdk.ts:254:12)
    at useMicrosoftOpenTelemetry (.../@microsoft/opentelemetry/dist/esm/distro/distro.js:170:11)
Current logger will overwrite one already registered from Error
    ...
```

Root cause: `@microsoft/opentelemetry`'s `NodeSDK` calls `diag.setLogger()` during init without passing `{ suppressOverrideMessage: true }`. `DiagAPI` exposes that flag specifically to suppress the warning, but the distro doesn't use it.

## Fix

Apply the workaround documented in the issue: monkey-patch `diag.setLogger` in each sample's `otel-setup.ts` (right after the import, before `useMicrosoftOpenTelemetry()` runs) so every call gets `suppressOverrideMessage: true`. Files changed:

- `node/samples/05-observability/otel-setup.ts`
- `node/samples/05-ai-langchain-otel/otel-setup.ts`

### Why patch in the samples (not in the library)

- `botas-core` does not call `diag.setLogger` itself, so there is no library code to fix.
- The warning only originates when a user wires up `@microsoft/opentelemetry` in their startup code (which is exactly what these two samples demonstrate).
- A library-level patch would silently mutate the global `DiagAPI` for any consumer that imports `botas-core`, even when they don't use OTel — a too-broad side effect.
- Putting the workaround in the sample setup keeps it visible, documented (with a link to #311), and easy for users to copy when they build their own OTel setup.

## Verification

- `npm run build` — passes
- `npm test` — 148 core + 12 express tests, all green
- `npm run typecheck` — passes for both samples

Both ports of the library are untouched; behavior parity across .NET/Node/Python is preserved.