### PR TITLE
docs: strike through 'bots' and add 'agents' in tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![JSR](https://jsr.io/badges/@botas/core)](https://jsr.io/@botas/core)
 [![PyPI](https://img.shields.io/pypi/v/botas.svg)](https://pypi.org/project/botas/)
 
-A lightweight, multi-language library for building [Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/) bots in **.NET**, **Node.js**, and **Python**.
+A lightweight, multi-language library for building [Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/) ~~bots~~ agents in **.NET**, **Node.js**, and **Python**.
 
 > 🤖 **This project is a GitHub Copilot Squads experiment.** All code, documentation, and samples have been produced by GitHub Copilot agents working as a cross-functional team. Meet the [Squad](#-the-squad) below!
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: BotAS
   text: The Bot App SDK
-  tagline: A lightweight, multi-language library for building Microsoft Teams bots with minimal overhead.
+  tagline: "A lightweight, multi-language library for building Microsoft Teams <s>bots</s> agents with minimal overhead."
   image:
     src: /logo.svg
     alt: BotAS Logo


### PR DESCRIPTION
Updates the tagline in both the main README and the VitePress home page to strike through `bots` and add `agents`.

- `README.md`: uses Markdown `~~bots~~ agents` syntax.
- `docs-site/index.md`: VitePress 1.6 renders the hero `tagline` with `v-html` (see `VPHero.vue:36`), so inline `<s>bots</s> agents` HTML works. The YAML string is quoted to keep `<` unambiguous to parsers.

No behavior or API changes.