### PR TITLE
feat: RedisStorage state provider + docker-compose samples (.NET, Node, Python)

### DIFF
--- a/docs-site/state.md
+++ b/docs-site/state.md
@@ -16,6 +16,8 @@ A runnable counter bot in all three languages that demonstrates conversation, us
 
 Run it locally, send a few messages, and watch the JSON files appear in `state-data/`.
 
+For multi-instance / production-style persistence, see the [Redis sample](#redisstorage) — same counter contract, but backed by a docker-compose Redis 7 instance.
+
 ## When do you need it?
 
 Use TurnState when you want to:
@@ -221,6 +223,46 @@ storage = FileStorage()
 
 # Or custom directory:
 storage = FileStorage('./data/bot-state')
+```
+:::
+
+**RedisStorage** — Persists state to a Redis instance. Suitable for **multi-instance** production deployments where multiple bot replicas need to share state. Distributed via opt-in packages, never pulled into the core install. The same Redis instance can back .NET, Node.js, and Python bots interchangeably — state documents are fully cross-language interoperable.
+
+::: code-group
+```csharp [.NET]
+// Install: dotnet add package Botas.Redis
+using Botas.Redis;
+
+await using var storage = new RedisStorage("redis://localhost:6379");
+
+// Custom prefix (for multi-tenant Redis instances):
+await using var storage = new RedisStorage("redis://localhost:6379", keyPrefix: "mybot:");
+```
+
+```typescript [Node.js]
+// Install: npm install botas-redis
+import { RedisStorage } from 'botas-redis'
+
+const storage = new RedisStorage('redis://localhost:6379')
+
+// Custom prefix:
+const storage = new RedisStorage('redis://localhost:6379', { keyPrefix: 'mybot:' })
+
+// Remember to close on shutdown:
+process.on('SIGINT', async () => { await storage.close() })
+```
+
+```python [Python]
+# Install: pip install "botas[redis]"
+from botas.state import RedisStorage
+
+storage = RedisStorage("redis://localhost:6379")
+
+# Custom prefix:
+storage = RedisStorage("redis://localhost:6379", key_prefix="mybot:")
+
+# Remember to close on shutdown:
+# await storage.aclose()
 ```
 :::
 
@@ -533,9 +575,28 @@ Future versions will include cloud-native adapters:
 
 - **BlobStorage** — Azure Blob Storage
 - **CosmosDbStorage** — Azure Cosmos DB
-- **RedisStorage** — Redis cache
 
-These will support multi-instance deployments, horizontal scaling, and better performance.
+These will support cloud-managed multi-instance deployments, horizontal scaling, and better performance.
+
+### RedisStorage
+
+Persists state to a Redis instance. **Suitable for multi-instance / horizontally scaled deployments** — the same Redis instance can be shared across all bot replicas and even across runtimes (.NET ↔ Node ↔ Python state documents are fully interoperable).
+
+- **Thread-safe**: Yes (Redis serializes operations)
+- **Persistence**: Configurable via Redis (RDB snapshots, AOF, or none)
+- **Use case**: Multi-instance production deployments, distributed bots, shared state across replicas
+- **Packaging**: Opt-in package — never pulled into the core install
+  - **.NET**: `dotnet add package Botas.Redis`
+  - **Node.js**: `npm install botas-redis`
+  - **Python**: `pip install "botas[redis]"`
+- **Key encoding**: Keys are stored as `<keyPrefix><raw_key>` with **no encoding** (Redis is binary-safe). Default prefix: `botas:`.
+- **Cluster compatibility**: All multi-key operations are issued as pipelined single-key commands (NOT `MGET`/multi-key `DEL`) so the provider works with Redis Cluster without `CROSSSLOT` errors.
+- **TTL**: Not set by default — state persists until explicitly deleted.
+- **Lifecycle**: Always call the cleanup method on shutdown — `await using` (`.NET`), `await storage.close()` (Node), `await storage.aclose()` (Python).
+- **Try it**: Runnable sample with docker-compose Redis in every language:
+  - **.NET**: [dotnet/samples/07-redis-state-bot/](https://github.com/rido-min/botas/tree/main/dotnet/samples/07-redis-state-bot/)
+  - **Node.js**: [node/samples/07-redis-state-bot/](https://github.com/rido-min/botas/tree/main/node/samples/07-redis-state-bot/)
+  - **Python**: [python/samples/07-redis-state-bot/](https://github.com/rido-min/botas/tree/main/python/samples/07-redis-state-bot/)
 
 ---
 
@@ -551,8 +612,8 @@ These will support multi-instance deployments, horizontal scaling, and better pe
 ## Limitations in v1
 
 - **No concurrency control** — If two turns write to the same state key simultaneously, last-write-wins (no detection of conflicts).
-- **Storage adapters** — Only MemoryStorage and FileStorage ship in v1. Cloud adapters (BlobStorage, Redis, Cosmos) are deferred.
-- **FileStorage is single-instance only** — Do not use in multi-process or scaled deployments.
+- **Storage adapters** — v1 ships **MemoryStorage**, **FileStorage**, and **RedisStorage**. Cloud-native adapters (BlobStorage, CosmosDbStorage) are deferred.
+- **FileStorage is single-instance only** — Do not use in multi-process or scaled deployments. Use **RedisStorage** instead for multi-instance.
 - **No encryption** — State values are serialized as plain JSON. For sensitive data, encrypt before storing.
 - **No expiration** — State persists indefinitely. Implement manual cleanup if needed.
 

--- a/dotnet/Botas.slnx
+++ b/dotnet/Botas.slnx
@@ -9,7 +9,10 @@
   <Project Path="samples/04-ai-openai/AiBot.csproj" />
   <Project Path="samples/05-observability/OtelBot.csproj" />
   <Project Path="samples/06-state-bot/StateBot.csproj" />
+  <Project Path="samples/07-redis-state-bot/RedisStateBot.csproj" />
   <Project Path="samples/TestBot/TestBot.csproj" />
   <Project Path="src/Botas/Botas.csproj" />
+  <Project Path="src/Botas.Redis/Botas.Redis.csproj" />
   <Project Path="tests/Botas.Tests/Botas.Tests.csproj" />
+  <Project Path="tests/Botas.Redis.Tests/Botas.Redis.Tests.csproj" />
 </Solution>

--- a/dotnet/samples/07-redis-state-bot/.gitignore
+++ b/dotnet/samples/07-redis-state-bot/.gitignore
@@ -1,0 +1,1 @@
+# Redis state is stored in the docker-compose volume.

--- a/dotnet/samples/07-redis-state-bot/Program.cs
+++ b/dotnet/samples/07-redis-state-bot/Program.cs
@@ -1,0 +1,82 @@
+using Botas;
+using Botas.Redis;
+using Microsoft.Extensions.Hosting;
+
+var app = BotApp.Create(args);
+
+var redisConnectionString = app.Builder.Configuration["Redis:ConnectionString"] ?? "redis://localhost:6379";
+var storage = new RedisStorage(redisConnectionString);
+
+app.Services.AddHostedService(sp => new RedisStorageShutdownService(
+    storage,
+    sp.GetRequiredService<IHostApplicationLifetime>()));
+
+// Register state middleware with RedisStorage
+app.UseState(storage);
+
+// Register message handler
+app.On("message", async (context, ct) =>
+{
+    var text = context.Activity.Text?.Trim() ?? "";
+
+    // Handle special commands
+    if (text.Equals("reset", StringComparison.OrdinalIgnoreCase))
+    {
+        context.State?.DeleteConversationState();
+        await context.SendAsync("✅ Conversation state cleared. Counters reset.", ct);
+        return;
+    }
+
+    if (text.Equals("whoami", StringComparison.OrdinalIgnoreCase))
+    {
+        var userMsgCount = context.State?.User.Get<int>("user_message_count") ?? 0;
+        var userId = context.Activity.From?.Id ?? "unknown";
+        await context.SendAsync($"👤 User ID: {userId}\n📊 Your message count: {userMsgCount}", ct);
+        return;
+    }
+
+    // Increment conversation-scoped turn counter (shared across all users in conversation)
+    var turnCount = context.State?.Conversation.Get<int>("turn_count") ?? 0;
+    turnCount++;
+    context.State?.Conversation.Set("turn_count", turnCount);
+
+    // Increment user-scoped message counter (follows this user across all conversations)
+    var userMessageCount = context.State?.User.Get<int>("user_message_count") ?? 0;
+    userMessageCount++;
+    context.State?.User.Set("user_message_count", userMessageCount);
+
+    // Use temp scope for the formatted reply (not persisted)
+    var reply = $"🔢 Turn #{turnCount} | 💬 Your message #{userMessageCount}\n📝 You said: {text}";
+    context.State?.Temp.Set("formatted_reply", reply);
+
+    var finalReply = context.State?.Temp.Get<string>("formatted_reply") ?? "Error formatting reply";
+    await context.SendAsync(finalReply, ct);
+});
+
+app.Run();
+
+sealed class RedisStorageShutdownService(RedisStorage storage, IHostApplicationLifetime lifetime) : IHostedService
+{
+    private IDisposable? _registration;
+    private int _disposed;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _registration = lifetime.ApplicationStopping.Register(() =>
+            DisposeStorageAsync().AsTask().GetAwaiter().GetResult());
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => DisposeStorageAsync().AsTask();
+
+    private async ValueTask DisposeStorageAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 1)
+        {
+            return;
+        }
+
+        _registration?.Dispose();
+        await storage.DisposeAsync();
+    }
+}

--- a/dotnet/samples/07-redis-state-bot/README.md
+++ b/dotnet/samples/07-redis-state-bot/README.md
@@ -1,0 +1,89 @@
+# Redis State Bot
+
+**Category:** 1 — Basic Bot  
+**Language:** .NET  
+**Complexity:** Intermediate  
+
+## What This Sample Demonstrates
+
+- Using `app.UseState(storage)` middleware to enable TurnState
+- Persisting data to Redis with `RedisStorage`
+- All three state scopes: conversation, user, and temp
+- Clearing conversation state with the `reset` command
+- Inspecting user state with the `whoami` command
+
+## Prerequisites
+
+- Docker
+- .NET 10 SDK
+
+## Run
+
+Start Redis 7:
+
+```bash
+cd dotnet/samples/07-redis-state-bot
+docker compose up -d
+```
+
+Run the bot:
+
+```bash
+dotnet run
+```
+
+The bot listens on **http://localhost:5006** by default.  
+Endpoint: `POST http://localhost:5006/api/messages`
+
+## Try It
+
+Send a message and watch the counters increment:
+
+```powershell
+$activity = @{
+    type = "message"
+    text = "Hello bot!"
+    from = @{ id = "user123"; name = "Test User" }
+    recipient = @{ id = "bot"; name = "Redis State Bot" }
+    conversation = @{ id = "conv456" }
+    channelId = "emulator"
+    serviceUrl = "http://localhost:5006"
+} | ConvertTo-Json -Depth 5
+
+Invoke-WebRequest -Uri "http://localhost:5006/api/messages" `
+    -Method POST `
+    -ContentType "application/json" `
+    -Body $activity
+```
+
+Expected response:
+
+```
+🔢 Turn #1 | 💬 Your message #1
+📝 You said: Hello bot!
+```
+
+Special commands:
+
+- `reset` — clears conversation scope and resets the turn counter.
+- `whoami` — shows your user ID and user-scoped message count.
+
+## Stop Redis
+
+Stop containers while preserving state in the Docker volume:
+
+```bash
+docker compose down
+```
+
+Reset state by removing the Docker volume:
+
+```bash
+docker compose down -v
+```
+
+## Learn More
+
+- [State Management Guide](../../../docs-site/state.md)
+- [TurnState Spec](../../../specs/turn-state.md)
+- [Architecture](../../../specs/architecture.md)

--- a/dotnet/samples/07-redis-state-bot/RedisStateBot.csproj
+++ b/dotnet/samples/07-redis-state-bot/RedisStateBot.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Botas\Botas.csproj" />
+    <ProjectReference Include="..\..\src\Botas.Redis\Botas.Redis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/samples/07-redis-state-bot/appsettings.json
+++ b/dotnet/samples/07-redis-state-bot/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Redis": {
+    "ConnectionString": "redis://localhost:6379"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/dotnet/samples/07-redis-state-bot/docker-compose.yml
+++ b/dotnet/samples/07-redis-state-bot/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: botas-redis-state-dotnet
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: ["redis-server", "--appendonly", "yes"]
+volumes:
+  redis-data:

--- a/dotnet/src/Botas.Redis/Botas.Redis.csproj
+++ b/dotnet/src/Botas.Redis/Botas.Redis.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Description>Redis-backed IStorage provider for Botas</Description>
+    <Authors>rido-min</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/rido-min/botas</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/rido-min/botas</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>bot;bot-framework;microsoft-teams;chatbot</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon-128.png</PackageIcon>
+
+    <!-- Generate XML documentation for API reference -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- SourceLink: embed source info and enable deterministic builds -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="../../../art/icon-128.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Botas\Botas.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/Botas.Redis/README.md
+++ b/dotnet/src/Botas.Redis/README.md
@@ -1,0 +1,26 @@
+# Botas.Redis
+
+Redis-backed `IStorage` provider for Botas state.
+
+## Install
+
+```bash
+dotnet add package Botas.Redis
+```
+
+## Quick start
+
+```csharp
+using Botas.Redis;
+
+await using var storage = new RedisStorage("redis://localhost:6379");
+app.UseState(storage);
+```
+
+Use a custom prefix when sharing a Redis instance:
+
+```csharp
+await using var storage = new RedisStorage("redis://localhost:6379", keyPrefix: "mybot:");
+```
+
+For more patterns, see the [State Management Guide](../../../docs-site/state.md).

--- a/dotnet/src/Botas.Redis/RedisStorage.cs
+++ b/dotnet/src/Botas.Redis/RedisStorage.cs
@@ -1,0 +1,198 @@
+using System.Text.Json;
+using Botas.State;
+using StackExchange.Redis;
+
+namespace Botas.Redis;
+
+/// <summary>
+/// Redis-backed storage implementation for Botas turn state.
+/// Values are stored as JSON strings under keys formatted as <c>{keyPrefix}{rawKey}</c>.
+/// </summary>
+public class RedisStorage : IStorage, IAsyncDisposable
+{
+    private readonly string _keyPrefix;
+    private readonly bool _ownsMultiplexer;
+    private readonly IConnectionMultiplexer? _providedMultiplexer;
+    private readonly Lazy<Task<IConnectionMultiplexer>> _multiplexer;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="RedisStorage" /> using a Redis connection string.
+    /// The Redis connection is opened lazily on the first storage operation.
+    /// </summary>
+    /// <param name="connectionString">Redis connection string, for example <c>redis://localhost:6379</c>.</param>
+    /// <param name="keyPrefix">Prefix applied to all Redis keys. Defaults to <c>botas:</c>.</param>
+    public RedisStorage(string connectionString, string keyPrefix = "botas:")
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        _keyPrefix = keyPrefix ?? throw new ArgumentNullException(nameof(keyPrefix));
+        _ownsMultiplexer = true;
+        _multiplexer = new Lazy<Task<IConnectionMultiplexer>>(async () =>
+            await ConnectionMultiplexer.ConnectAsync(ToConfigurationOptions(connectionString)).ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="RedisStorage" /> using an existing Redis connection multiplexer.
+    /// </summary>
+    /// <param name="multiplexer">Existing Redis connection multiplexer.</param>
+    /// <param name="keyPrefix">Prefix applied to all Redis keys. Defaults to <c>botas:</c>.</param>
+    /// <param name="ownsMultiplexer">Whether this storage instance should dispose the multiplexer.</param>
+    public RedisStorage(IConnectionMultiplexer multiplexer, string keyPrefix = "botas:", bool ownsMultiplexer = false)
+    {
+        ArgumentNullException.ThrowIfNull(multiplexer);
+
+        _keyPrefix = keyPrefix ?? throw new ArgumentNullException(nameof(keyPrefix));
+        _ownsMultiplexer = ownsMultiplexer;
+        _providedMultiplexer = multiplexer;
+        _multiplexer = new Lazy<Task<IConnectionMultiplexer>>(() => Task.FromResult(multiplexer));
+    }
+
+    /// <summary>
+    /// Read items from Redis.
+    /// Missing keys are not included in the returned dictionary.
+    /// </summary>
+    /// <param name="keys">Keys to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Dictionary of key-value pairs that exist in storage.</returns>
+    public async Task<IDictionary<string, object>> ReadAsync(string[] keys, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var database = await GetDatabaseAsync().ConfigureAwait(false);
+        var tasks = keys.Select(key => database.StringGetAsync(ToRedisKey(key))).ToArray();
+        var values = await Task.WhenAll(tasks).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var result = new Dictionary<string, object>();
+        for (var i = 0; i < keys.Length; i++)
+        {
+            var value = values[i];
+            if (value.IsNull)
+            {
+                continue;
+            }
+
+            var deserialized = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                value.ToString(),
+                CoreActivity.DefaultJsonOptions);
+            if (deserialized is not null)
+            {
+                result[keys[i]] = deserialized;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Write items to Redis as JSON strings.
+    /// </summary>
+    /// <param name="changes">Dictionary of key-value pairs to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task WriteAsync(IDictionary<string, object> changes, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(changes);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var database = await GetDatabaseAsync().ConfigureAwait(false);
+        var tasks = changes.Select(kvp =>
+        {
+            var json = JsonSerializer.Serialize(kvp.Value, CoreActivity.DefaultJsonOptions);
+            return database.StringSetAsync(ToRedisKey(kvp.Key), json);
+        }).ToArray();
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    /// <summary>
+    /// Delete items from Redis.
+    /// The operation is idempotent; missing keys are ignored.
+    /// </summary>
+    /// <param name="keys">Keys to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task DeleteAsync(string[] keys, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var database = await GetDatabaseAsync().ConfigureAwait(false);
+        var tasks = keys.Select(key => database.KeyDeleteAsync(ToRedisKey(key))).ToArray();
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    /// <summary>
+    /// Disposes the Redis connection multiplexer when this instance owns it.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (!_ownsMultiplexer)
+        {
+            return;
+        }
+
+        if (_providedMultiplexer is null && !_multiplexer.IsValueCreated)
+        {
+            return;
+        }
+
+        var multiplexer = _providedMultiplexer ?? await _multiplexer.Value.ConfigureAwait(false);
+        if (multiplexer is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else
+        {
+            multiplexer.Dispose();
+        }
+    }
+
+    private async Task<IDatabase> GetDatabaseAsync()
+    {
+        var multiplexer = await _multiplexer.Value.ConfigureAwait(false);
+        return multiplexer.GetDatabase();
+    }
+
+    private RedisKey ToRedisKey(string key) => _keyPrefix + key;
+
+    private static ConfigurationOptions ToConfigurationOptions(string connectionString)
+    {
+        if (!Uri.TryCreate(connectionString, UriKind.Absolute, out var uri)
+            || (uri.Scheme != "redis" && uri.Scheme != "rediss"))
+        {
+            return ConfigurationOptions.Parse(connectionString);
+        }
+
+        var options = new ConfigurationOptions
+        {
+            Ssl = uri.Scheme == "rediss"
+        };
+
+        var port = uri.IsDefaultPort ? 6379 : uri.Port;
+        options.EndPoints.Add(uri.Host, port);
+
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            var userInfo = uri.UserInfo.Split(':', 2);
+            if (userInfo.Length == 2)
+            {
+                options.User = Uri.UnescapeDataString(userInfo[0]);
+                options.Password = Uri.UnescapeDataString(userInfo[1]);
+            }
+            else
+            {
+                options.Password = Uri.UnescapeDataString(userInfo[0]);
+            }
+        }
+
+        var path = uri.AbsolutePath.Trim('/');
+        if (!string.IsNullOrEmpty(path) && int.TryParse(path, out var database))
+        {
+            options.DefaultDatabase = database;
+        }
+
+        return options;
+    }
+}

--- a/dotnet/tests/Botas.Redis.Tests/Botas.Redis.Tests.csproj
+++ b/dotnet/tests/Botas.Redis.Tests/Botas.Redis.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Botas.Redis\Botas.Redis.csproj" />
+    <ProjectReference Include="..\..\src\Botas\Botas.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/tests/Botas.Redis.Tests/RedisStorageTests.cs
+++ b/dotnet/tests/Botas.Redis.Tests/RedisStorageTests.cs
@@ -1,0 +1,408 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Botas.Redis;
+using StackExchange.Redis;
+
+namespace Botas.Redis.Tests;
+
+public class RedisStorageTests
+{
+    [Fact]
+    public async Task ReadAsync_OmitsMissingKeys()
+    {
+        var fake = new FakeConnectionMultiplexer();
+        var storage = new RedisStorage(fake.Multiplexer);
+
+        var result = await storage.ReadAsync(["missing"]);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ThenReadAsync_PreservesJson()
+    {
+        var fake = new FakeConnectionMultiplexer();
+        var storage = new RedisStorage(fake.Multiplexer);
+        var expected = new Dictionary<string, object>
+        {
+            ["count"] = 42,
+            ["name"] = "test",
+            ["active"] = true
+        };
+
+        await storage.WriteAsync(new Dictionary<string, object> { ["state"] = expected });
+        var result = await storage.ReadAsync(["state"]);
+
+        Assert.True(result.ContainsKey("state"));
+        AssertJsonEqual(expected, result["state"]);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_IsIdempotent()
+    {
+        var fake = new FakeConnectionMultiplexer();
+        var storage = new RedisStorage(fake.Multiplexer);
+
+        await storage.DeleteAsync(["state"]);
+        await storage.DeleteAsync(["state"]);
+
+        Assert.Empty(fake.Data);
+    }
+
+    [Fact]
+    public async Task WriteAsync_AppliesKeyPrefix()
+    {
+        var fake = new FakeConnectionMultiplexer();
+        var storage = new RedisStorage(fake.Multiplexer, keyPrefix: "custom:");
+
+        await storage.WriteAsync(new Dictionary<string, object>
+        {
+            ["state"] = new Dictionary<string, object> { ["count"] = 1 }
+        });
+
+        Assert.True(fake.Data.ContainsKey((RedisKey)"custom:state"));
+        Assert.False(fake.Data.ContainsKey((RedisKey)"state"));
+    }
+
+    [Fact]
+    public async Task KeysWithSpecialCharacters_RoundTripWithoutModification()
+    {
+        var fake = new FakeConnectionMultiplexer();
+        var storage = new RedisStorage(fake.Multiplexer);
+        var key = "channels/msteams:conv%20 with space";
+        var expected = new Dictionary<string, object> { ["value"] = "ok" };
+
+        await storage.WriteAsync(new Dictionary<string, object> { [key] = expected });
+        var result = await storage.ReadAsync([key]);
+
+        Assert.True(fake.Data.ContainsKey((RedisKey)("botas:" + key)));
+        Assert.True(result.ContainsKey(key));
+        AssertJsonEqual(expected, result[key]);
+    }
+
+    [Fact]
+    public async Task EmptyObject_IsPreserved()
+    {
+        var fake = new FakeConnectionMultiplexer();
+        var storage = new RedisStorage(fake.Multiplexer);
+
+        await storage.WriteAsync(new Dictionary<string, object>
+        {
+            ["empty"] = new Dictionary<string, object>()
+        });
+        var result = await storage.ReadAsync(["empty"]);
+
+        var state = Assert.IsType<Dictionary<string, object>>(result["empty"]);
+        Assert.Empty(state);
+    }
+
+    [Fact]
+    public async Task NestedObjects_ArePreserved()
+    {
+        var fake = new FakeConnectionMultiplexer();
+        var storage = new RedisStorage(fake.Multiplexer);
+        var expected = new Dictionary<string, object>
+        {
+            ["profile"] = new Dictionary<string, object>
+            {
+                ["name"] = "Ada",
+                ["stats"] = new Dictionary<string, object>
+                {
+                    ["turns"] = 3
+                }
+            },
+            ["tags"] = new[] { "redis", "state" }
+        };
+
+        await storage.WriteAsync(new Dictionary<string, object> { ["nested"] = expected });
+        var result = await storage.ReadAsync(["nested"]);
+
+        AssertJsonEqual(expected, result["nested"]);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesOwnedMultiplexer()
+    {
+        var fake = new FakeConnectionMultiplexer();
+        var storage = new RedisStorage(fake.Multiplexer, ownsMultiplexer: true);
+
+        await storage.ReadAsync(["missing"]);
+        await storage.DisposeAsync();
+
+        Assert.True(fake.Disposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesOwnedMultiplexerWithoutPriorUse()
+    {
+        var fake = new FakeConnectionMultiplexer();
+        var storage = new RedisStorage(fake.Multiplexer, ownsMultiplexer: true);
+
+        await storage.DisposeAsync();
+
+        Assert.True(fake.Disposed);
+    }
+
+    private static void AssertJsonEqual(object expected, object actual)
+    {
+        var expectedNode = JsonSerializer.SerializeToNode(expected, CoreActivity.DefaultJsonOptions);
+        var actualNode = JsonSerializer.SerializeToNode(actual, CoreActivity.DefaultJsonOptions);
+        Assert.True(
+            JsonNode.DeepEquals(expectedNode, actualNode),
+            $"Expected {expectedNode?.ToJsonString()} but got {actualNode?.ToJsonString()}");
+    }
+}
+
+public class RedisStorageIntegrationTests
+{
+    [SkipIfNoRedisFact]
+    public async Task Integration_ReadAsync_OmitsMissingKeys()
+    {
+        await using var storage = CreateStorage();
+
+        var result = await storage.ReadAsync(["missing"]);
+
+        Assert.Empty(result);
+    }
+
+    [SkipIfNoRedisFact]
+    public async Task Integration_WriteAsync_ThenReadAsync_PreservesJson()
+    {
+        await using var storage = CreateStorage();
+        var expected = new Dictionary<string, object>
+        {
+            ["count"] = 42,
+            ["name"] = "test",
+            ["active"] = true
+        };
+
+        await storage.WriteAsync(new Dictionary<string, object> { ["state"] = expected });
+        var result = await storage.ReadAsync(["state"]);
+
+        Assert.True(result.ContainsKey("state"));
+        AssertJsonEqual(expected, result["state"]);
+    }
+
+    [SkipIfNoRedisFact]
+    public async Task Integration_DeleteAsync_IsIdempotent()
+    {
+        await using var storage = CreateStorage();
+
+        await storage.DeleteAsync(["state"]);
+        await storage.DeleteAsync(["state"]);
+
+        var result = await storage.ReadAsync(["state"]);
+        Assert.Empty(result);
+    }
+
+    [SkipIfNoRedisFact]
+    public async Task Integration_KeyPrefix_IsApplied()
+    {
+        await using var storage = CreateStorage(prefix: $"botas-test-{Guid.NewGuid():N}:");
+        var expected = new Dictionary<string, object> { ["value"] = "ok" };
+
+        await storage.WriteAsync(new Dictionary<string, object> { ["state"] = expected });
+        var result = await storage.ReadAsync(["state"]);
+
+        AssertJsonEqual(expected, result["state"]);
+    }
+
+    [SkipIfNoRedisFact]
+    public async Task Integration_KeysWithSpecialCharacters_RoundTripWithoutModification()
+    {
+        await using var storage = CreateStorage();
+        var key = "channels/msteams:conv%20 with space";
+        var expected = new Dictionary<string, object> { ["value"] = "ok" };
+
+        await storage.WriteAsync(new Dictionary<string, object> { [key] = expected });
+        var result = await storage.ReadAsync([key]);
+
+        Assert.True(result.ContainsKey(key));
+        AssertJsonEqual(expected, result[key]);
+    }
+
+    [SkipIfNoRedisFact]
+    public async Task Integration_EmptyObject_IsPreserved()
+    {
+        await using var storage = CreateStorage();
+
+        await storage.WriteAsync(new Dictionary<string, object>
+        {
+            ["empty"] = new Dictionary<string, object>()
+        });
+        var result = await storage.ReadAsync(["empty"]);
+
+        var state = Assert.IsType<Dictionary<string, object>>(result["empty"]);
+        Assert.Empty(state);
+    }
+
+    [SkipIfNoRedisFact]
+    public async Task Integration_NestedObjects_ArePreserved()
+    {
+        await using var storage = CreateStorage();
+        var expected = new Dictionary<string, object>
+        {
+            ["profile"] = new Dictionary<string, object>
+            {
+                ["name"] = "Ada",
+                ["stats"] = new Dictionary<string, object>
+                {
+                    ["turns"] = 3
+                }
+            },
+            ["tags"] = new[] { "redis", "state" }
+        };
+
+        await storage.WriteAsync(new Dictionary<string, object> { ["nested"] = expected });
+        var result = await storage.ReadAsync(["nested"]);
+
+        AssertJsonEqual(expected, result["nested"]);
+    }
+
+    private static RedisStorage CreateStorage(string? prefix = null)
+    {
+        var redisUrl = Environment.GetEnvironmentVariable("REDIS_URL")!;
+        return new RedisStorage(redisUrl, prefix ?? $"botas-test-{Guid.NewGuid():N}:");
+    }
+
+    private static void AssertJsonEqual(object expected, object actual)
+    {
+        var expectedNode = JsonSerializer.SerializeToNode(expected, CoreActivity.DefaultJsonOptions);
+        var actualNode = JsonSerializer.SerializeToNode(actual, CoreActivity.DefaultJsonOptions);
+        Assert.True(
+            JsonNode.DeepEquals(expectedNode, actualNode),
+            $"Expected {expectedNode?.ToJsonString()} but got {actualNode?.ToJsonString()}");
+    }
+}
+
+public sealed class SkipIfNoRedisFactAttribute : FactAttribute
+{
+    public SkipIfNoRedisFactAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("REDIS_URL")))
+        {
+            Skip = "Set REDIS_URL to run Redis integration tests.";
+        }
+    }
+}
+
+// Test-only — implements only methods used by RedisStorage.
+internal sealed class FakeConnectionMultiplexer
+{
+    private readonly FakeDatabase _database;
+
+    public FakeConnectionMultiplexer()
+    {
+        _database = new FakeDatabase();
+        Multiplexer = ConnectionProxy.Create(this);
+    }
+
+    public IConnectionMultiplexer Multiplexer { get; }
+
+    public IReadOnlyDictionary<RedisKey, RedisValue> Data => _database.Data;
+
+    public bool Disposed { get; private set; }
+
+    private class ConnectionProxy : DispatchProxy
+    {
+        public FakeConnectionMultiplexer Owner { get; set; } = null!;
+
+        public static IConnectionMultiplexer Create(FakeConnectionMultiplexer owner)
+        {
+            var proxy = DispatchProxy.Create<IConnectionMultiplexer, ConnectionProxy>();
+            ((ConnectionProxy)(object)proxy).Owner = owner;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.Name switch
+            {
+                nameof(IConnectionMultiplexer.GetDatabase) => Owner._database.Database,
+                nameof(IDisposable.Dispose) => DisposeOwner(),
+                nameof(IAsyncDisposable.DisposeAsync) => DisposeAsyncOwner(),
+                nameof(IConnectionMultiplexer.Close) => DisposeOwner(),
+                nameof(IConnectionMultiplexer.CloseAsync) => CloseAsyncOwner(),
+                _ => throw new NotSupportedException($"FakeConnectionMultiplexer does not implement {targetMethod?.Name}.")
+            };
+        }
+
+        private object? DisposeOwner()
+        {
+            Owner.Disposed = true;
+            return null;
+        }
+
+        private ValueTask DisposeAsyncOwner()
+        {
+            Owner.Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+
+        private Task CloseAsyncOwner()
+        {
+            Owner.Disposed = true;
+            return Task.CompletedTask;
+        }
+    }
+}
+
+// Test-only — implements only methods used by RedisStorage.
+internal sealed class FakeDatabase
+{
+    private readonly ConcurrentDictionary<RedisKey, RedisValue> _data = new();
+
+    public FakeDatabase()
+    {
+        Database = DatabaseProxy.Create(this);
+    }
+
+    public IDatabase Database { get; }
+
+    public IReadOnlyDictionary<RedisKey, RedisValue> Data => _data;
+
+    private class DatabaseProxy : DispatchProxy
+    {
+        public FakeDatabase Owner { get; set; } = null!;
+
+        public static IDatabase Create(FakeDatabase owner)
+        {
+            var proxy = DispatchProxy.Create<IDatabase, DatabaseProxy>();
+            ((DatabaseProxy)(object)proxy).Owner = owner;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.Name switch
+            {
+                nameof(IDatabase.StringGetAsync) => StringGetAsync(args),
+                nameof(IDatabase.StringSetAsync) => StringSetAsync(args),
+                nameof(IDatabase.KeyDeleteAsync) => KeyDeleteAsync(args),
+                _ => throw new NotSupportedException($"FakeDatabase does not implement {targetMethod?.Name}.")
+            };
+        }
+
+        private Task<RedisValue> StringGetAsync(object?[]? args)
+        {
+            var key = (RedisKey)args![0]!;
+            return Task.FromResult(Owner._data.TryGetValue(key, out var value) ? value : RedisValue.Null);
+        }
+
+        private Task<bool> StringSetAsync(object?[]? args)
+        {
+            var key = (RedisKey)args![0]!;
+            var value = (RedisValue)args[1]!;
+            Owner._data[key] = value;
+            return Task.FromResult(true);
+        }
+
+        private Task<bool> KeyDeleteAsync(object?[]? args)
+        {
+            var key = (RedisKey)args![0]!;
+            return Task.FromResult(Owner._data.TryRemove(key, out _));
+        }
+    }
+}

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -2750,6 +2750,65 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
@@ -3453,6 +3512,10 @@
       "resolved": "samples/06-state-bot",
       "link": true
     },
+    "node_modules/07-redis-state-bot": {
+      "resolved": "samples/07-redis-state-bot",
+      "link": true
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3870,6 +3933,10 @@
       "resolved": "packages/botas-express",
       "link": true
     },
+    "node_modules/botas-redis": {
+      "resolved": "packages/botas-redis",
+      "link": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -4063,6 +4130,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -5590,6 +5666,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-caller-file": {
@@ -8175,6 +8260,23 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -9495,6 +9597,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
@@ -9631,6 +9739,20 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
+        "typedoc": "^0.28.19"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/botas-redis": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "botas-core": "*",
+        "redis": "^4.7.0"
+      },
+      "devDependencies": {
         "typedoc": "^0.28.19"
       },
       "engines": {
@@ -10010,6 +10132,14 @@
       "dependencies": {
         "botas-core": "*",
         "botas-express": "*"
+      }
+    },
+    "samples/07-redis-state-bot": {
+      "version": "0.1.0",
+      "dependencies": {
+        "botas-core": "*",
+        "botas-express": "*",
+        "botas-redis": "*"
       }
     },
     "samples/test-bot": {

--- a/node/packages/botas-redis/README.md
+++ b/node/packages/botas-redis/README.md
@@ -1,0 +1,34 @@
+# botas-redis
+
+Redis-backed `Storage` provider for botas state.
+
+## Install
+
+```bash
+npm install botas-redis
+```
+
+## Quick start
+
+```ts
+import { BotApp } from 'botas-express'
+import { RedisStorage } from 'botas-redis'
+
+const app = new BotApp()
+const storage = new RedisStorage('redis://localhost:6379')
+
+app.useState(storage)
+
+process.once('SIGINT', async () => {
+  await storage.close()
+  process.exit(0)
+})
+```
+
+Use a custom prefix when sharing Redis with other apps:
+
+```ts
+const storage = new RedisStorage('redis://localhost:6379', { keyPrefix: 'mybot:' })
+```
+
+Learn more in the [State Management Guide](../../../docs-site/state.md).

--- a/node/packages/botas-redis/package.json
+++ b/node/packages/botas-redis/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "botas-redis",
+  "version": "0.1.0",
+  "description": "Redis-backed Storage provider for botas",
+  "type": "module",
+  "license": "MIT",
+  "author": "rido-min",
+  "homepage": "https://github.com/rido-min/botas#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rido-min/botas.git",
+    "directory": "node/packages/botas-redis"
+  },
+  "bugs": {
+    "url": "https://github.com/rido-min/botas/issues"
+  },
+  "keywords": [
+    "bot",
+    "bot-framework",
+    "redis",
+    "state",
+    "microsoft-teams"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "engines": {
+    "node": ">=20"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "clean": "npx rimraf ./dist",
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build",
+    "test": "node --import tsx --test src/redis-storage.spec.ts",
+    "docs": "typedoc"
+  },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "dependencies": {
+    "botas-core": "*",
+    "redis": "^4.7.0"
+  },
+  "devDependencies": {
+    "typedoc": "^0.28.19"
+  }
+}

--- a/node/packages/botas-redis/src/index.ts
+++ b/node/packages/botas-redis/src/index.ts
@@ -1,0 +1,1 @@
+export * from './redis-storage.js'

--- a/node/packages/botas-redis/src/redis-storage.spec.ts
+++ b/node/packages/botas-redis/src/redis-storage.spec.ts
@@ -1,0 +1,231 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { randomUUID } from 'node:crypto'
+import { describe, it, test } from 'node:test'
+import assert from 'node:assert/strict'
+import type { RedisClientType } from 'redis'
+import { RedisStorage } from './redis-storage.js'
+
+// Test-only — implements only methods used by RedisStorage.
+class FakeRedisClient {
+  readonly store = new Map<string, string>()
+  readonly commands: Array<{ command: 'GET' | 'SET' | 'DEL', key: string }> = []
+  isOpen = false
+  connectCalls = 0
+  quitCalls = 0
+
+  async connect (): Promise<FakeRedisClient> {
+    this.isOpen = true
+    this.connectCalls += 1
+    return this
+  }
+
+  async GET (key: string): Promise<string | null> {
+    this.commands.push({ command: 'GET', key })
+    return this.store.get(key) ?? null
+  }
+
+  async SET (key: string, value: string): Promise<'OK'> {
+    this.commands.push({ command: 'SET', key })
+    this.store.set(key, value)
+    return 'OK'
+  }
+
+  async DEL (key: string): Promise<number> {
+    this.commands.push({ command: 'DEL', key })
+    const existed = this.store.delete(key)
+    return existed ? 1 : 0
+  }
+
+  async quit (): Promise<'OK'> {
+    if (this.isOpen) {
+      this.isOpen = false
+      this.quitCalls += 1
+    }
+    return 'OK'
+  }
+
+  rawGet (key: string): string | null {
+    return this.store.get(key) ?? null
+  }
+
+  asRedisClient (): RedisClientType {
+    return this as unknown as RedisClientType
+  }
+}
+
+interface StorageFixture {
+  storage: RedisStorage
+  fake?: FakeRedisClient
+}
+
+interface StorageCase {
+  name: string
+  keyPrefix?: string
+  run: (fixture: StorageFixture) => Promise<void>
+}
+
+const storageCases: StorageCase[] = [
+  {
+    name: 'omits missing keys',
+    run: async ({ storage }) => {
+      const result = await storage.read(['missing-key'])
+      assert.deepStrictEqual(result, {})
+    }
+  },
+  {
+    name: 'writes and reads JSON values',
+    run: async ({ storage }) => {
+      const data = { key1: { foo: 'bar' }, key2: 42 }
+      await storage.write(data)
+
+      const result = await storage.read(['key1', 'key2'])
+      assert.deepStrictEqual(result, data)
+
+      await storage.delete(Object.keys(data))
+    }
+  },
+  {
+    name: 'deletes idempotently',
+    run: async ({ storage }) => {
+      await storage.write({ key1: 'value1', key2: 'value2' })
+      await storage.delete(['key1', 'missing-key'])
+      await storage.delete(['key1', 'missing-key'])
+
+      const result = await storage.read(['key1', 'key2'])
+      assert.deepStrictEqual(result, { key2: 'value2' })
+
+      await storage.delete(['key2'])
+    }
+  },
+  {
+    name: 'applies the configured key prefix',
+    keyPrefix: 'custom:',
+    run: async ({ storage, fake }) => {
+      await storage.write({ state: 'value' })
+      const result = await storage.read(['state'])
+      await storage.delete(['state'])
+
+      assert.deepStrictEqual(result, { state: 'value' })
+
+      if (fake !== undefined) {
+        assert.equal(fake.rawGet('state'), null)
+        assert.deepStrictEqual(fake.commands.map(command => command.key), [
+          'custom:state',
+          'custom:state',
+          'custom:state'
+        ])
+      }
+    }
+  },
+  {
+    name: 'round-trips keys with special characters',
+    run: async ({ storage }) => {
+      const key = 'msteams/botId/conversations/19:meeting id/%/🤖'
+      const data = { [key]: { value: 'test' } }
+      await storage.write(data)
+
+      const result = await storage.read([key])
+      assert.deepStrictEqual(result, data)
+
+      await storage.delete([key])
+    }
+  },
+  {
+    name: 'preserves empty objects',
+    run: async ({ storage }) => {
+      const data = { empty: {} }
+      await storage.write(data)
+
+      const result = await storage.read(['empty'])
+      assert.deepStrictEqual(result, data)
+
+      await storage.delete(['empty'])
+    }
+  },
+  {
+    name: 'preserves nested objects and arrays',
+    run: async ({ storage }) => {
+      const data = {
+        nested: {
+          child: {
+            values: [1, 'two', true, { deep: 'value' }]
+          }
+        }
+      }
+      await storage.write(data)
+
+      const result = await storage.read(['nested'])
+      assert.deepStrictEqual(result, data)
+
+      await storage.delete(['nested'])
+    }
+  },
+  {
+    name: 'preserves null values inside state',
+    run: async ({ storage }) => {
+      const data = {
+        key1: {
+          value: null,
+          nested: { alsoNull: null },
+          array: [null, { child: null }]
+        }
+      }
+      await storage.write(data)
+
+      const result = await storage.read(['key1'])
+      assert.deepStrictEqual(result, data)
+
+      await storage.delete(['key1'])
+    }
+  },
+  {
+    name: 'closes idempotently',
+    run: async ({ storage, fake }) => {
+      await storage.write({ closeKey: 'value' })
+      await storage.delete(['closeKey'])
+      await storage.close()
+      await storage.close()
+
+      if (fake !== undefined) {
+        assert.equal(fake.quitCalls, 1)
+      }
+    }
+  }
+]
+
+describe('RedisStorage', () => {
+  for (const storageCase of storageCases) {
+    it(storageCase.name, async () => {
+      const fake = new FakeRedisClient()
+      const storage = new RedisStorage(fake.asRedisClient(), {
+        keyPrefix: storageCase.keyPrefix,
+        ownsClient: true
+      })
+
+      try {
+        await storageCase.run({ storage, fake })
+      } finally {
+        await storage.close()
+      }
+    })
+  }
+})
+
+test('RedisStorage integration contract', { skip: !process.env.REDIS_URL }, async () => {
+  const redisUrl = process.env.REDIS_URL
+  assert.ok(redisUrl)
+
+  for (const storageCase of storageCases) {
+    const storage = new RedisStorage(redisUrl, {
+      keyPrefix: storageCase.keyPrefix ?? `botas-test:${randomUUID()}:`
+    })
+
+    try {
+      await storageCase.run({ storage })
+    } finally {
+      await storage.close()
+    }
+  }
+})

--- a/node/packages/botas-redis/src/redis-storage.ts
+++ b/node/packages/botas-redis/src/redis-storage.ts
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { createClient } from 'redis'
+import type { RedisClientType } from 'redis'
+import type { Storage } from 'botas-core'
+
+/** Options for RedisStorage. */
+export interface RedisStorageOptions {
+  /** Prefix applied to every Redis key. Defaults to 'botas:'. */
+  keyPrefix?: string
+}
+
+/** Options for RedisStorage when using an existing Redis client. */
+export interface RedisStorageClientOptions extends RedisStorageOptions {
+  /** Whether RedisStorage should close the provided client when close() is called. */
+  ownsClient?: boolean
+}
+
+/**
+ * Redis-backed storage implementation for distributed bot state.
+ *
+ * Stores each state item as a JSON-encoded Redis string using keys in the form
+ * `<keyPrefix><raw_key>`. Operations use per-key GET/SET/DEL calls for Redis
+ * Cluster compatibility.
+ *
+ * @example
+ * ```ts
+ * const storage = new RedisStorage('redis://localhost:6379')
+ * bot.useState(storage)
+ * ```
+ */
+export class RedisStorage implements Storage {
+  private readonly client: RedisClientType
+  private readonly keyPrefix: string
+  private readonly ownsClient: boolean
+  private connectPromise?: Promise<RedisClientType>
+
+  /**
+   * Create RedisStorage from a Redis URL. The client connects lazily on first use.
+   * @param url - Redis connection URL, for example 'redis://localhost:6379'.
+   * @param options - Storage options.
+   */
+  constructor (url: string, options?: RedisStorageOptions)
+
+  /**
+   * Create RedisStorage from an existing Redis client.
+   * @param client - Redis client to use for storage operations.
+   * @param options - Storage options.
+   */
+  constructor (client: RedisClientType, options?: RedisStorageClientOptions)
+
+  constructor (redis: string | RedisClientType, options: RedisStorageOptions | RedisStorageClientOptions = {}) {
+    this.client = typeof redis === 'string' ? createClient({ url: redis }) : redis
+    this.keyPrefix = options.keyPrefix ?? 'botas:'
+    this.ownsClient = typeof redis === 'string' || ('ownsClient' in options && options.ownsClient === true)
+  }
+
+  /**
+   * Read items from Redis.
+   * @param keys - Keys to read.
+   * @returns Dictionary of key-value pairs that exist in storage.
+   */
+  async read (keys: string[]): Promise<Record<string, unknown>> {
+    const client = await this.ensureConnected()
+    const result: Record<string, unknown> = {}
+
+    await Promise.all(
+      keys.map(async key => {
+        const value = await client.GET(this.getRedisKey(key))
+        if (value !== null) {
+          result[key] = JSON.parse(value)
+        }
+      })
+    )
+
+    return result
+  }
+
+  /**
+   * Write items to Redis.
+   * @param changes - Dictionary of key-value pairs to write.
+   */
+  async write (changes: Record<string, unknown>): Promise<void> {
+    const client = await this.ensureConnected()
+
+    await Promise.all(
+      Object.entries(changes).map(async ([key, value]) => {
+        await client.SET(this.getRedisKey(key), JSON.stringify(value))
+      })
+    )
+  }
+
+  /**
+   * Delete items from Redis. Missing keys are ignored.
+   * @param keys - Keys to delete.
+   */
+  async delete (keys: string[]): Promise<void> {
+    const client = await this.ensureConnected()
+
+    await Promise.all(
+      keys.map(async key => {
+        await client.DEL(this.getRedisKey(key))
+      })
+    )
+  }
+
+  /** Close the Redis client if this storage instance owns it. */
+  async close (): Promise<void> {
+    if (!this.ownsClient) {
+      return
+    }
+
+    if (this.client.isOpen) {
+      await this.client.quit()
+    }
+
+    this.connectPromise = undefined
+  }
+
+  private async ensureConnected (): Promise<RedisClientType> {
+    if (this.client.isOpen) {
+      return this.client
+    }
+
+    this.connectPromise ??= this.client.connect()
+      .then(() => this.client)
+      .catch((err: unknown) => {
+        this.connectPromise = undefined
+        throw err
+      })
+
+    return await this.connectPromise
+  }
+
+  private getRedisKey (key: string): string {
+    return `${this.keyPrefix}${key}`
+  }
+}

--- a/node/packages/botas-redis/tsconfig.json
+++ b/node/packages/botas-redis/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noImplicitAny": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "dist", "node_modules"]
+}

--- a/node/samples/07-redis-state-bot/.gitignore
+++ b/node/samples/07-redis-state-bot/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+state-data/

--- a/node/samples/07-redis-state-bot/README.md
+++ b/node/samples/07-redis-state-bot/README.md
@@ -1,0 +1,46 @@
+# Redis State Bot
+
+**Category:** 7 — Redis State Management
+**Language:** Node.js
+**Complexity:** Intermediate
+
+This sample mirrors `06-state-bot` but persists state in Redis 7 using `botas-redis`.
+
+## Prerequisites
+
+- Docker
+- Node.js 20+
+
+## Run Redis
+
+```bash
+docker compose up -d
+```
+
+## Install and start
+
+```bash
+npm install
+npm start
+```
+
+The bot listens on `http://localhost:3978/api/messages` by default. It supports the same counter contract as `06-state-bot`:
+
+- Send any message to increment conversation and user counters.
+- Send `whoami` to see your user counter.
+- Send `reset` to clear the conversation counter.
+
+## Stop Redis
+
+```bash
+# Stop containers and keep Redis state volume
+docker compose down
+
+# Stop containers and delete Redis state volume
+docker compose down -v
+```
+
+## Learn More
+
+- [State Management Guide](../../../docs-site/state.md)
+- [TurnState Spec](../../../specs/turn-state.md)

--- a/node/samples/07-redis-state-bot/docker-compose.yml
+++ b/node/samples/07-redis-state-bot/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: botas-redis-state-node
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: ["redis-server", "--appendonly", "yes"]
+volumes:
+  redis-data:

--- a/node/samples/07-redis-state-bot/index.ts
+++ b/node/samples/07-redis-state-bot/index.ts
@@ -1,0 +1,51 @@
+// Redis State Bot — demonstrates TurnState with RedisStorage
+// Run: npm start
+
+import { BotApp } from 'botas-express'
+import { RedisStorage } from 'botas-redis'
+
+const app = new BotApp({ auth: false }) // Disable auth for local testing
+
+const storage = new RedisStorage('redis://localhost:6379')
+
+// Register state middleware with RedisStorage
+app.useState(storage)
+
+app.on('message', async ctx => {
+  const text = ctx.activity.text?.toLowerCase() || ''
+
+  // Handle "reset" command
+  if (text === 'reset') {
+    ctx.state?.conversation.clear()
+    await ctx.send('Counters reset!')
+    return
+  }
+
+  // Handle "whoami" command
+  if (text === 'whoami') {
+    const userCount = ctx.state?.user.get<number>('user_message_count') ?? 0
+    const userId = ctx.activity.from?.id ?? 'unknown'
+    await ctx.send(`You are ${userId}. You have sent ${userCount} message(s).`)
+    return
+  }
+
+  // Increment conversation-scoped turn counter
+  const turnCount = (ctx.state?.conversation.get<number>('turn_count') ?? 0) + 1
+  ctx.state?.conversation.set('turn_count', turnCount)
+
+  // Increment user-scoped message counter
+  const userCount = (ctx.state?.user.get<number>('user_message_count') ?? 0) + 1
+  ctx.state?.user.set('user_message_count', userCount)
+
+  // Use temp scope for formatted reply (not persisted)
+  const reply = `Turn #${turnCount} | Your message #${userCount}: ${ctx.activity.text}`
+  ctx.state?.temp.set('reply', reply)
+
+  await ctx.send(ctx.state?.temp.get<string>('reply') ?? reply)
+})
+
+process.once('SIGINT', () => {
+  storage.close().finally(() => process.exit(0))
+})
+
+app.start()

--- a/node/samples/07-redis-state-bot/package.json
+++ b/node/samples/07-redis-state-bot/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "07-redis-state-bot",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node --import tsx index.ts",
+    "dev": "node --import tsx --watch index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "botas-core": "*",
+    "botas-express": "*",
+    "botas-redis": "*"
+  }
+}

--- a/node/samples/07-redis-state-bot/tsconfig.json
+++ b/node/samples/07-redis-state-bot/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}

--- a/python/packages/botas/pyproject.toml
+++ b/python/packages/botas/pyproject.toml
@@ -40,6 +40,9 @@ Issues = "https://github.com/rido-min/botas/issues"
 observability = [
     "opentelemetry-api>=1.20",
 ]
+redis = [
+    "redis>=5",
+]
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.23",
@@ -48,6 +51,8 @@ dev = [
     "pdoc>=15",
     "opentelemetry-api>=1.20",
     "opentelemetry-sdk>=1.20",
+    "redis>=5",
+    "fakeredis>=2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/python/packages/botas/src/botas/state/__init__.py
+++ b/python/packages/botas/src/botas/state/__init__.py
@@ -2,7 +2,7 @@
 
 Provides the :class:`TurnState` class with three scopes (conversation, user, temp),
 the :class:`Storage` protocol for pluggable backends, and built-in implementations
-(:class:`MemoryStorage`, :class:`FileStorage`).
+(:class:`MemoryStorage`, :class:`FileStorage`, and lazy opt-in :class:`RedisStorage`).
 """
 
 from __future__ import annotations
@@ -13,10 +13,21 @@ from botas.state.state_scope import StateScope
 from botas.state.storage import Storage
 from botas.state.turn_state import TurnState
 
+
+def __getattr__(name: str):
+    """Lazily expose optional state providers."""
+    if name == "RedisStorage":
+        from botas.state.redis_storage import RedisStorage
+
+        return RedisStorage
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "Storage",
     "MemoryStorage",
     "FileStorage",
+    "RedisStorage",
     "TurnState",
     "StateScope",
 ]

--- a/python/packages/botas/src/botas/state/redis_storage.py
+++ b/python/packages/botas/src/botas/state/redis_storage.py
@@ -1,0 +1,165 @@
+"""Redis-backed storage implementation (opt-in extra)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis as AsyncRedis
+
+_INSTALL_HINT = 'RedisStorage requires the redis extra. Install with: pip install "botas[redis]"'
+
+
+class RedisStorage:
+    """Redis-backed storage for bot state across multiple instances.
+
+    Stores each state key as a JSON-encoded Redis string. Keys are written as
+    ``<key_prefix><raw_key>`` without encoding, and operations use pipelined
+    single-key commands for Redis Cluster compatibility.
+
+    Example::
+
+        from botas.state import RedisStorage
+
+        storage = RedisStorage("redis://localhost:6379")
+        await storage.write({"conversation/123": {"count": 5}})
+        data = await storage.read(["conversation/123"])
+        # data = {"conversation/123": {"count": 5}}
+        await storage.aclose()
+
+    Example::
+
+        from botas.state import RedisStorage
+
+        storage = RedisStorage("redis://localhost:6379", key_prefix="mybot:")
+
+    Example::
+
+        from botas.state import RedisStorage
+
+        storage = RedisStorage(client=existing_client, key_prefix="mybot:")
+
+    Args:
+        url: Redis connection URL, such as ``"redis://localhost:6379"``.
+        client: Existing ``redis.asyncio.Redis`` client. When provided, the
+            storage will not close the client in :meth:`aclose`.
+        key_prefix: Prefix to prepend to every Redis key. Defaults to ``"botas:"``.
+
+    Raises:
+        ValueError: If neither ``url`` nor ``client`` is provided, or both are provided.
+        ImportError: If the ``redis`` package is not installed.
+    """
+
+    def __init__(
+        self,
+        url: Optional[str] = None,
+        *,
+        client: Optional["AsyncRedis"] = None,
+        key_prefix: str = "botas:",
+    ) -> None:
+        """Initialize Redis storage.
+
+        Args:
+            url: Redis connection URL, such as ``"redis://localhost:6379"``.
+            client: Existing ``redis.asyncio.Redis`` client. When provided, the
+                storage will not close the client in :meth:`aclose`.
+            key_prefix: Prefix to prepend to every Redis key. Defaults to ``"botas:"``.
+
+        Raises:
+            ValueError: If neither ``url`` nor ``client`` is provided, or both are provided.
+            ImportError: If the ``redis`` package is not installed.
+        """
+        if url is None and client is None:
+            raise ValueError("Provide either a Redis URL or an existing client.")
+        if url is not None and client is not None:
+            raise ValueError("Provide either url OR client, not both.")
+        try:
+            import redis.asyncio as _redis_asyncio
+        except ImportError as e:
+            raise ImportError(_INSTALL_HINT) from e
+
+        self._key_prefix = key_prefix
+        if client is not None:
+            self._client = client
+            self._owns_client = False
+        else:
+            self._client = _redis_asyncio.from_url(url, decode_responses=True)
+            self._owns_client = True
+
+    async def read(self, keys: list[str]) -> dict[str, object]:
+        """Read items from storage.
+
+        Uses pipelined per-key ``GET`` commands rather than ``MGET`` for Redis
+        Cluster compatibility.
+
+        Args:
+            keys: Keys to read.
+
+        Returns:
+            Dictionary of key-value pairs that exist in storage.
+            Missing keys are omitted from the result.
+        """
+        pipe = self._client.pipeline(transaction=False)
+        for key in keys:
+            pipe.get(self._key_prefix + key)
+        values = await pipe.execute()
+
+        result: dict[str, object] = {}
+        for key, val in zip(keys, values):
+            if val is not None:
+                result[key] = json.loads(val)
+        return result
+
+    async def write(self, changes: dict[str, object]) -> None:
+        """Write items to storage.
+
+        Uses pipelined per-key ``SET`` commands for Redis Cluster compatibility.
+        Values are serialized as JSON strings with UTF-8 characters preserved.
+
+        Args:
+            changes: Dictionary of key-value pairs to write.
+        """
+        pipe = self._client.pipeline(transaction=False)
+        for key, value in changes.items():
+            pipe.set(self._key_prefix + key, json.dumps(value, ensure_ascii=False))
+        await pipe.execute()
+
+    async def delete(self, keys: list[str]) -> None:
+        """Delete items from storage.
+
+        Uses pipelined per-key ``DEL`` commands rather than multi-key ``DEL`` for
+        Redis Cluster compatibility.
+
+        Args:
+            keys: Keys to delete. Idempotent — no error if key doesn't exist.
+        """
+        pipe = self._client.pipeline(transaction=False)
+        for key in keys:
+            pipe.delete(self._key_prefix + key)
+        await pipe.execute()
+
+    async def aclose(self) -> None:
+        """Close the underlying Redis connection if this storage owns it.
+
+        Existing clients passed with ``client=`` are owned by the caller and are
+        not closed by this method.
+        """
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> "RedisStorage":
+        """Enter the async context manager.
+
+        Returns:
+            This storage instance.
+        """
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit the async context manager and close owned Redis connections.
+
+        Args:
+            *args: Exception details supplied by the async context manager protocol.
+        """
+        await self.aclose()

--- a/python/packages/botas/tests/test_redis_storage.py
+++ b/python/packages/botas/tests/test_redis_storage.py
@@ -1,0 +1,183 @@
+"""Tests for RedisStorage."""
+
+from __future__ import annotations
+
+import builtins
+import json
+import os
+import re
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import fakeredis.aioredis
+import pytest
+
+from botas.state import RedisStorage
+from botas.state.redis_storage import _INSTALL_HINT
+
+ROUND_TRIP_STATE = {
+    "key1": {"count": 5, "label": "hello"},
+    "special/key:with%chars space🤖": {"emoji": "🤖", "text": "slash/colon:percent% space"},
+    "empty-object": {},
+    "nested-object": {"outer": {"inner": [1, "two", {"three": None}]}, "enabled": True},
+    "null-inside-state": {"optional": None, "items": [None, {"value": "present"}]},
+}
+
+
+def create_fake_client():
+    """Create an async fake Redis client."""
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+async def exercise_storage(storage: RedisStorage) -> None:
+    """Run the core RedisStorage behavior scenarios."""
+    assert await storage.read(["missing"]) == {}
+
+    await storage.write(ROUND_TRIP_STATE)
+    data = await storage.read(list(ROUND_TRIP_STATE.keys()))
+    assert data == ROUND_TRIP_STATE
+
+    await storage.delete(["key1", "missing"])
+    await storage.delete(["key1", "missing"])
+    data = await storage.read(list(ROUND_TRIP_STATE.keys()))
+    assert "key1" not in data
+    assert data == {key: value for key, value in ROUND_TRIP_STATE.items() if key != "key1"}
+
+
+class TestRedisStorage:
+    """Unit tests for RedisStorage using fakeredis."""
+
+    @pytest.mark.asyncio
+    async def test_missing_key_omitted(self):
+        client = create_fake_client()
+        storage = RedisStorage(client=client)
+
+        assert await storage.read(["missing"]) == {}
+
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_write_read_json_round_trip(self):
+        client = create_fake_client()
+        storage = RedisStorage(client=client)
+
+        await storage.write({"key1": {"count": 5, "message": "héllo 🤖"}})
+        data = await storage.read(["key1"])
+
+        assert data == {"key1": {"count": 5, "message": "héllo 🤖"}}
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_delete_idempotent(self):
+        client = create_fake_client()
+        storage = RedisStorage(client=client)
+
+        await storage.write({"key1": {"count": 5}})
+        await storage.delete(["key1", "missing"])
+        await storage.delete(["key1", "missing"])
+
+        assert await storage.read(["key1", "missing"]) == {}
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_key_prefix_applied(self):
+        client = create_fake_client()
+        storage = RedisStorage(client=client, key_prefix="mybot:")
+
+        await storage.write({"raw/key": {"count": 1}})
+
+        raw_value = await client.get("mybot:raw/key")
+        assert raw_value is not None
+        assert json.loads(raw_value) == {"count": 1}
+        assert await client.get("raw/key") is None
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_special_chars_in_keys(self):
+        client = create_fake_client()
+        storage = RedisStorage(client=client)
+        key = "slash/key:colon%percent space🤖"
+
+        await storage.write({key: {"value": "stored"}})
+        data = await storage.read([key])
+
+        assert data == {key: {"value": "stored"}}
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_empty_object_preserved(self):
+        client = create_fake_client()
+        storage = RedisStorage(client=client)
+
+        await storage.write({"empty": {}})
+        data = await storage.read(["empty"])
+
+        assert data == {"empty": {}}
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_nested_objects_and_null_values_preserved(self):
+        client = create_fake_client()
+        storage = RedisStorage(client=client)
+        value = {"nested": {"items": [1, {"value": None}, "🤖"]}, "optional": None}
+
+        await storage.write({"complex": value})
+        data = await storage.read(["complex"])
+
+        assert data == {"complex": value}
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_aclose_does_not_close_non_owned_client(self):
+        client = create_fake_client()
+        client.aclose = AsyncMock()
+        storage = RedisStorage(client=client)
+
+        await storage.aclose()
+
+        client.aclose.assert_not_awaited()
+
+    def test_import_error_message_when_redis_missing(self):
+        real_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "redis" or name == "redis.asyncio":
+                raise ImportError("No module named redis")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            with pytest.raises(ImportError, match=re.escape(_INSTALL_HINT)):
+                RedisStorage("redis://localhost:6379")
+
+    def test_requires_url_or_client(self):
+        with pytest.raises(ValueError, match="Provide either a Redis URL or an existing client"):
+            RedisStorage()
+
+    def test_rejects_url_and_client_together(self):
+        client = create_fake_client()
+        with pytest.raises(ValueError, match="Provide either url OR client, not both"):
+            RedisStorage("redis://localhost:6379", client=client)
+
+
+@pytest.mark.asyncio
+async def test_fake_redis_core_scenarios():
+    """Run core scenarios against fakeredis."""
+    client = create_fake_client()
+    storage = RedisStorage(client=client, key_prefix="botas-test:")
+
+    await exercise_storage(storage)
+    await client.aclose()
+
+
+@pytest.mark.skipif(not os.getenv("REDIS_URL"), reason="REDIS_URL not set")
+@pytest.mark.asyncio
+async def test_real_redis_core_scenarios():
+    """Run core scenarios against a real Redis connection when REDIS_URL is set."""
+    prefix = f"botas-test:{uuid.uuid4()}:"
+    storage = RedisStorage(os.environ["REDIS_URL"], key_prefix=prefix)
+
+    try:
+        await exercise_storage(storage)
+    finally:
+        await storage.delete(list(ROUND_TRIP_STATE.keys()))
+        await storage.aclose()

--- a/python/samples/07-redis-state-bot/README.md
+++ b/python/samples/07-redis-state-bot/README.md
@@ -1,0 +1,95 @@
+# Redis State Bot
+
+**Category:** 1 — Basic Bot  
+**Language:** Python  
+**Complexity:** Basic
+
+## What This Sample Demonstrates
+
+- **TurnState** with conversation, user, and temp scopes
+- **RedisStorage** backend persisting state to Redis 7
+- Conversation-wide turn counter
+- Per-user message counter
+- Special commands: `reset` and `whoami`
+- **Offline mode**: When `CLIENT_ID` is not set, bot replies are logged to console instead of sent to Bot Service
+
+## Prerequisites
+
+- Docker
+- Python 3.9+
+- No Azure credentials needed for local testing (runs in offline mode)
+- **Optional**: Set `CLIENT_ID` and `CLIENT_SECRET` environment variables to enable real Bot Service communication
+
+## Run
+
+```bash
+cd python/samples/07-redis-state-bot
+docker compose up -d
+pip install -e .
+python main.py
+```
+
+The bot listens on **http://localhost:3978/api/messages** by default and uses Redis at **redis://localhost:6379**.
+
+## Key Files
+
+- `main.py` — Bot setup, Redis state middleware registration, and message handler
+- `docker-compose.yml` — Local Redis 7 service with append-only persistence
+
+## Try It
+
+When running **without `CLIENT_ID`** (offline mode), the bot logs replies to console instead of sending them to Bot Service. State is still persisted in Redis.
+
+### Send a message
+
+```bash
+curl -X POST http://localhost:3978/api/messages \
+  -H "Content-Type: application/json" \
+  -d '{"type":"message","text":"Hello!","from":{"id":"user-123","name":"Test"},"recipient":{"id":"bot-456","name":"Bot"},"conversation":{"id":"conv-789"},"channelId":"emulator","serviceUrl":"http://localhost:3978"}'
+```
+
+**Expected**:
+
+- Bot returns `{}` (200 OK)
+- Console shows: `[OFFLINE] Would send: Turn #1 | Your message #1: Hello!`
+- State is persisted to Redis keys with the `botas:` prefix
+
+Restart the bot and send another message — counters resume from persisted values.
+
+### Reset counters
+
+```bash
+curl -X POST http://localhost:3978/api/messages \
+  -H "Content-Type: application/json" \
+  -d '{"type":"message","text":"reset","from":{"id":"user-123","name":"Test"},"recipient":{"id":"bot-456","name":"Bot"},"conversation":{"id":"conv-789"},"channelId":"emulator","serviceUrl":"http://localhost:3978"}'
+```
+
+**Expected**:
+
+- Console shows: `[OFFLINE] Would send: ✅ Conversation state cleared. Counters reset.`
+- Conversation state is cleared, but user state persists
+
+## Stop Redis
+
+```bash
+docker compose down
+```
+
+This stops Redis but keeps the Docker volume, so state remains available next time.
+
+To reset all Redis state:
+
+```bash
+docker compose down -v
+```
+
+## State Scopes
+
+- **Conversation** (`ctx.state.conversation`) — Shared across all participants in the conversation. Used for turn counters, dialog flow state.
+- **User** (`ctx.state.user`) — Tracks data per user across all conversations. Used for user preferences, message counts.
+- **Temp** (`ctx.state.temp`) — Ephemeral, per-turn only. Never persisted. Used for intermediate values during turn processing.
+
+## Learn More
+
+- [State Management Guide](../../../docs-site/state.md) — Detailed patterns, API reference, storage adapters
+- [TurnState Spec](../../../specs/turn-state.md) — Technical architecture and lifecycle

--- a/python/samples/07-redis-state-bot/docker-compose.yml
+++ b/python/samples/07-redis-state-bot/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: botas-redis-state-python
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: ["redis-server", "--appendonly", "yes"]
+volumes:
+  redis-data:

--- a/python/samples/07-redis-state-bot/main.py
+++ b/python/samples/07-redis-state-bot/main.py
@@ -1,0 +1,91 @@
+# Redis State Bot — TurnState sample with RedisStorage
+# Run: python main.py
+
+import atexit
+import asyncio
+import os
+
+from botas.state import RedisStorage
+from botas_fastapi import BotApp
+
+app = BotApp()
+
+# Register state middleware with RedisStorage
+storage = RedisStorage("redis://localhost:6379")
+app.bot.use_state(storage)  # Access underlying BotApplication
+
+_storage_closed = False
+
+
+def close_storage() -> None:
+    """Close Redis connections on shutdown."""
+    global _storage_closed
+    if _storage_closed:
+        return
+    _storage_closed = True
+    asyncio.run(storage.aclose())
+
+
+atexit.register(close_storage)
+
+# Check if running in offline mode (no bot credentials configured)
+OFFLINE_MODE = not os.environ.get("CLIENT_ID")
+if OFFLINE_MODE:
+    print("\n⚠️  Running in OFFLINE MODE (no CLIENT_ID set)")
+    print("📝 Bot replies will be logged to console instead of sent to Bot Service\n")
+
+
+@app.on("message")
+async def on_message(ctx):
+    if not ctx.state:
+        # State is not configured - shouldn't happen with use_state registered
+        return
+
+    text = (ctx.activity.text or "").strip()
+
+    # Special command: reset
+    if text.lower() == "reset":
+        ctx.state.conversation.delete("turn_count")
+        reply_text = "✅ Conversation state cleared. Counters reset."
+        if OFFLINE_MODE:
+            print(f"[OFFLINE] Would send: {reply_text}")
+        else:
+            await ctx.send(reply_text)
+        return
+
+    # Special command: whoami
+    if text.lower() == "whoami":
+        user_count = ctx.state.user.get("user_message_count", int) or 0
+        user_id = ctx.activity.from_.id if ctx.activity.from_ else "unknown"
+        reply_text = f"👤 User ID: {user_id}\n📊 Your message count: {user_count}"
+        if OFFLINE_MODE:
+            print(f"[OFFLINE] Would send: {reply_text}")
+        else:
+            await ctx.send(reply_text)
+        return
+
+    # Regular message: increment counters
+    turn_count = (ctx.state.conversation.get("turn_count", int) or 0) + 1
+    ctx.state.conversation.set("turn_count", turn_count)
+
+    user_count = (ctx.state.user.get("user_message_count", int) or 0) + 1
+    ctx.state.user.set("user_message_count", user_count)
+
+    # Use temp scope for the formatted reply (demonstrating all three scopes)
+    reply = f"Turn #{turn_count} | Your message #{user_count}: {text}"
+    ctx.state.temp.set("reply", reply)
+
+    # Send the reply to the user (or log it in offline mode)
+    final_reply = ctx.state.temp.get("reply", str) or reply
+    if OFFLINE_MODE:
+        print(f"[OFFLINE] Would send: {final_reply}")
+    else:
+        await ctx.send(final_reply)
+
+    # State will be persisted automatically when handler completes
+
+
+try:
+    app.start()
+finally:
+    close_storage()

--- a/python/samples/07-redis-state-bot/pyproject.toml
+++ b/python/samples/07-redis-state-bot/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "07-redis-state-bot"
+version = "0.1.0"
+requires-python = ">=3.8"
+dependencies = [
+    "botas-fastapi",
+    "botas[redis]",
+]
+
+[tool.uv.sources]
+botas = { path = "../../packages/botas", editable = true }
+botas-fastapi = { path = "../../packages/botas-fastapi", editable = true }

--- a/specs/turn-state.md
+++ b/specs/turn-state.md
@@ -190,6 +190,7 @@ class Storage(Protocol):
 |----------------|-------------|-------------|----------|
 | `MemoryStorage` | In-process dictionary | Yes (with locking) | Development, testing, single-instance bots |
 | `FileStorage` | JSON files on disk | No (single-instance only) | Development, simple persistence for single-instance deployments |
+| `RedisStorage` | Redis-backed key/value store | Yes (Redis is the synchronization point) | Multi-instance deployments, distributed bots, shared state across replicas |
 
 **FileStorage details:**
 - One JSON file per key (path-safe key encoding)
@@ -200,13 +201,27 @@ class Storage(Protocol):
 - `delete()` is idempotent (no error if file doesn't exist)
 - **Limitation**: Not suitable for multi-instance deployments (horizontal scaling, web farms)
 
+**RedisStorage details:**
+- Distributed via Redis — same Redis instance can be shared across `.NET`/`Node`/`Python` bots
+- Distributed via opt-in packages (not in the core library) — install only when needed
+  - **.NET**: `Botas.Redis` NuGet package (separate assembly, namespace `Botas.Redis`)
+  - **Node.js**: `botas-redis` npm package (separate workspace package)
+  - **Python**: `pip install botas[redis]` extra (in-tree, lazy `redis` import)
+- Configurable connection string (`redis://host:port[/db]`) and key prefix (default: `botas:`)
+- Stores values as JSON-encoded UTF-8 strings (same on-disk format as FileStorage for portability)
+- Keys are stored as `<prefix><raw_key>` — no encoding/normalization (Redis is binary-safe)
+- `read()`, `write()`, `delete()` use **pipelined per-key commands**, NOT multi-key `MGET`/`MSET`/`DEL` — keeps the provider compatible with Redis Cluster (avoids `CROSSSLOT` errors)
+- No default TTL (state lives until the bot deletes it)
+- Lifecycle: exposes explicit cleanup (`IAsyncDisposable` / `close()` / `aclose()`); samples close storage on shutdown
+- Connection is lazy — constructed but not opened until the first operation (or first explicit connect)
+- Thread-safety: Redis itself serializes operations; client multiplexers are safe to share
+
 **Deferred to future versions:**
 
 | Implementation | Description |
 |----------------|-------------|
 | `BlobStorage` | Azure Blob Storage |
 | `CosmosDbStorage` | Azure Cosmos DB |
-| `RedisStorage` | Redis cache |
 
 ### MemoryStorage API
 
@@ -261,6 +276,65 @@ storage = FileStorage('./data/state')
 - Writes create parent directories automatically
 - Deletes are idempotent (no error if file missing)
 - Thread-safety: **None** — assumes single-process, single-instance deployment
+
+### RedisStorage API
+
+**.NET:** (install `Botas.Redis` package)
+```csharp
+using Botas.Redis;
+
+// Default prefix: "botas:"
+await using var storage = new RedisStorage("redis://localhost:6379");
+
+// Custom prefix (for multi-tenant Redis instances)
+await using var storage = new RedisStorage("redis://localhost:6379", keyPrefix: "mybot:");
+
+// Use existing IConnectionMultiplexer (recommended for hosted apps)
+await using var storage = new RedisStorage(multiplexer, keyPrefix: "mybot:");
+```
+
+**Node.js:** (install `botas-redis` package)
+```typescript
+import { RedisStorage } from 'botas-redis'
+
+// Default prefix: 'botas:'
+const storage = new RedisStorage('redis://localhost:6379')
+
+// Custom prefix
+const storage = new RedisStorage('redis://localhost:6379', { keyPrefix: 'mybot:' })
+
+// Use existing redis client
+const storage = new RedisStorage(existingClient, { keyPrefix: 'mybot:' })
+
+// Cleanup on shutdown
+await storage.close()
+```
+
+**Python:** (install with `pip install botas[redis]`)
+```python
+from botas.state import RedisStorage
+
+# Default prefix: 'botas:'
+storage = RedisStorage("redis://localhost:6379")
+
+# Custom prefix
+storage = RedisStorage("redis://localhost:6379", key_prefix="mybot:")
+
+# Use existing redis.asyncio.Redis client
+storage = RedisStorage(client=existing_client, key_prefix="mybot:")
+
+# Cleanup on shutdown
+await storage.aclose()
+```
+
+**RedisStorage implementation notes:**
+- Keys stored as `<keyPrefix><raw_key>` — no encoding (Redis is binary-safe)
+- Values JSON-encoded UTF-8 strings (cross-language portable: a state document written by .NET is readable from Node/Python and vice versa)
+- `read()`/`write()`/`delete()` use pipelined per-key `GET`/`SET`/`DEL` (NOT `MGET`/`MSET`/`DEL key1 key2 ...`) for Redis Cluster compatibility
+- No TTL by default — state persists until explicitly deleted
+- Connection is lazy — opened on first operation
+- Thread-safe via Redis client multiplexing
+- Cross-language parity: same Redis instance can back .NET, Node, and Python bots simultaneously; state is fully interoperable
 
 ---
 
@@ -853,11 +927,11 @@ userId         = activity.from.id
 
 The following are explicitly deferred to future versions:
 
-1. **Cloud storage adapters** — BlobStorage, CosmosDbStorage, RedisStorage (FileStorage is sufficient for v1 simple persistence needs)
+1. **Cloud storage adapters** — BlobStorage, CosmosDbStorage (FileStorage and RedisStorage cover the v1 persistence story)
 2. **Optimistic concurrency** — ETag-based conflict detection
 3. **Custom scopes** — User-defined scopes beyond conversation/user/temp
 4. **State encryption** — At-rest encryption of state values
-5. **State expiration** — TTL-based automatic cleanup
+5. **State expiration** — TTL-based automatic cleanup (RedisStorage may support TTL in a follow-up)
 6. **MemoryFork** — Copy-on-write state isolation (from TeamsAI reference)
 7. **Strongly-typed state** — Derived TurnState classes with typed properties
 8. **Temp scope pre-population** — Built-in keys like `input` (activity.text) or `authTokens` (deferred to AI/prompting features)
@@ -872,10 +946,15 @@ The following design decisions have been finalized:
 
 2. **Save on error**: **Discard**. State changes are saved ONLY when the turn completes successfully. If a handler or middleware throws, the save phase is skipped — no state writes go to storage. Provides atomic per-turn semantics. (Matches `teams-sdk` default behavior.)
 
-3. **v1 storage adapters**: **MemoryStorage AND FileStorage**. Both ship in v1:
-   - `MemoryStorage` — In-process dictionary for development/testing
-   - `FileStorage` — JSON files on disk for simple persistence in single-instance deployments
-   - Cloud adapters (BlobStorage, CosmosDbStorage, RedisStorage) deferred to follow-up issues
+3. **v1 storage adapters**: **MemoryStorage, FileStorage, and RedisStorage**:
+   - `MemoryStorage` — In-process dictionary for development/testing (built-in core)
+   - `FileStorage` — JSON files on disk for simple persistence in single-instance deployments (built-in core)
+   - `RedisStorage` — Redis-backed distributed storage for multi-instance deployments (opt-in package: `Botas.Redis` / `botas-redis` / `botas[redis]` extra)
+   - Cloud-native adapters (BlobStorage, CosmosDbStorage) deferred to follow-up issues
+
+4. **RedisStorage cluster compatibility**: Pipelined single-key operations (not `MGET`/multi-key `DEL`) to avoid `CROSSSLOT` errors in Redis Cluster.
+
+5. **RedisStorage packaging**: Opt-in across all ecosystems — never pulled into the core install. Lazy redis import in Python so `import botas` works without the extra installed.
 
 **Deferred decisions** (out of scope for v1):
 - Temp scope pre-population (`input`, `authTokens`, etc.) — deferred to future AI/prompting features


### PR DESCRIPTION
## Summary
Adds **RedisStorage** as the third built-in TurnState storage adapter, distributed as opt-in packages so the core install is unaffected. Same on-disk format as `FileStorage` (JSON-encoded UTF-8 strings), so the **same Redis instance can back .NET, Node, and Python bots interoperably**.

Stacked on top of #362 (TurnState foundation). Will rebase after #362 merges.

## Library

| Language | Package | Install |
|----------|---------|---------|
| .NET | `Botas.Redis` (new csproj, namespace `Botas.Redis`, `StackExchange.Redis`-based) | `dotnet add package Botas.Redis` |
| Node | `botas-redis` (new workspace package, `redis@4`-based) | `npm install botas-redis` |
| Python | `botas.state.RedisStorage` (in-tree, lazy `__getattr__`, lazy `redis` import) | `pip install ""botas[redis]""` |

### Shared semantics (parity)
- Pipelined per-key `GET`/`SET`/`DEL` — **NOT** `MGET`/multi-key `DEL` — keeps the provider Redis Cluster-safe (avoids `CROSSSLOT`)
- Configurable key prefix (default `botas:`); no key encoding (Redis is binary-safe)
- Lazy connection (open on first op); explicit cleanup (`IAsyncDisposable` / `close()` / `aclose()`)
- No default TTL — state lives until explicitly deleted
- JSON-encoded UTF-8 values, identical to `FileStorage` for portability

## Samples

| Path | What it shows |
|------|---------------|
| `dotnet/samples/07-redis-state-bot` | .NET counter bot wired to RedisStorage + shutdown hook |
| `node/samples/07-redis-state-bot`   | Node counter bot wired to RedisStorage + SIGINT cleanup |
| `python/samples/07-redis-state-bot` | Python counter bot with OFFLINE_MODE + atexit cleanup |

Each sample ships a `docker-compose.yml` (Redis 7, named volume `redis-data`, AOF on) with README documenting:
- `docker compose up -d` — start Redis
- `docker compose down` — stop (state survives)
- `docker compose down -v` — reset state intentionally

## Tests

- **Unit (always run)** — language-appropriate fakes:
  - .NET: hand-rolled `FakeConnectionMultiplexer` test-only
  - Node: inline `FakeRedisClient` test-only
  - Python: `fakeredis>=2`
- **Integration (gated)** — same suite, skipped unless `REDIS_URL` env var is set
- **Parity scenarios** — missing keys omitted, write/read JSON roundtrip, idempotent delete, key prefix isolation, special chars (`/ : % space `🤖`), empty `{}`, nested objects/arrays, `null` field values

### Results (local)
- .NET: `167 passed / 1 skipped` (Botas.Tests) + `9 passed` (Botas.Redis.Tests)
- Node: `191 passed` (botas-core) + `12 passed` (botas-express) + `9 passed / 1 skipped` (botas-redis)
- Python: `217 passed / 12 skipped` (12 skipped = REDIS_URL-gated integration cases)
- Ruff: clean
- `import botas` works without the redis extra installed; `RedisStorage(...)` raises `ImportError` with install hint

## Docs / Spec
- `specs/turn-state.md` — RedisStorage moved from **Deferred** to **Built-in**; full RedisStorage API section per language; cluster compatibility recorded as a resolved decision
- `docs-site/state.md` — quick-start, dedicated adapter section, links to the three samples

## Out of scope (follow-ups)
- TTL option (per-write expiration) — easy add when needed
- Cloud-managed adapters: `BlobStorage`, `CosmosDbStorage`

## Try it locally
```bash
cd dotnet/samples/07-redis-state-bot
docker compose up -d
dotnet run
```
(Or substitute `node/` / `python/` paths.)

Fixes part of #361.
